### PR TITLE
## PR 3/4 — Cooking Core Backend

### DIFF
--- a/.github/instructions/review-checklist.instructions.md
+++ b/.github/instructions/review-checklist.instructions.md
@@ -15,17 +15,23 @@ Generic review procedure to catch common issues before submitting a PR. Based on
 - [ ] **Data tags over hardcoded ID lists** — when items share a property (e.g., fire affinity), add a tag to the data JSON files (e.g., `"tags": ["fire"]`) and check via `ItemConstants.TAGS.X` instead of maintaining a static list of IDs in constants
 - [ ] **Constants in the right location** — shared constants go in `Lib/src/constants/`, not duplicated across services
 - [ ] **No duplicate constants** — search for similar values already defined elsewhere before creating new ones
+- [ ] **Magic numbers as named constants** — any numeric literal in algorithms (primes, multipliers, masks) must be a named constant. Trivial values (0, 1, -1) in obvious contexts are acceptable
+- [ ] **Pre-compute derived constants** — when a constant is always used in a derived form (e.g., hours → milliseconds), compute the derived value at the constant definition level (`FOO_MS = FOO_HOURS * 3_600_000`) and use that directly. Don't repeat the conversion formula at every call site
 
 ## 2. TypeScript Types
 
 - [ ] **Explicit return types** on all functions (enforced by ESLint `@typescript-eslint/explicit-function-return-type`)
 - [ ] **Derived union types** from `as const` objects using `typeof Object[keyof typeof Object]` — avoid raw `string` when a finite set of values exists
 - [ ] **Type aliases for repeated inline types** — if an inline type `{ slot: number; category: ItemCategory }` appears 2+ times, extract it to a named type
+- [ ] **Extract nested type accessors** — avoid repeating `SomeType["nested"]["field"][number]` across functions; extract to a `type Alias = SomeType["nested"]["field"][number]` and reference the alias
 - [ ] **Shared types in `Lib/src/types/`** — types used across multiple packets or services must be extracted to a dedicated file in `Lib/src/types/`, not defined inline in packet files or duplicated across consumers
 - [ ] **No `any`** — use proper types or generics
 - [ ] **No unnecessary type assertions** — don't cast to `readonly T[]` or force types when the type is already correctly inferred; let TypeScript's inference do the work
+- [ ] **Avoid `NonNullable<Awaited<ReturnType<...>>>`** — when a concrete model type exists (e.g., `Player`, `Home`, `Guild`), import and use it directly instead of deriving the type from a function's return type
 - [ ] **Replace `null` with semantic values** — when `null` has a specific meaning (e.g., "not applicable"), use a named enum/constant (e.g., `NON_APPLICABLE = -3`) instead of `| null` everywhere
 - [ ] **Parameter object pattern** for functions with 4+ arguments — group related parameters into a single options object
+- [ ] **Group related optional fields into sub-objects** — instead of flat `petFoodType?`, `petFoodQuantity?`, `petFoodLovePoints?`, group into `petFood?: { type; quantity; lovePoints }`. This makes the relationship explicit and simplifies partial updates and spread operations
+- [ ] **Use TypeScript overloads** when a function accepts multiple input types and returns a correspondingly typed output (e.g., `buildResponse(IgniteRes, params): IgniteRes` / `buildResponse(ReviveRes, params): ReviveRes`)
 
 ## 3. Code Complexity
 
@@ -36,6 +42,10 @@ Generic review procedure to catch common issues before submitting a PR. Based on
 - [ ] **Inline collectors extracted** — `createCollector` callbacks in menu builders should be extracted to named functions, not defined inline in the return object
 - [ ] **Large files split by responsibility** — files with big switch statements covering many cases (e.g., one case per shop reaction) should be split into one file per case/handler
 - [ ] **Max 4 function arguments** (CodeScene "Excess Number of Function Arguments") — use parameter objects for 5+
+- [ ] **Early null checks / guard clauses** — when a nullable value is checked in 2+ downstream functions, validate it once at the top and pass guaranteed non-null values to sub-functions. Don't repeat the same `if (!x) return` in every helper
+- [ ] **Use spread for field forwarding** — when passing 3+ fields from one object to another with the same keys, use `...obj` spread instead of listing fields one by one. Also prefer destructuring `const { unwanted, ...rest } = obj` to separate fields
+- [ ] **Consistent parameter order across sibling functions** — related functions (e.g., handlers for the same feature) should use the same parameter order (e.g., `context, player, recipe` not `player, context, recipe` in one and `context, player` in another)
+- [ ] **No boolean expression bugs** — watch for `x === null || undefined` (always truthy) instead of `x === null` or `x == null`. These are subtle bugs that TypeScript may not catch
 
 ## 4. Imports & Module Organization
 
@@ -51,6 +61,7 @@ Generic review procedure to catch common issues before submitting a PR. Based on
 - [ ] **Cross-file duplicate functions** — search for identical or near-identical private functions across command files (e.g., `withUnlimitedMaxValue` in both EquipCommand and ChestFeatureHandler) and move to a shared utility class
 - [ ] **TypeScript overloads over duplicated functions** — when two functions differ only by type parameters/return types (e.g., `getBlacksmithUpgradeItem`/`getBlacksmithDisenchantItem`), use TypeScript function overloads with a single implementation
 - [ ] **Reuse existing Lib utilities** — before implementing utility logic (e.g., `frac()`, `getWeekNumber()`), check if a shared function already exists in `Lib/src/utils/`
+- [ ] **Domain logic belongs on the model** — if a check or computation is intrinsic to an entity (e.g., `isFoodCompatibleWithPet` belongs on `Pet`), place it as a method on the model class rather than in an unrelated service
 - [ ] **Translation keys shared when appropriate** — if multiple commands use the same labels (e.g., category names), put them in a shared namespace (`items.json` not `commands.json`)
 
 ## 6. Translations (i18n)
@@ -65,6 +76,8 @@ Generic review procedure to catch common issues before submitting a PR. Based on
 ## 7. Dead Code & Cleanup
 
 - [ ] **Remove unused imports, variables, and functions** — don't leave commented-out code or unreachable paths
+- [ ] **Remove useless wrapper functions** — if a function only forwards to another with the exact same arguments and adds no logic, remove the wrapper and call the target directly
+- [ ] **No useless constant aliases** — don't create a local alias for an imported constant that adds no semantic value (e.g., `const RECIPES = CookingConstants.RECIPES;`); use the original directly
 - [ ] **Update related comments** when code changes — don't leave outdated "TODO" or "Future features" comments
 - [ ] **Remove default cases that are unreachable** — if a switch exhausts all enum values, the default clause is dead code (or use it for the last case)
 

--- a/Core/__tests__/core/cooking/CookingConstants.test.ts
+++ b/Core/__tests__/core/cooking/CookingConstants.test.ts
@@ -1,0 +1,138 @@
+import {
+	describe, expect, it
+} from "vitest";
+import {
+	getCookingGrade, COOKING_GRADES, CookingXpConstants,
+	FAILURE_PENALTY_BASE, FURNACE_MAX_USES_PER_DAY,
+	GASPARD_JO_RECIPE_COSTS, FARMER_RECIPE_COSTS,
+	SLOT_CONFIGS, SLOT_SEED_OFFSETS
+} from "../../../../Lib/src/constants/CookingConstants";
+
+describe("CookingConstants", () => {
+	describe("getCookingGrade", () => {
+		it("should return aideCuisine for level 0", () => {
+			expect(getCookingGrade(0).name).toBe("aideCuisine");
+		});
+
+		it("should return aideCuisine for level 10", () => {
+			expect(getCookingGrade(10).name).toBe("aideCuisine");
+		});
+
+		it("should return marmiton for level 11", () => {
+			expect(getCookingGrade(11).name).toBe("marmiton");
+		});
+
+		it("should return grandCuisinierRoyal for level 91", () => {
+			expect(getCookingGrade(91).name).toBe("grandCuisinierRoyal");
+		});
+
+		it("should return grandCuisinierRoyal for very high levels", () => {
+			expect(getCookingGrade(500).name).toBe("grandCuisinierRoyal");
+		});
+
+		it("should return the last grade as fallback for unreachable levels", () => {
+			// getCookingGrade should always return a valid grade
+			const grade = getCookingGrade(999);
+			expect(grade).toBeDefined();
+			expect(grade.name).toBe("grandCuisinierRoyal");
+		});
+	});
+
+	describe("grade boundaries", () => {
+		it("should have no gaps between grade level ranges", () => {
+			for (let i = 1; i < COOKING_GRADES.length; i++) {
+				expect(COOKING_GRADES[i].minLevel).toBe(COOKING_GRADES[i - 1].maxLevel + 1);
+			}
+		});
+
+		it("should start at level 0", () => {
+			expect(COOKING_GRADES[0].minLevel).toBe(0);
+		});
+
+		it("should end at Infinity", () => {
+			expect(COOKING_GRADES[COOKING_GRADES.length - 1].maxLevel).toBe(Infinity);
+		});
+
+		it("should have 10 grades total", () => {
+			expect(COOKING_GRADES).toHaveLength(10);
+		});
+
+		it("every grade should have non-negative failureRate", () => {
+			for (const grade of COOKING_GRADES) {
+				expect(grade.failureRate).toBeGreaterThanOrEqual(0);
+				expect(grade.failureRate).toBeLessThanOrEqual(1);
+			}
+		});
+
+		it("every grade should have non-negative secretRecipeRate", () => {
+			for (const grade of COOKING_GRADES) {
+				expect(grade.secretRecipeRate).toBeGreaterThanOrEqual(0);
+				expect(grade.secretRecipeRate).toBeLessThanOrEqual(1);
+			}
+		});
+
+		it("every grade should have non-negative materialSaveChance and woodSaveChance", () => {
+			for (const grade of COOKING_GRADES) {
+				expect(grade.materialSaveChance).toBeGreaterThanOrEqual(0);
+				expect(grade.woodSaveChance).toBeGreaterThanOrEqual(0);
+			}
+		});
+	});
+
+	describe("slot configs", () => {
+		it("should have same count as seed offsets", () => {
+			expect(SLOT_CONFIGS.length).toBe(SLOT_SEED_OFFSETS.length);
+		});
+
+		it("each slot should have valid level range", () => {
+			for (const config of SLOT_CONFIGS) {
+				expect(config.minLevel).toBeLessThanOrEqual(config.maxLevel);
+				expect(config.minLevel).toBeGreaterThanOrEqual(1);
+			}
+		});
+
+		it("each slot should have at least one eligible type", () => {
+			for (const config of SLOT_CONFIGS) {
+				expect(config.eligibleTypes.length).toBeGreaterThan(0);
+			}
+		});
+	});
+
+	describe("progressive costs", () => {
+		it("GASPARD_JO_RECIPE_COSTS should be strictly increasing", () => {
+			for (let i = 1; i < GASPARD_JO_RECIPE_COSTS.length; i++) {
+				expect(GASPARD_JO_RECIPE_COSTS[i]).toBeGreaterThan(GASPARD_JO_RECIPE_COSTS[i - 1]);
+			}
+		});
+
+		it("FARMER_RECIPE_COSTS should be strictly increasing", () => {
+			for (let i = 1; i < FARMER_RECIPE_COSTS.length; i++) {
+				expect(FARMER_RECIPE_COSTS[i]).toBeGreaterThan(FARMER_RECIPE_COSTS[i - 1]);
+			}
+		});
+
+		it("first cost should be affordable for new players", () => {
+			expect(GASPARD_JO_RECIPE_COSTS[0]).toBeLessThanOrEqual(50);
+			expect(FARMER_RECIPE_COSTS[0]).toBeLessThanOrEqual(50);
+		});
+	});
+
+	describe("xp constants", () => {
+		it("should have positive weights summing to 1", () => {
+			expect(CookingXpConstants.PLANT_WEIGHT).toBeGreaterThan(0);
+			expect(CookingXpConstants.MATERIAL_WEIGHT).toBeGreaterThan(0);
+			expect(CookingXpConstants.PLANT_WEIGHT + CookingXpConstants.MATERIAL_WEIGHT).toBe(1);
+		});
+
+		it("should have positive failure XP per level", () => {
+			expect(CookingXpConstants.FAILURE_XP_PER_LEVEL).toBeGreaterThan(0);
+		});
+	});
+
+	describe("furnace limits", () => {
+		it("should allow a reasonable number of daily uses", () => {
+			expect(FURNACE_MAX_USES_PER_DAY).toBeGreaterThanOrEqual(5);
+			expect(FURNACE_MAX_USES_PER_DAY).toBeLessThanOrEqual(50);
+		});
+	});
+});

--- a/Core/__tests__/core/cooking/CookingConstants.test.ts
+++ b/Core/__tests__/core/cooking/CookingConstants.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import {
 	getCookingGrade, COOKING_GRADES, CookingXpConstants,
-	FAILURE_PENALTY_BASE, FURNACE_MAX_USES_PER_DAY,
+	FAILURE_LEVEL_OFFSET, FURNACE_MAX_USES_PER_DAY,
 	GASPARD_JO_RECIPE_COSTS, FARMER_RECIPE_COSTS,
 	SLOT_CONFIGS, SLOT_SEED_OFFSETS
 } from "../../../../Lib/src/constants/CookingConstants";

--- a/Core/__tests__/core/cooking/CookingConstants.test.ts
+++ b/Core/__tests__/core/cooking/CookingConstants.test.ts
@@ -10,31 +10,31 @@ import {
 
 describe("CookingConstants", () => {
 	describe("getCookingGrade", () => {
-		it("should return aideCuisine for level 0", () => {
-			expect(getCookingGrade(0).name).toBe("aideCuisine");
+		it("should return kitchenHelper for level 0", () => {
+			expect(getCookingGrade(0).id).toBe("kitchenHelper");
 		});
 
-		it("should return aideCuisine for level 10", () => {
-			expect(getCookingGrade(10).name).toBe("aideCuisine");
+		it("should return kitchenHelper for level 10", () => {
+			expect(getCookingGrade(10).id).toBe("kitchenHelper");
 		});
 
-		it("should return marmiton for level 11", () => {
-			expect(getCookingGrade(11).name).toBe("marmiton");
+		it("should return scullion for level 11", () => {
+			expect(getCookingGrade(11).id).toBe("scullion");
 		});
 
-		it("should return grandCuisinierRoyal for level 91", () => {
-			expect(getCookingGrade(91).name).toBe("grandCuisinierRoyal");
+		it("should return royalGrandChef for level 91", () => {
+			expect(getCookingGrade(91).id).toBe("royalGrandChef");
 		});
 
-		it("should return grandCuisinierRoyal for very high levels", () => {
-			expect(getCookingGrade(500).name).toBe("grandCuisinierRoyal");
+		it("should return royalGrandChef for very high levels", () => {
+			expect(getCookingGrade(500).id).toBe("royalGrandChef");
 		});
 
 		it("should return the last grade as fallback for unreachable levels", () => {
 			// getCookingGrade should always return a valid grade
 			const grade = getCookingGrade(999);
 			expect(grade).toBeDefined();
-			expect(grade.name).toBe("grandCuisinierRoyal");
+			expect(grade.id).toBe("royalGrandChef");
 		});
 	});
 

--- a/Core/__tests__/core/cooking/CookingService.test.ts
+++ b/Core/__tests__/core/cooking/CookingService.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import { CookingService } from "../../../src/core/cooking/CookingService";
 import {
-	getCookingGrade, CookingXpConstants, FAILURE_PENALTY_BASE,
+	getCookingGrade, CookingXpConstants, FAILURE_LEVEL_OFFSET,
 	PLANT_COOKING_XP, MATERIAL_RARITY_COOKING_XP
 } from "../../../../Lib/src/constants/CookingConstants";
 import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
@@ -121,7 +121,7 @@ describe("CookingService - pure functions", () => {
 		it("should apply penalty when recipe level exceeds grade limit", () => {
 			const grade = getCookingGrade(0); // failureRate = 0.10, maxRecipeLevelWithoutPenalty = 2
 			const rate = CookingService.getFailureRate(grade, 5);
-			const expected = grade.failureRate * (FAILURE_PENALTY_BASE + 5);
+			const expected = grade.failureRate * (FAILURE_LEVEL_OFFSET + 5);
 			expect(rate).toBe(expected);
 		});
 

--- a/Core/__tests__/core/cooking/CookingService.test.ts
+++ b/Core/__tests__/core/cooking/CookingService.test.ts
@@ -1,0 +1,164 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { CookingService } from "../../../src/core/cooking/CookingService";
+import {
+	getCookingGrade, CookingXpConstants, FAILURE_PENALTY_BASE,
+	PLANT_COOKING_XP, MATERIAL_RARITY_COOKING_XP
+} from "../../../../Lib/src/constants/CookingConstants";
+import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
+import { PlantId } from "../../../../Lib/src/constants/PlantConstants";
+import { Constants } from "../../../../Lib/src/constants/Constants";
+
+/**
+ * Minimal recipe factory for testing
+ */
+function createTestRecipe(overrides: Partial<CookingRecipe> = {}): CookingRecipe {
+	return {
+		id: "test_recipe",
+		level: 1,
+		recipeType: "POTION_HEALTH" as CookingRecipe["recipeType"],
+		plants: [{ plantId: PlantId.COMMON_HERB, quantity: 1 }],
+		materials: [{ materialId: 68, quantity: 1 }],
+		outputType: "potion",
+		discoveredByDefault: true,
+		...overrides
+	};
+}
+
+describe("CookingService - pure functions", () => {
+	describe("calculateCookingXp", () => {
+		it("should return positive XP for a valid recipe", () => {
+			const recipe = createTestRecipe();
+			const xp = CookingService.calculateCookingXp(recipe);
+			expect(xp).toBeGreaterThan(0);
+		});
+
+		it("should scale with plant quantity", () => {
+			const recipe1 = createTestRecipe({
+				plants: [{ plantId: PlantId.COMMON_HERB, quantity: 1 }],
+				materials: []
+			});
+			const recipe2 = createTestRecipe({
+				plants: [{ plantId: PlantId.COMMON_HERB, quantity: 3 }],
+				materials: []
+			});
+			const xp1 = CookingService.calculateCookingXp(recipe1);
+			const xp2 = CookingService.calculateCookingXp(recipe2);
+			expect(xp2).toBeGreaterThan(xp1);
+		});
+
+		it("should give more XP for higher-tier plants", () => {
+			const recipeLow = createTestRecipe({
+				plants: [{ plantId: PlantId.COMMON_HERB, quantity: 1 }],
+				materials: []
+			});
+			const recipeHigh = createTestRecipe({
+				plants: [{ plantId: PlantId.ANCIENT_TREE, quantity: 1 }],
+				materials: []
+			});
+			const xpLow = CookingService.calculateCookingXp(recipeLow);
+			const xpHigh = CookingService.calculateCookingXp(recipeHigh);
+			expect(xpHigh).toBeGreaterThan(xpLow);
+		});
+
+		it("should handle multiple plants", () => {
+			const recipe = createTestRecipe({
+				plants: [
+					{ plantId: PlantId.COMMON_HERB, quantity: 2 },
+					{ plantId: PlantId.GOLDEN_CLOVER, quantity: 1 }
+				],
+				materials: []
+			});
+			const xp = CookingService.calculateCookingXp(recipe);
+			const expected = Math.round(
+				(PLANT_COOKING_XP[PlantId.COMMON_HERB] * 2 + PLANT_COOKING_XP[PlantId.GOLDEN_CLOVER] * 1) * CookingXpConstants.PLANT_WEIGHT
+			);
+			expect(xp).toBe(expected);
+		});
+
+		it("should return 0 for recipe with no plants and no recognized materials", () => {
+			const recipe = createTestRecipe({
+				plants: [],
+				materials: [{ materialId: 999999, quantity: 1 }] // Non-existent material
+			});
+			const xp = CookingService.calculateCookingXp(recipe);
+			// Material data controller might not find this ID, so materialXp = 0
+			expect(xp).toBeGreaterThanOrEqual(0);
+		});
+	});
+
+	describe("calculateFailureXp", () => {
+		it("should return positive XP", () => {
+			expect(CookingService.calculateFailureXp(1)).toBeGreaterThan(0);
+		});
+
+		it("should scale linearly with recipe level", () => {
+			const xp1 = CookingService.calculateFailureXp(1);
+			const xp5 = CookingService.calculateFailureXp(5);
+			expect(xp5).toBe(xp1 * 5);
+		});
+
+		it("should equal FAILURE_XP_PER_LEVEL * level", () => {
+			const level = 4;
+			expect(CookingService.calculateFailureXp(level)).toBe(CookingXpConstants.FAILURE_XP_PER_LEVEL * level);
+		});
+	});
+
+	describe("getFailureRate", () => {
+		it("should return base rate when recipe level is within grade limit", () => {
+			const grade = getCookingGrade(0); // aideCuisine, maxRecipeLevelWithoutPenalty = 2
+			const rate = CookingService.getFailureRate(grade, 1);
+			expect(rate).toBe(grade.failureRate);
+		});
+
+		it("should return base rate at exact boundary", () => {
+			const grade = getCookingGrade(0);
+			const rate = CookingService.getFailureRate(grade, grade.maxRecipeLevelWithoutPenalty);
+			expect(rate).toBe(grade.failureRate);
+		});
+
+		it("should apply penalty when recipe level exceeds grade limit", () => {
+			const grade = getCookingGrade(0); // failureRate = 0.10, maxRecipeLevelWithoutPenalty = 2
+			const rate = CookingService.getFailureRate(grade, 5);
+			const expected = grade.failureRate * (FAILURE_PENALTY_BASE + 5);
+			expect(rate).toBe(expected);
+		});
+
+		it("should increase penalty with recipe level", () => {
+			const grade = getCookingGrade(0);
+			const rate3 = CookingService.getFailureRate(grade, 3);
+			const rate8 = CookingService.getFailureRate(grade, 8);
+			expect(rate8).toBeGreaterThan(rate3);
+		});
+
+		it("should not exceed 100% after capping in executeCraft", () => {
+			// getFailureRate itself can exceed 1.0, capping is done in executeCraft
+			const grade = getCookingGrade(0);
+			const rate = CookingService.getFailureRate(grade, 8);
+			expect(rate).toBeGreaterThan(0);
+		});
+	});
+
+	describe("getXpNeededForLevel", () => {
+		it("should return a positive number for level 0", () => {
+			expect(CookingService.getXpNeededForLevel(0)).toBeGreaterThan(0);
+		});
+
+		it("should increase with level", () => {
+			const xp5 = CookingService.getXpNeededForLevel(5);
+			const xp10 = CookingService.getXpNeededForLevel(10);
+			const xp50 = CookingService.getXpNeededForLevel(50);
+			expect(xp10).toBeGreaterThan(xp5);
+			expect(xp50).toBeGreaterThan(xp10);
+		});
+
+		it("should match the shared Constants.XP formula", () => {
+			const level = 15;
+			const expected = Math.round(
+				Constants.XP.BASE_VALUE * Math.pow(Constants.XP.COEFFICIENT, level + 1)
+			) - Constants.XP.MINUS;
+			expect(CookingService.getXpNeededForLevel(level)).toBe(expected);
+		});
+	});
+});

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -2,7 +2,7 @@ import {
 	describe, expect, it
 } from "vitest";
 import {
-	getSlotCycle, getRecipeForSlot, getUniqueRecipesForSlots, isRecipeSecret, getCurrentDaySeed
+	getSlotCycle, getRecipeForSlotExcluding, getUniqueRecipesForSlots, isRecipeSecret, getCurrentDaySeed
 } from "../../../src/core/cooking/CookingSlotRotation";
 import {
 	SLOT_CONFIGS, RecipeType, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES, CookingOutputType
@@ -41,12 +41,12 @@ describe("CookingSlotRotation", () => {
 		});
 	});
 
-	describe("getRecipeForSlot", () => {
+	describe("getRecipeForSlotExcluding", () => {
 		it("should return null when no discovered recipes match", () => {
 			// Empty discovered list means only discoveredByDefault recipes
 			// Slot 3 (potions only, level 3-8) — may have no match for empty list
-			const result = getRecipeForSlot({
-				slotIndex: 3, furnacePosition: 0, daySeed: 12345, discoveredRecipeIds: []
+			const result = getRecipeForSlotExcluding({
+				slotIndex: 3, furnacePosition: 0, daySeed: 12345, discoveredRecipeIds: [], excludedRecipeIds: new Set()
 			});
 			// Result depends on data, but should not crash
 			expect(result === null || typeof result.id === "string").toBe(true);
@@ -54,11 +54,11 @@ describe("CookingSlotRotation", () => {
 
 		it("should be deterministic for same parameters", () => {
 			const discovered = ["potion_health_1", "potion_health_2", "potion_energy_1"];
-			const a = getRecipeForSlot({
-				slotIndex: 0, furnacePosition: 5, daySeed: 42, discoveredRecipeIds: discovered
+			const a = getRecipeForSlotExcluding({
+				slotIndex: 0, furnacePosition: 5, daySeed: 42, discoveredRecipeIds: discovered, excludedRecipeIds: new Set()
 			});
-			const b = getRecipeForSlot({
-				slotIndex: 0, furnacePosition: 5, daySeed: 42, discoveredRecipeIds: discovered
+			const b = getRecipeForSlotExcluding({
+				slotIndex: 0, furnacePosition: 5, daySeed: 42, discoveredRecipeIds: discovered, excludedRecipeIds: new Set()
 			});
 			expect(a?.id).toEqual(b?.id);
 		});
@@ -68,8 +68,8 @@ describe("CookingSlotRotation", () => {
 			const seed = 100;
 			const recipes = [];
 			for (let pos = 0; pos < 10; pos++) {
-				recipes.push(getRecipeForSlot({
-					slotIndex: 0, furnacePosition: pos, daySeed: seed, discoveredRecipeIds: discovered
+				recipes.push(getRecipeForSlotExcluding({
+					slotIndex: 0, furnacePosition: pos, daySeed: seed, discoveredRecipeIds: discovered, excludedRecipeIds: new Set()
 				}));
 			}
 			// Should have variation (not all the same recipe)

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -1,0 +1,148 @@
+import {
+	describe, expect, it
+} from "vitest";
+import {
+	getSlotCycle, getRecipeForSlot, getUniqueRecipesForSlots, isRecipeSecret, getCurrentDaySeed
+} from "../../../src/core/cooking/CookingSlotRotation";
+import {
+	SLOT_CONFIGS, RecipeType
+} from "../../../../Lib/src/constants/CookingConstants";
+import { recipeRegistry } from "../../../src/core/cooking/RecipeRegistry";
+
+describe("CookingSlotRotation", () => {
+	describe("getSlotCycle", () => {
+		it("should return all eligible types for a slot", () => {
+			const cycle = getSlotCycle(0, 12345);
+			const expected = SLOT_CONFIGS[0].eligibleTypes;
+			expect(cycle).toHaveLength(expected.length);
+			expect(new Set(cycle)).toEqual(new Set(expected));
+		});
+
+		it("should be deterministic — same seed same result", () => {
+			const a = getSlotCycle(1, 99999);
+			const b = getSlotCycle(1, 99999);
+			expect(a).toEqual(b);
+		});
+
+		it("should produce different orders for different seeds", () => {
+			const a = getSlotCycle(0, 1);
+			const b = getSlotCycle(0, 2);
+			// Very unlikely to be identical for different seeds
+			const sameOrder = a.every((v, i) => v === b[i]);
+			expect(sameOrder).toBe(false);
+		});
+
+		it("should produce different orders for different slots with same seed", () => {
+			const a = getSlotCycle(0, 1000);
+			const b = getSlotCycle(1, 1000);
+			// Different seed offsets should give different permutations
+			const sameOrder = a.length === b.length && a.every((v, i) => v === b[i]);
+			expect(sameOrder).toBe(false);
+		});
+	});
+
+	describe("getRecipeForSlot", () => {
+		it("should return null when no discovered recipes match", () => {
+			// Empty discovered list means only discoveredByDefault recipes
+			// Slot 3 (potions only, level 3-8) — may have no match for empty list
+			const result = getRecipeForSlot(3, 0, 12345, []);
+			// Result depends on data, but should not crash
+			expect(result === null || typeof result.id === "string").toBe(true);
+		});
+
+		it("should be deterministic for same parameters", () => {
+			const discovered = ["potion_health_1", "potion_health_2", "potion_energy_1"];
+			const a = getRecipeForSlot(0, 5, 42, discovered);
+			const b = getRecipeForSlot(0, 5, 42, discovered);
+			expect(a?.id).toEqual(b?.id);
+		});
+
+		it("should cycle through recipe types as furnace position changes", () => {
+			const discovered = ["potion_health_1", "potion_energy_1", "potion_attack_1"];
+			const seed = 100;
+			const recipes = [];
+			for (let pos = 0; pos < 10; pos++) {
+				recipes.push(getRecipeForSlot(0, pos, seed, discovered));
+			}
+			// Should have variation (not all the same recipe)
+			const ids = recipes.filter(r => r !== null).map(r => r!.id);
+			const uniqueIds = new Set(ids);
+			expect(uniqueIds.size).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("getUniqueRecipesForSlots", () => {
+		it("should not propose the same recipe in two slots at the same time", () => {
+			const discovered = recipeRegistry.getAll().map(recipe => recipe.id);
+			const daySeeds = [
+				1,
+				42,
+				12345
+			];
+
+			for (const daySeed of daySeeds) {
+				for (let furnacePosition = 0; furnacePosition < 40; furnacePosition++) {
+					const recipes = getUniqueRecipesForSlots({
+						cookingSlots: SLOT_CONFIGS.length,
+						furnacePosition,
+						daySeed,
+						discoveredRecipeIds: discovered
+					});
+					const ids = recipes.filter(recipe => recipe !== null).map(recipe => recipe!.id);
+					expect(ids).toHaveLength(new Set(ids).size);
+				}
+			}
+		});
+
+		it("should exclude pet food recipes when guild storage is unavailable", () => {
+			const discovered = recipeRegistry.getAll().map(recipe => recipe.id);
+			const recipes = getUniqueRecipesForSlots({
+				cookingSlots: SLOT_CONFIGS.length,
+				furnacePosition: 12,
+				daySeed: 77,
+				discoveredRecipeIds: discovered,
+				allowPetFoodRecipes: false
+			});
+
+			expect(recipes.every(recipe => recipe === null || recipe.outputType !== "petFood")).toBe(true);
+		});
+	});
+
+	describe("isRecipeSecret", () => {
+		it("should be deterministic for same inputs", () => {
+			const a = isRecipeSecret(0, 3, 42, 0.5);
+			const b = isRecipeSecret(0, 3, 42, 0.5);
+			expect(a).toBe(b);
+		});
+
+		it("should return false when secretRate is 0", () => {
+			// With rate 0, no recipe should ever be secret
+			let anySecret = false;
+			for (let i = 0; i < 100; i++) {
+				if (isRecipeSecret(0, i, i * 7, 0)) {
+					anySecret = true;
+				}
+			}
+			expect(anySecret).toBe(false);
+		});
+
+		it("should return true when secretRate is 1", () => {
+			// With rate 1.0, all should be secret
+			let allSecret = true;
+			for (let i = 0; i < 100; i++) {
+				if (!isRecipeSecret(0, i, i * 7, 1)) {
+					allSecret = false;
+				}
+			}
+			expect(allSecret).toBe(true);
+		});
+	});
+
+	describe("getCurrentDaySeed", () => {
+		it("should return a positive integer", () => {
+			const seed = getCurrentDaySeed();
+			expect(seed).toBeGreaterThan(0);
+			expect(Number.isInteger(seed)).toBe(true);
+		});
+	});
+});

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -45,15 +45,21 @@ describe("CookingSlotRotation", () => {
 		it("should return null when no discovered recipes match", () => {
 			// Empty discovered list means only discoveredByDefault recipes
 			// Slot 3 (potions only, level 3-8) — may have no match for empty list
-			const result = getRecipeForSlot(3, 0, 12345, []);
+			const result = getRecipeForSlot({
+				slotIndex: 3, furnacePosition: 0, daySeed: 12345, discoveredRecipeIds: []
+			});
 			// Result depends on data, but should not crash
 			expect(result === null || typeof result.id === "string").toBe(true);
 		});
 
 		it("should be deterministic for same parameters", () => {
 			const discovered = ["potion_health_1", "potion_health_2", "potion_energy_1"];
-			const a = getRecipeForSlot(0, 5, 42, discovered);
-			const b = getRecipeForSlot(0, 5, 42, discovered);
+			const a = getRecipeForSlot({
+				slotIndex: 0, furnacePosition: 5, daySeed: 42, discoveredRecipeIds: discovered
+			});
+			const b = getRecipeForSlot({
+				slotIndex: 0, furnacePosition: 5, daySeed: 42, discoveredRecipeIds: discovered
+			});
 			expect(a?.id).toEqual(b?.id);
 		});
 
@@ -62,7 +68,9 @@ describe("CookingSlotRotation", () => {
 			const seed = 100;
 			const recipes = [];
 			for (let pos = 0; pos < 10; pos++) {
-				recipes.push(getRecipeForSlot(0, pos, seed, discovered));
+				recipes.push(getRecipeForSlot({
+					slotIndex: 0, furnacePosition: pos, daySeed: seed, discoveredRecipeIds: discovered
+				}));
 			}
 			// Should have variation (not all the same recipe)
 			const ids = recipes.filter(r => r !== null).map(r => r!.id);
@@ -182,8 +190,12 @@ describe("CookingSlotRotation", () => {
 
 	describe("isRecipeSecret", () => {
 		it("should be deterministic for same inputs", () => {
-			const a = isRecipeSecret(0, 3, 42, 0.5);
-			const b = isRecipeSecret(0, 3, 42, 0.5);
+			const a = isRecipeSecret({
+				slotIndex: 0, furnacePosition: 3, daySeed: 42, secretRate: 0.5
+			});
+			const b = isRecipeSecret({
+				slotIndex: 0, furnacePosition: 3, daySeed: 42, secretRate: 0.5
+			});
 			expect(a).toBe(b);
 		});
 
@@ -191,7 +203,9 @@ describe("CookingSlotRotation", () => {
 			// With rate 0, no recipe should ever be secret
 			let anySecret = false;
 			for (let i = 0; i < 100; i++) {
-				if (isRecipeSecret(0, i, i * 7, 0)) {
+				if (isRecipeSecret({
+					slotIndex: 0, furnacePosition: i, daySeed: i * 7, secretRate: 0
+				})) {
 					anySecret = true;
 				}
 			}
@@ -202,7 +216,9 @@ describe("CookingSlotRotation", () => {
 			// With rate 1.0, all should be secret
 			let allSecret = true;
 			for (let i = 0; i < 100; i++) {
-				if (!isRecipeSecret(0, i, i * 7, 1)) {
+				if (!isRecipeSecret({
+					slotIndex: 0, furnacePosition: i, daySeed: i * 7, secretRate: 1
+				})) {
 					allSecret = false;
 				}
 			}

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -5,9 +5,9 @@ import {
 	getSlotCycle, getRecipeForSlot, getUniqueRecipesForSlots, isRecipeSecret, getCurrentDaySeed
 } from "../../../src/core/cooking/CookingSlotRotation";
 import {
-	SLOT_CONFIGS, RecipeType
+	SLOT_CONFIGS, RecipeType, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES
 } from "../../../../Lib/src/constants/CookingConstants";
-import { recipeRegistry } from "../../../src/core/cooking/RecipeRegistry";
+import { CookingRecipeDataController } from "../../../src/data/CookingRecipeData";
 
 describe("CookingSlotRotation", () => {
 	describe("getSlotCycle", () => {
@@ -73,7 +73,7 @@ describe("CookingSlotRotation", () => {
 
 	describe("getUniqueRecipesForSlots", () => {
 		it("should not propose the same recipe in two slots at the same time", () => {
-			const discovered = recipeRegistry.getAll().map(recipe => recipe.id);
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
 			const daySeeds = [
 				1,
 				42,
@@ -95,7 +95,7 @@ describe("CookingSlotRotation", () => {
 		});
 
 		it("should exclude pet food recipes when guild storage is unavailable", () => {
-			const discovered = recipeRegistry.getAll().map(recipe => recipe.id);
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
 			const recipes = getUniqueRecipesForSlots({
 				cookingSlots: SLOT_CONFIGS.length,
 				furnacePosition: 12,
@@ -105,6 +105,78 @@ describe("CookingSlotRotation", () => {
 			});
 
 			expect(recipes.every(recipe => recipe === null || recipe.outputType !== "petFood")).toBe(true);
+		});
+
+		it("should guarantee at least 2 recipes at player level for low-level players", () => {
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
+			const maxRecipeLevelWithoutPenalty = 2; // Aide-cuisine grade
+
+			for (let furnacePosition = 0; furnacePosition < 40; furnacePosition++) {
+				const recipes = getUniqueRecipesForSlots({
+					cookingSlots: SLOT_CONFIGS.length,
+					furnacePosition,
+					daySeed: 42,
+					discoveredRecipeIds: discovered,
+					maxRecipeLevelWithoutPenalty
+				});
+
+				const playerLevelRecipes = recipes.filter(
+					recipe => recipe !== null && recipe.level <= maxRecipeLevelWithoutPenalty
+				);
+				expect(playerLevelRecipes.length).toBeGreaterThanOrEqual(MIN_GUARANTEED_PLAYER_LEVEL_RECIPES);
+			}
+		});
+
+		it("should guarantee player-level recipes across many day seeds", () => {
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
+			const maxRecipeLevelWithoutPenalty = 2;
+
+			for (const daySeed of [1, 42, 100, 999, 12345, 50000]) {
+				for (let furnacePosition = 0; furnacePosition < 20; furnacePosition++) {
+					const recipes = getUniqueRecipesForSlots({
+						cookingSlots: SLOT_CONFIGS.length,
+						furnacePosition,
+						daySeed,
+						discoveredRecipeIds: discovered,
+						maxRecipeLevelWithoutPenalty
+					});
+
+					const playerLevelRecipes = recipes.filter(
+						recipe => recipe !== null && recipe.level <= maxRecipeLevelWithoutPenalty
+					);
+					expect(playerLevelRecipes.length).toBeGreaterThanOrEqual(MIN_GUARANTEED_PLAYER_LEVEL_RECIPES);
+				}
+			}
+		});
+
+		it("should still produce no duplicates when using level guarantee", () => {
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
+
+			for (const daySeed of [1, 42, 12345]) {
+				for (let furnacePosition = 0; furnacePosition < 40; furnacePosition++) {
+					const recipes = getUniqueRecipesForSlots({
+						cookingSlots: SLOT_CONFIGS.length,
+						furnacePosition,
+						daySeed,
+						discoveredRecipeIds: discovered,
+						maxRecipeLevelWithoutPenalty: 2
+					});
+					const ids = recipes.filter(recipe => recipe !== null).map(recipe => recipe!.id);
+					expect(ids).toHaveLength(new Set(ids).size);
+				}
+			}
+		});
+
+		it("should behave identically without maxRecipeLevelWithoutPenalty parameter", () => {
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
+			const recipesWithout = getUniqueRecipesForSlots({
+				cookingSlots: SLOT_CONFIGS.length,
+				furnacePosition: 5,
+				daySeed: 42,
+				discoveredRecipeIds: discovered
+			});
+			// Without the param, should still work (backward compatible)
+			expect(recipesWithout).toHaveLength(SLOT_CONFIGS.length);
 		});
 	});
 

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -2,7 +2,7 @@ import {
 	describe, expect, it
 } from "vitest";
 import {
-	getSlotCycle, getRecipeForSlotExcluding, getUniqueRecipesForSlots, isRecipeSecret, getCurrentDaySeed
+	getSlotCycle, getRecipeForSlotExcluding, getUniqueRecipesForSlots, isRecipeSecret
 } from "../../../src/core/cooking/CookingSlotRotation";
 import {
 	SLOT_CONFIGS, RecipeType, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES, CookingOutputType
@@ -226,13 +226,7 @@ describe("CookingSlotRotation", () => {
 		});
 	});
 
-	describe("getCurrentDaySeed", () => {
-		it("should return a positive integer", () => {
-			const seed = getCurrentDaySeed();
-			expect(seed).toBeGreaterThan(0);
-			expect(Number.isInteger(seed)).toBe(true);
-		});
-	});
+
 
 	describe("edge cases", () => {
 		it("should return an empty array when cookingSlots is 0", () => {

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -5,7 +5,7 @@ import {
 	getSlotCycle, getRecipeForSlot, getUniqueRecipesForSlots, isRecipeSecret, getCurrentDaySeed
 } from "../../../src/core/cooking/CookingSlotRotation";
 import {
-	SLOT_CONFIGS, RecipeType, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES
+	SLOT_CONFIGS, RecipeType, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES, CookingOutputType
 } from "../../../../Lib/src/constants/CookingConstants";
 import { CookingRecipeDataController } from "../../../src/data/CookingRecipeData";
 
@@ -104,7 +104,7 @@ describe("CookingSlotRotation", () => {
 				allowPetFoodRecipes: false
 			});
 
-			expect(recipes.every(recipe => recipe === null || recipe.outputType !== "petFood")).toBe(true);
+			expect(recipes.every(recipe => recipe === null || recipe.outputType !== CookingOutputType.PET_FOOD)).toBe(true);
 		});
 
 		it("should guarantee at least 2 recipes at player level for low-level players", () => {
@@ -215,6 +215,34 @@ describe("CookingSlotRotation", () => {
 			const seed = getCurrentDaySeed();
 			expect(seed).toBeGreaterThan(0);
 			expect(Number.isInteger(seed)).toBe(true);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("should return an empty array when cookingSlots is 0", () => {
+			const discovered = CookingRecipeDataController.instance.getAll().map(recipe => recipe.id);
+			const recipes = getUniqueRecipesForSlots({
+				cookingSlots: 0,
+				furnacePosition: 5,
+				daySeed: 42,
+				discoveredRecipeIds: discovered
+			});
+			expect(recipes).toHaveLength(0);
+		});
+
+		it("should handle empty discoveredRecipeIds with no default recipes gracefully", () => {
+			const recipes = getUniqueRecipesForSlots({
+				cookingSlots: SLOT_CONFIGS.length,
+				furnacePosition: 0,
+				daySeed: 42,
+				discoveredRecipeIds: []
+			});
+			// Should not crash — recipes are either null or discoveredByDefault
+			for (const recipe of recipes) {
+				if (recipe !== null) {
+					expect(recipe.discoveredByDefault).toBe(true);
+				}
+			}
 		});
 	});
 });

--- a/Core/__tests__/core/data/CookingRecipeData.test.ts
+++ b/Core/__tests__/core/data/CookingRecipeData.test.ts
@@ -25,8 +25,16 @@ interface MonsterData {
 }
 
 describe("Cooking Recipe Data Validation", () => {
-	const recipesPath = resolve(__dirname, "../../../resources/cooking/recipes.json");
-	const recipes: RecipeData[] = JSON.parse(readFileSync(recipesPath, "utf-8"));
+	const recipesDir = resolve(__dirname, "../../../resources/cooking/recipes");
+	const recipes: RecipeData[] = readdirSync(recipesDir)
+		.filter(f => f.endsWith(".json"))
+		.map(f => {
+			const data = JSON.parse(readFileSync(resolve(recipesDir, f), "utf-8")) as Omit<RecipeData, "id">;
+			return {
+				...data,
+				id: f.replace(".json", "")
+			} as RecipeData;
+		});
 
 	it("should have the same number of ISLAND_BOSS recipes as final boss locations", () => {
 		const islandBossRecipes = recipes.filter(r => r.discoverySource === "ISLAND_BOSS");

--- a/Core/__tests__/core/data/CookingRecipeData.test.ts
+++ b/Core/__tests__/core/data/CookingRecipeData.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { FightConstants } from "../../../../Lib/src/constants/FightConstants";
+
+interface RecipeData {
+	id: string;
+	level: number;
+	discoveredByDefault: boolean;
+	discoverySource?: string;
+}
+
+interface MapLocationData {
+	type: string;
+	attribute: string;
+}
+
+interface MapLinkData {
+	startMap: number;
+	endMap: number;
+}
+
+interface MonsterData {
+	maps: number[];
+}
+
+describe("Cooking Recipe Data Validation", () => {
+	const recipesPath = resolve(__dirname, "../../../resources/cooking/recipes.json");
+	const recipes: RecipeData[] = JSON.parse(readFileSync(recipesPath, "utf-8"));
+
+	it("should have the same number of ISLAND_BOSS recipes as final boss locations", () => {
+		const islandBossRecipes = recipes.filter(r => r.discoverySource === "ISLAND_BOSS");
+		const finalBossCount = Object.keys(FightConstants.FINAL_BOSS_MONSTER_IDS).length;
+
+		// When the oceanic island is merged, add 2 more ISLAND_BOSS recipes:
+		// potion_health_8 and potion_time_speedup_8 (currently set as DEFAULT in recipes.json)
+		expect(islandBossRecipes.length).toBe(finalBossCount);
+	});
+
+	it("should have every final boss location covered by a monster in FINAL_BOSS_MONSTER_IDS", () => {
+		const resourcesPath = resolve(__dirname, "../../../resources");
+
+		// Load map locations
+		const locationsDir = resolve(resourcesPath, "mapLocations");
+		const locations: Record<number, MapLocationData> = {};
+		for (const file of readdirSync(locationsDir).filter(f => f.endsWith(".json"))) {
+			const id = parseInt(file.replace(".json", ""));
+			locations[id] = JSON.parse(readFileSync(resolve(locationsDir, file), "utf-8"));
+		}
+
+		// Load map links
+		const linksDir = resolve(resourcesPath, "mapLinks");
+		const links: MapLinkData[] = [];
+		for (const file of readdirSync(linksDir).filter(f => f.endsWith(".json"))) {
+			links.push(JSON.parse(readFileSync(resolve(linksDir, file), "utf-8")));
+		}
+
+		// Compute final boss map IDs: pve_island locations where all outgoing links go to pve_exit
+		const pveIslandIds = Object.entries(locations)
+			.filter(([, loc]) => loc.attribute === "pve_island")
+			.map(([id]) => parseInt(id));
+
+		const finalBossMapIds = pveIslandIds.filter(id => {
+			const outgoing = links.filter(l => l.startMap === id);
+			return outgoing.length > 0 && outgoing.every(l => locations[l.endMap]?.attribute === "pve_exit");
+		});
+
+		// Load monster data for each final boss and collect covered map IDs
+		const bossMonsterIds = Object.values(FightConstants.FINAL_BOSS_MONSTER_IDS);
+		const monstersDir = resolve(resourcesPath, "monsters");
+		const coveredMapIds = new Set<number>();
+		for (const monsterId of bossMonsterIds) {
+			const monsterData: MonsterData = JSON.parse(
+				readFileSync(resolve(monstersDir, `${monsterId}.json`), "utf-8")
+			);
+			for (const mapId of monsterData.maps) {
+				coveredMapIds.add(mapId);
+			}
+		}
+
+		// Every final boss location must be covered by a boss monster
+		const uncoveredLocations = finalBossMapIds.filter(id => !coveredMapIds.has(id));
+		expect(
+			uncoveredLocations,
+			`Final boss locations ${uncoveredLocations.join(", ")} have no monster from FINAL_BOSS_MONSTER_IDS assigned to them`
+		).toHaveLength(0);
+	});
+
+	it("should have unique ids for all recipes", () => {
+		const ids = recipes.map(r => r.id);
+		const uniqueIds = new Set(ids);
+		expect(uniqueIds.size).toBe(ids.length);
+	});
+
+	it("should have a valid discoverySource or be discoveredByDefault", () => {
+		const validSources = [
+			"ISLAND_BOSS", "CAMPAIGN_MILESTONE", "PLAYER_LEVEL_MILESTONE",
+			"GASPARD_JO", "FARMER", "COOKING_LEVEL", "WITCH"
+		];
+
+		for (const recipe of recipes) {
+			if (!recipe.discoveredByDefault) {
+				expect(
+					validSources.includes(recipe.discoverySource!),
+					`Recipe ${recipe.id} is not discoveredByDefault but has invalid discoverySource: ${recipe.discoverySource}`
+				).toBe(true);
+			}
+		}
+	});
+});

--- a/Core/resources/cities/coco_village.json
+++ b/Core/resources/cities/coco_village.json
@@ -10,7 +10,8 @@
   "hasBlacksmith": false,
   "shops": [
     "generalShop",
-    "herbalist"
+    "herbalist",
+    "lumberjack"
   ],
   "inns": [
     {

--- a/Core/resources/cooking/recipes/material_alloy_1.json
+++ b/Core/resources/cooking/recipes/material_alloy_1.json
@@ -20,5 +20,6 @@
   "outputType": "material",
   "outputMaterialId": 22,
   "outputMaterialQuantity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_alloy_2.json
+++ b/Core/resources/cooking/recipes/material_alloy_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 39,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_alloy_3.json
+++ b/Core/resources/cooking/recipes/material_alloy_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 67,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_explosive_1.json
+++ b/Core/resources/cooking/recipes/material_explosive_1.json
@@ -20,5 +20,6 @@
   "outputType": "material",
   "outputMaterialId": 6,
   "outputMaterialQuantity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_explosive_2.json
+++ b/Core/resources/cooking/recipes/material_explosive_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 28,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_explosive_3.json
+++ b/Core/resources/cooking/recipes/material_explosive_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 56,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_leather_1.json
+++ b/Core/resources/cooking/recipes/material_leather_1.json
@@ -21,5 +21,6 @@
   "outputMaterialId": 11,
   "outputMaterialQuantity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_leather_2.json
+++ b/Core/resources/cooking/recipes/material_leather_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 27,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_leather_3.json
+++ b/Core/resources/cooking/recipes/material_leather_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 83,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_magic_1.json
+++ b/Core/resources/cooking/recipes/material_magic_1.json
@@ -20,5 +20,6 @@
   "outputType": "material",
   "outputMaterialId": 62,
   "outputMaterialQuantity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_magic_2.json
+++ b/Core/resources/cooking/recipes/material_magic_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 69,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_magic_3.json
+++ b/Core/resources/cooking/recipes/material_magic_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 76,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_metal_1.json
+++ b/Core/resources/cooking/recipes/material_metal_1.json
@@ -20,5 +20,6 @@
   "outputType": "material",
   "outputMaterialId": 4,
   "outputMaterialQuantity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_metal_2.json
+++ b/Core/resources/cooking/recipes/material_metal_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 16,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_metal_3.json
+++ b/Core/resources/cooking/recipes/material_metal_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 86,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_nature_1.json
+++ b/Core/resources/cooking/recipes/material_nature_1.json
@@ -20,5 +20,6 @@
   "outputType": "material",
   "outputMaterialId": 19,
   "outputMaterialQuantity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_nature_2.json
+++ b/Core/resources/cooking/recipes/material_nature_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 40,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_nature_3.json
+++ b/Core/resources/cooking/recipes/material_nature_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 87,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_poison_1.json
+++ b/Core/resources/cooking/recipes/material_poison_1.json
@@ -21,5 +21,6 @@
   "outputMaterialId": 3,
   "outputMaterialQuantity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_poison_2.json
+++ b/Core/resources/cooking/recipes/material_poison_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 36,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_poison_3.json
+++ b/Core/resources/cooking/recipes/material_poison_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 65,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_rope_1.json
+++ b/Core/resources/cooking/recipes/material_rope_1.json
@@ -20,5 +20,6 @@
   "outputType": "material",
   "outputMaterialId": 12,
   "outputMaterialQuantity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_rope_2.json
+++ b/Core/resources/cooking/recipes/material_rope_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 57,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_rope_3.json
+++ b/Core/resources/cooking/recipes/material_rope_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 75,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_spiritual_1.json
+++ b/Core/resources/cooking/recipes/material_spiritual_1.json
@@ -21,5 +21,6 @@
   "outputMaterialId": 5,
   "outputMaterialQuantity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_spiritual_2.json
+++ b/Core/resources/cooking/recipes/material_spiritual_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 61,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_spiritual_3.json
+++ b/Core/resources/cooking/recipes/material_spiritual_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 72,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_wood_1.json
+++ b/Core/resources/cooking/recipes/material_wood_1.json
@@ -21,5 +21,6 @@
   "outputMaterialId": 18,
   "outputMaterialQuantity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_wood_2.json
+++ b/Core/resources/cooking/recipes/material_wood_2.json
@@ -25,5 +25,6 @@
   "outputMaterialId": 31,
   "outputMaterialQuantity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/material_wood_3.json
+++ b/Core/resources/cooking/recipes/material_wood_3.json
@@ -29,5 +29,6 @@
   "outputMaterialId": 84,
   "outputMaterialQuantity": 3,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/petfood_candy_1.json
+++ b/Core/resources/cooking/recipes/petfood_candy_1.json
@@ -14,9 +14,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "commonFood",
-  "petFoodQuantity": 1,
-  "petFoodLovePoints": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": {
+    "type": "commonFood",
+    "quantity": 1,
+    "lovePoints": 1
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_candy_2.json
+++ b/Core/resources/cooking/recipes/petfood_candy_2.json
@@ -18,8 +18,10 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "commonFood",
-  "petFoodQuantity": 3,
-  "petFoodLovePoints": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": {
+    "type": "commonFood",
+    "quantity": 3,
+    "lovePoints": 3
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_candy_3.json
+++ b/Core/resources/cooking/recipes/petfood_candy_3.json
@@ -22,8 +22,10 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "commonFood",
-  "petFoodQuantity": 7,
-  "petFoodLovePoints": 7,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": {
+    "type": "commonFood",
+    "quantity": 7,
+    "lovePoints": 7
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_candy_4.json
+++ b/Core/resources/cooking/recipes/petfood_candy_4.json
@@ -26,9 +26,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "commonFood",
-  "petFoodQuantity": 12,
-  "petFoodLovePoints": 12,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": {
+    "type": "commonFood",
+    "quantity": 12,
+    "lovePoints": 12
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_candy_5.json
+++ b/Core/resources/cooking/recipes/petfood_candy_5.json
@@ -34,9 +34,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "commonFood",
-  "petFoodQuantity": 18,
-  "petFoodLovePoints": 18,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": {
+    "type": "commonFood",
+    "quantity": 18,
+    "lovePoints": 18
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_meat_1.json
+++ b/Core/resources/cooking/recipes/petfood_meat_1.json
@@ -14,8 +14,10 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "carnivorousFood",
-  "petFoodQuantity": 1,
-  "petFoodLovePoints": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": {
+    "type": "carnivorousFood",
+    "quantity": 1,
+    "lovePoints": 3
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_meat_2.json
+++ b/Core/resources/cooking/recipes/petfood_meat_2.json
@@ -14,9 +14,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "carnivorousFood",
-  "petFoodQuantity": 2,
-  "petFoodLovePoints": 6,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": {
+    "type": "carnivorousFood",
+    "quantity": 2,
+    "lovePoints": 6
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_meat_3.json
+++ b/Core/resources/cooking/recipes/petfood_meat_3.json
@@ -22,9 +22,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "carnivorousFood",
-  "petFoodQuantity": 4,
-  "petFoodLovePoints": 12,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": {
+    "type": "carnivorousFood",
+    "quantity": 4,
+    "lovePoints": 12
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_meat_4.json
+++ b/Core/resources/cooking/recipes/petfood_meat_4.json
@@ -30,9 +30,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "carnivorousFood",
-  "petFoodQuantity": 7,
-  "petFoodLovePoints": 21,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": {
+    "type": "carnivorousFood",
+    "quantity": 7,
+    "lovePoints": 21
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_meat_5.json
+++ b/Core/resources/cooking/recipes/petfood_meat_5.json
@@ -34,9 +34,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "carnivorousFood",
-  "petFoodQuantity": 10,
-  "petFoodLovePoints": 30,
   "discoveredByDefault": false,
-  "discoverySource": "COOKING_LEVEL"
+  "discoverySource": "COOKING_LEVEL",
+  "petFood": {
+    "type": "carnivorousFood",
+    "quantity": 10,
+    "lovePoints": 30
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_salad_1.json
+++ b/Core/resources/cooking/recipes/petfood_salad_1.json
@@ -14,8 +14,10 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "herbivorousFood",
-  "petFoodQuantity": 1,
-  "petFoodLovePoints": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": {
+    "type": "herbivorousFood",
+    "quantity": 1,
+    "lovePoints": 3
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_salad_2.json
+++ b/Core/resources/cooking/recipes/petfood_salad_2.json
@@ -14,8 +14,10 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "herbivorousFood",
-  "petFoodQuantity": 2,
-  "petFoodLovePoints": 6,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": {
+    "type": "herbivorousFood",
+    "quantity": 2,
+    "lovePoints": 6
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_salad_3.json
+++ b/Core/resources/cooking/recipes/petfood_salad_3.json
@@ -22,9 +22,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "herbivorousFood",
-  "petFoodQuantity": 4,
-  "petFoodLovePoints": 12,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": {
+    "type": "herbivorousFood",
+    "quantity": 4,
+    "lovePoints": 12
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_salad_4.json
+++ b/Core/resources/cooking/recipes/petfood_salad_4.json
@@ -30,9 +30,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "herbivorousFood",
-  "petFoodQuantity": 7,
-  "petFoodLovePoints": 21,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": {
+    "type": "herbivorousFood",
+    "quantity": 7,
+    "lovePoints": 21
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_salad_5.json
+++ b/Core/resources/cooking/recipes/petfood_salad_5.json
@@ -34,9 +34,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "herbivorousFood",
-  "petFoodQuantity": 10,
-  "petFoodLovePoints": 30,
   "discoveredByDefault": false,
-  "discoverySource": "FARMER"
+  "discoverySource": "FARMER",
+  "petFood": {
+    "type": "herbivorousFood",
+    "quantity": 10,
+    "lovePoints": 30
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_ultimate_1.json
+++ b/Core/resources/cooking/recipes/petfood_ultimate_1.json
@@ -14,8 +14,10 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "ultimateFood",
-  "petFoodQuantity": 1,
-  "petFoodLovePoints": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": {
+    "type": "ultimateFood",
+    "quantity": 1,
+    "lovePoints": 3
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_ultimate_2.json
+++ b/Core/resources/cooking/recipes/petfood_ultimate_2.json
@@ -14,9 +14,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "ultimateFood",
-  "petFoodQuantity": 1,
-  "petFoodLovePoints": 5,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": {
+    "type": "ultimateFood",
+    "quantity": 1,
+    "lovePoints": 5
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_ultimate_3.json
+++ b/Core/resources/cooking/recipes/petfood_ultimate_3.json
@@ -22,9 +22,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "ultimateFood",
-  "petFoodQuantity": 3,
-  "petFoodLovePoints": 15,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": {
+    "type": "ultimateFood",
+    "quantity": 3,
+    "lovePoints": 15
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_ultimate_4.json
+++ b/Core/resources/cooking/recipes/petfood_ultimate_4.json
@@ -26,9 +26,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "ultimateFood",
-  "petFoodQuantity": 5,
-  "petFoodLovePoints": 25,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": {
+    "type": "ultimateFood",
+    "quantity": 5,
+    "lovePoints": 25
+  }
 }

--- a/Core/resources/cooking/recipes/petfood_ultimate_5.json
+++ b/Core/resources/cooking/recipes/petfood_ultimate_5.json
@@ -38,9 +38,11 @@
     }
   ],
   "outputType": "petFood",
-  "petFoodType": "ultimateFood",
-  "petFoodQuantity": 8,
-  "petFoodLovePoints": 40,
   "discoveredByDefault": false,
-  "discoverySource": "GASPARD_JO"
+  "discoverySource": "GASPARD_JO",
+  "petFood": {
+    "type": "ultimateFood",
+    "quantity": 8,
+    "lovePoints": 40
+  }
 }

--- a/Core/resources/cooking/recipes/potion_attack_1.json
+++ b/Core/resources/cooking/recipes/potion_attack_1.json
@@ -16,5 +16,6 @@
   "outputType": "potion",
   "potionNature": 3,
   "potionRarity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_2.json
+++ b/Core/resources/cooking/recipes/potion_attack_2.json
@@ -20,5 +20,6 @@
   "outputType": "potion",
   "potionNature": 3,
   "potionRarity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_3.json
+++ b/Core/resources/cooking/recipes/potion_attack_3.json
@@ -21,5 +21,6 @@
   "potionNature": 3,
   "potionRarity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_4.json
+++ b/Core/resources/cooking/recipes/potion_attack_4.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 3,
   "potionRarity": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_5.json
+++ b/Core/resources/cooking/recipes/potion_attack_5.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 3,
   "potionRarity": 4,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_6.json
+++ b/Core/resources/cooking/recipes/potion_attack_6.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 3,
   "potionRarity": 5,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_7.json
+++ b/Core/resources/cooking/recipes/potion_attack_7.json
@@ -25,5 +25,6 @@
   "potionNature": 3,
   "potionRarity": 6,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_attack_8.json
+++ b/Core/resources/cooking/recipes/potion_attack_8.json
@@ -29,5 +29,6 @@
   "potionNature": 3,
   "potionRarity": 7,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_1.json
+++ b/Core/resources/cooking/recipes/potion_defense_1.json
@@ -17,5 +17,6 @@
   "potionNature": 4,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_2.json
+++ b/Core/resources/cooking/recipes/potion_defense_2.json
@@ -21,5 +21,6 @@
   "potionNature": 4,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_3.json
+++ b/Core/resources/cooking/recipes/potion_defense_3.json
@@ -20,5 +20,6 @@
   "outputType": "potion",
   "potionNature": 4,
   "potionRarity": 2,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_4.json
+++ b/Core/resources/cooking/recipes/potion_defense_4.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 4,
   "potionRarity": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_5.json
+++ b/Core/resources/cooking/recipes/potion_defense_5.json
@@ -25,5 +25,6 @@
   "potionNature": 4,
   "potionRarity": 4,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_6.json
+++ b/Core/resources/cooking/recipes/potion_defense_6.json
@@ -25,5 +25,6 @@
   "potionNature": 4,
   "potionRarity": 5,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_7.json
+++ b/Core/resources/cooking/recipes/potion_defense_7.json
@@ -29,5 +29,6 @@
   "potionNature": 4,
   "potionRarity": 6,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_defense_8.json
+++ b/Core/resources/cooking/recipes/potion_defense_8.json
@@ -33,5 +33,6 @@
   "potionNature": 4,
   "potionRarity": 7,
   "discoveredByDefault": false,
-  "discoverySource": "CAMPAIGN_MILESTONE"
+  "discoverySource": "CAMPAIGN_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_1.json
+++ b/Core/resources/cooking/recipes/potion_energy_1.json
@@ -16,5 +16,6 @@
   "outputType": "potion",
   "potionNature": 7,
   "potionRarity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_2.json
+++ b/Core/resources/cooking/recipes/potion_energy_2.json
@@ -21,5 +21,6 @@
   "potionNature": 7,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_3.json
+++ b/Core/resources/cooking/recipes/potion_energy_3.json
@@ -21,5 +21,6 @@
   "potionNature": 7,
   "potionRarity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_4.json
+++ b/Core/resources/cooking/recipes/potion_energy_4.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 7,
   "potionRarity": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_5.json
+++ b/Core/resources/cooking/recipes/potion_energy_5.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 7,
   "potionRarity": 4,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_6.json
+++ b/Core/resources/cooking/recipes/potion_energy_6.json
@@ -29,5 +29,6 @@
   "potionNature": 7,
   "potionRarity": 5,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_7.json
+++ b/Core/resources/cooking/recipes/potion_energy_7.json
@@ -25,5 +25,6 @@
   "potionNature": 7,
   "potionRarity": 6,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_energy_8.json
+++ b/Core/resources/cooking/recipes/potion_energy_8.json
@@ -29,5 +29,6 @@
   "potionNature": 7,
   "potionRarity": 7,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_1.json
+++ b/Core/resources/cooking/recipes/potion_health_1.json
@@ -16,5 +16,6 @@
   "outputType": "potion",
   "potionNature": 1,
   "potionRarity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_2.json
+++ b/Core/resources/cooking/recipes/potion_health_2.json
@@ -21,5 +21,6 @@
   "potionNature": 1,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_3.json
+++ b/Core/resources/cooking/recipes/potion_health_3.json
@@ -20,5 +20,6 @@
   "outputType": "potion",
   "potionNature": 1,
   "potionRarity": 2,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_4.json
+++ b/Core/resources/cooking/recipes/potion_health_4.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 1,
   "potionRarity": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_5.json
+++ b/Core/resources/cooking/recipes/potion_health_5.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 1,
   "potionRarity": 4,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_6.json
+++ b/Core/resources/cooking/recipes/potion_health_6.json
@@ -28,5 +28,6 @@
   "outputType": "potion",
   "potionNature": 1,
   "potionRarity": 5,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_7.json
+++ b/Core/resources/cooking/recipes/potion_health_7.json
@@ -25,5 +25,6 @@
   "potionNature": 1,
   "potionRarity": 6,
   "discoveredByDefault": false,
-  "discoverySource": "ISLAND_BOSS"
+  "discoverySource": "ISLAND_BOSS",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_health_8.json
+++ b/Core/resources/cooking/recipes/potion_health_8.json
@@ -28,5 +28,6 @@
   "outputType": "potion",
   "potionNature": 1,
   "potionRarity": 7,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_1.json
+++ b/Core/resources/cooking/recipes/potion_speed_1.json
@@ -17,5 +17,6 @@
   "potionNature": 2,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_2.json
+++ b/Core/resources/cooking/recipes/potion_speed_2.json
@@ -21,5 +21,6 @@
   "potionNature": 2,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_3.json
+++ b/Core/resources/cooking/recipes/potion_speed_3.json
@@ -20,5 +20,6 @@
   "outputType": "potion",
   "potionNature": 2,
   "potionRarity": 2,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_4.json
+++ b/Core/resources/cooking/recipes/potion_speed_4.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 2,
   "potionRarity": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_5.json
+++ b/Core/resources/cooking/recipes/potion_speed_5.json
@@ -25,5 +25,6 @@
   "potionNature": 2,
   "potionRarity": 4,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_6.json
+++ b/Core/resources/cooking/recipes/potion_speed_6.json
@@ -25,5 +25,6 @@
   "potionNature": 2,
   "potionRarity": 5,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_7.json
+++ b/Core/resources/cooking/recipes/potion_speed_7.json
@@ -29,5 +29,6 @@
   "potionNature": 2,
   "potionRarity": 6,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_speed_8.json
+++ b/Core/resources/cooking/recipes/potion_speed_8.json
@@ -33,5 +33,6 @@
   "potionNature": 2,
   "potionRarity": 7,
   "discoveredByDefault": false,
-  "discoverySource": "PLAYER_LEVEL_MILESTONE"
+  "discoverySource": "PLAYER_LEVEL_MILESTONE",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_1.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_1.json
@@ -17,5 +17,6 @@
   "potionNature": 5,
   "potionRarity": 1,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_2.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_2.json
@@ -20,5 +20,6 @@
   "outputType": "potion",
   "potionNature": 5,
   "potionRarity": 1,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_3.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_3.json
@@ -21,5 +21,6 @@
   "potionNature": 5,
   "potionRarity": 2,
   "discoveredByDefault": false,
-  "discoverySource": "WITCH"
+  "discoverySource": "WITCH",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_4.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_4.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 5,
   "potionRarity": 3,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_5.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_5.json
@@ -24,5 +24,6 @@
   "outputType": "potion",
   "potionNature": 5,
   "potionRarity": 4,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_6.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_6.json
@@ -25,5 +25,6 @@
   "potionNature": 5,
   "potionRarity": 5,
   "discoveredByDefault": false,
-  "discoverySource": "ISLAND_BOSS"
+  "discoverySource": "ISLAND_BOSS",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_7.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_7.json
@@ -29,5 +29,6 @@
   "potionNature": 5,
   "potionRarity": 6,
   "discoveredByDefault": false,
-  "discoverySource": "ISLAND_BOSS"
+  "discoverySource": "ISLAND_BOSS",
+  "petFood": null
 }

--- a/Core/resources/cooking/recipes/potion_time_speedup_8.json
+++ b/Core/resources/cooking/recipes/potion_time_speedup_8.json
@@ -32,5 +32,6 @@
   "outputType": "potion",
   "potionNature": 5,
   "potionRarity": 7,
-  "discoveredByDefault": true
+  "discoveredByDefault": true,
+  "petFood": null
 }

--- a/Core/src/commands/admin/testCommands/Home/GiveMaterialTestCommand.ts
+++ b/Core/src/commands/admin/testCommands/Home/GiveMaterialTestCommand.ts
@@ -1,0 +1,25 @@
+import {
+	ExecuteTestCommandLike, ITestCommand, TypeKey
+} from "../../../../core/CommandsTest";
+import { Materials } from "../../../../core/database/game/models/Material";
+
+export const commandInfo: ITestCommand = {
+	name: "givematerial",
+	commandFormat: "<materialId> <quantity>",
+	typeWaited: {
+		materialId: TypeKey.INTEGER,
+		quantity: TypeKey.INTEGER
+	},
+	description: "Donne un matériau au joueur. Ex: bois commun=51,58,64 | bois peu commun=2,9,88 | bois rare=18,31,84"
+};
+
+const giveMaterialTestCommand: ExecuteTestCommandLike = async (player, args) => {
+	const materialId = parseInt(args[0], 10);
+	const quantity = parseInt(args[1], 10);
+
+	await Materials.giveMaterial(player.id, materialId, quantity);
+
+	return `Vous avez reçu ${quantity}x matériau #${materialId} !`;
+};
+
+commandInfo.execute = giveMaterialTestCommand;

--- a/Core/src/commands/admin/testCommands/Home/ResetFurnaceTestCommand.ts
+++ b/Core/src/commands/admin/testCommands/Home/ResetFurnaceTestCommand.ts
@@ -1,0 +1,20 @@
+import {
+	ExecuteTestCommandLike, ITestCommand
+} from "../../../../core/CommandsTest";
+
+export const commandInfo: ITestCommand = {
+	name: "resetfurnace",
+	commandFormat: "",
+	typeWaited: {},
+	description: "Réinitialise la surchauffe et les utilisations du fourneau"
+};
+
+const resetFurnaceTestCommand: ExecuteTestCommandLike = async player => {
+	player.furnaceUsesToday = 0;
+	player.furnaceOverheatUntil = null;
+	await player.save();
+
+	return "Fourneau réinitialisé ! Surchauffe levée et utilisations remises à 0.";
+};
+
+commandInfo.execute = resetFurnaceTestCommand;

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -223,7 +223,7 @@ export default class ProfileCommand {
 				tokens: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? toCheckPlayer.tokens : undefined,
 				tokensMax: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? TokensConstants.MAX : undefined,
 				cookingLevel: home?.getLevel()?.features.cookingSlots ? toCheckPlayer.cookingLevel : undefined,
-				cookingGrade: home?.getLevel()?.features.cookingSlots ? getCookingGrade(toCheckPlayer.cookingLevel).name : undefined
+				cookingGrade: home?.getLevel()?.features.cookingSlots ? getCookingGrade(toCheckPlayer.cookingLevel).id : undefined
 			}
 		}));
 	}

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -19,7 +19,9 @@ import { Campaign } from "../../core/missions/Campaign";
 import {
 	Player, Players
 } from "../../core/database/game/models/Player";
-import { Guilds } from "../../core/database/game/models/Guild";
+import {
+	Guild, Guilds
+} from "../../core/database/game/models/Guild";
 import {
 	Pet, PetDataController
 } from "../../data/Pet";
@@ -33,7 +35,7 @@ import { Effect } from "../../../../Lib/src/types/Effect";
 import { TokensConstants } from "../../../../Lib/src/constants/TokensConstants";
 import { PlayerBadgesManager } from "../../core/database/game/models/PlayerBadges";
 import { getCookingGrade } from "../../../../Lib/src/constants/CookingConstants";
-import { Homes } from "../../core/database/game/models/Home";
+import Home, { Homes } from "../../core/database/game/models/Home";
 
 /**
  * Get the current campaign progression of the player
@@ -45,15 +47,17 @@ function getCampaignProgression(missionsInfo: PlayerMissionsInfo): number {
 	return Math.round(Campaign.getAmountOfCampaignCompleted(missionsInfo.campaignBlob) / Campaign.getMaxCampaignNumber() * 100);
 }
 
-/**
- * Build pet data for profile
- */
-function buildPetData(petEntity: PetEntity, petModel: Pet): {
+interface ProfilePetData {
 	typeId: number;
 	sex: SexTypeShort;
 	nickname: string;
 	rarity: number;
-} {
+}
+
+/**
+ * Build pet data for profile
+ */
+function buildPetData(petEntity: PetEntity, petModel: Pet): ProfilePetData {
 	return {
 		typeId: petModel.id,
 		sex: petEntity.sex as SexTypeShort,
@@ -65,7 +69,7 @@ function buildPetData(petEntity: PetEntity, petModel: Pet): {
 /**
  * Resolve pet data from a pet entity, handling null cases
  */
-function resolvePetData(petEntity: PetEntity | null): ReturnType<typeof buildPetData> | undefined {
+function resolvePetData(petEntity: PetEntity | null): ProfilePetData | undefined {
 	if (!petEntity) {
 		return undefined;
 	}
@@ -79,11 +83,11 @@ function resolvePetData(petEntity: PetEntity | null): ReturnType<typeof buildPet
 /**
  * Resolve glory rank for a player
  */
-function resolveGloryRank(player: Player): Promise<number> | number {
+async function resolveGloryRank(player: Player): Promise<number> {
 	if (player.fightCountdown > FightConstants.FIGHT_COUNTDOWN_MAXIMAL_VALUE) {
 		return -1;
 	}
-	return Players.getGloryRankById(player.id);
+	return await Players.getGloryRankById(player.id);
 }
 
 /**
@@ -184,47 +188,51 @@ function buildRankData(rank: number, numberOfPlayers: number, score: number): {
 	};
 }
 
+interface ProfileCookingData {
+	level: number;
+	grade: string;
+}
+
 /**
  * Build cooking data for profile (only if home has cooking slots)
  */
-function buildCookingData(player: Player, home: Awaited<ReturnType<typeof Homes.getOfPlayer>>): {
-	cookingLevel: number;
-	cookingGrade: string;
-} | undefined {
+function buildCookingData(player: Player, home: Home | null): ProfileCookingData | undefined {
 	const hasCooking = home?.getLevel()?.features.cookingSlots;
 	if (!hasCooking) {
 		return undefined;
 	}
 	return {
-		cookingLevel: player.cookingLevel,
-		cookingGrade: getCookingGrade(player.cookingLevel).id
+		level: player.cookingLevel,
+		grade: getCookingGrade(player.cookingLevel).id
 	};
+}
+
+interface ProfileTokenData {
+	value: number;
+	max: number;
 }
 
 /**
  * Build token data for profile (only if player level is high enough)
  */
-function buildTokenData(player: Player): {
-	tokens: number;
-	tokensMax: number;
-} | undefined {
+function buildTokenData(player: Player): ProfileTokenData | undefined {
 	if (player.level < TokensConstants.LEVEL_TO_UNLOCK) {
 		return undefined;
 	}
 	return {
-		tokens: player.tokens,
-		tokensMax: TokensConstants.MAX
+		value: player.tokens,
+		max: TokensConstants.MAX
 	};
 }
 
 interface ProfileFetchedData {
-	guild: Awaited<ReturnType<typeof Guilds.getById>> | null;
+	guild: Guild | null;
 	rank: number;
 	numberOfPlayers: number;
 	petEntity: PetEntity | null;
 	missionsInfo: PlayerMissionsInfo;
 	playerActiveObjects: PlayerActiveObjects;
-	home: Awaited<ReturnType<typeof Homes.getOfPlayer>>;
+	home: Home | null;
 	gloryRank: number;
 }
 
@@ -269,10 +277,8 @@ async function buildProfilePacket(
 				max: toCheckPlayer.getMaxHealthBase()
 			},
 			money: toCheckPlayer.money,
-			tokens: tokenData?.tokens,
-			tokensMax: tokenData?.tokensMax,
-			cookingLevel: cookingData?.cookingLevel,
-			cookingGrade: cookingData?.cookingGrade
+			tokens: tokenData,
+			cooking: cookingData
 		}
 	});
 }

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -63,6 +63,40 @@ function buildPetData(petEntity: PetEntity, petModel: Pet): {
 }
 
 /**
+ * Resolve pet data from a pet entity, handling null cases
+ */
+function resolvePetData(petEntity: PetEntity | null): ReturnType<typeof buildPetData> | undefined {
+	if (!petEntity) {
+		return undefined;
+	}
+	const petModel = PetDataController.instance.getById(petEntity.typeId);
+	if (!petModel) {
+		return undefined;
+	}
+	return buildPetData(petEntity, petModel);
+}
+
+/**
+ * Resolve glory rank for a player
+ */
+function resolveGloryRank(player: Player): Promise<number> | number {
+	if (player.fightCountdown > FightConstants.FIGHT_COUNTDOWN_MAXIMAL_VALUE) {
+		return -1;
+	}
+	return Players.getGloryRankById(player.id);
+}
+
+/**
+ * Resolve map type ID from a destination
+ */
+function resolveMapTypeId(destinationId: number | null): number | undefined {
+	if (!destinationId) {
+		return undefined;
+	}
+	return MapLocationDataController.instance.getById(destinationId)?.type;
+}
+
+/**
  * Build effect data for profile
  */
 function buildEffectData(player: Player): {
@@ -183,6 +217,66 @@ function buildTokenData(player: Player): {
 	};
 }
 
+interface ProfileFetchedData {
+	guild: Awaited<ReturnType<typeof Guilds.getById>> | null;
+	rank: number;
+	numberOfPlayers: number;
+	petEntity: PetEntity | null;
+	missionsInfo: PlayerMissionsInfo;
+	playerActiveObjects: PlayerActiveObjects;
+	home: Awaited<ReturnType<typeof Homes.getOfPlayer>>;
+	gloryRank: number;
+}
+
+/**
+ * Build the full profile response packet from fetched data
+ */
+async function buildProfilePacket(
+	toCheckPlayer: Player,
+	data: ProfileFetchedData
+): Promise<CommandProfilePacketRes> {
+	const petData = resolvePetData(data.petEntity);
+	const destinationId = toCheckPlayer.getDestinationId();
+	const badges = await PlayerBadgesManager.getOfPlayer(toCheckPlayer.id);
+	const cookingData = buildCookingData(toCheckPlayer, data.home);
+	const tokenData = buildTokenData(toCheckPlayer);
+
+	return makePacket(CommandProfilePacketRes, {
+		keycloakId: toCheckPlayer.keycloakId,
+		playerData: {
+			badges,
+			guild: data.guild?.name ?? undefined,
+			level: toCheckPlayer.level,
+			rank: buildRankData(data.rank, data.numberOfPlayers, toCheckPlayer.score),
+			classId: toCheckPlayer.class,
+			color: toCheckPlayer.getProfileColor() ?? undefined,
+			pet: petData,
+			destinationId: destinationId ?? undefined,
+			mapTypeId: resolveMapTypeId(destinationId),
+			effect: buildEffectData(toCheckPlayer),
+			fightRanking: await buildFightRankingData(toCheckPlayer, data.gloryRank) ?? undefined,
+			missions: {
+				gems: data.missionsInfo.gems,
+				campaignProgression: getCampaignProgression(data.missionsInfo)
+			},
+			stats: buildStatsData(toCheckPlayer, data.playerActiveObjects) ?? undefined,
+			experience: {
+				value: toCheckPlayer.experience,
+				max: toCheckPlayer.getExperienceNeededToLevelUp()
+			},
+			health: {
+				value: toCheckPlayer.getHealthValue(),
+				max: toCheckPlayer.getMaxHealthBase()
+			},
+			money: toCheckPlayer.money,
+			tokens: tokenData?.tokens,
+			tokensMax: tokenData?.tokensMax,
+			cookingLevel: cookingData?.cookingLevel,
+			cookingGrade: cookingData?.cookingGrade
+		}
+	});
+}
+
 export default class ProfileCommand {
 	@commandRequires(CommandProfilePacketReq, {
 		notBlocked: false,
@@ -216,50 +310,10 @@ export default class ProfileCommand {
 			Homes.getOfPlayer(toCheckPlayer.id)
 		]);
 
-		const gloryRank = toCheckPlayer.fightCountdown > FightConstants.FIGHT_COUNTDOWN_MAXIMAL_VALUE
-			? -1
-			: await Players.getGloryRankById(toCheckPlayer.id);
+		const gloryRank = await resolveGloryRank(toCheckPlayer);
 
-		const petModel = petEntity ? PetDataController.instance.getById(petEntity.typeId) : null;
-		const petData = petEntity && petModel ? buildPetData(petEntity, petModel) : undefined;
-		const destinationId = toCheckPlayer.getDestinationId();
-		const badges = await PlayerBadgesManager.getOfPlayer(toCheckPlayer.id);
-		const cookingData = buildCookingData(toCheckPlayer, home);
-		const tokenData = buildTokenData(toCheckPlayer);
-
-		response.push(makePacket(CommandProfilePacketRes, {
-			keycloakId: toCheckPlayer.keycloakId,
-			playerData: {
-				badges,
-				guild: guild?.name ?? undefined,
-				level: toCheckPlayer.level,
-				rank: buildRankData(rank, numberOfPlayers, toCheckPlayer.score),
-				classId: toCheckPlayer.class,
-				color: toCheckPlayer.getProfileColor() ?? undefined,
-				pet: petData,
-				destinationId: destinationId ?? undefined,
-				mapTypeId: destinationId ? MapLocationDataController.instance.getById(destinationId)?.type : undefined,
-				effect: buildEffectData(toCheckPlayer),
-				fightRanking: await buildFightRankingData(toCheckPlayer, gloryRank) ?? undefined,
-				missions: {
-					gems: missionsInfo.gems,
-					campaignProgression: getCampaignProgression(missionsInfo)
-				},
-				stats: buildStatsData(toCheckPlayer, playerActiveObjects) ?? undefined,
-				experience: {
-					value: toCheckPlayer.experience,
-					max: toCheckPlayer.getExperienceNeededToLevelUp()
-				},
-				health: {
-					value: toCheckPlayer.getHealthValue(),
-					max: toCheckPlayer.getMaxHealthBase()
-				},
-				money: toCheckPlayer.money,
-				tokens: tokenData?.tokens,
-				tokensMax: tokenData?.tokensMax,
-				cookingLevel: cookingData?.cookingLevel,
-				cookingGrade: cookingData?.cookingGrade
-			}
+		response.push(await buildProfilePacket(toCheckPlayer, {
+			guild, rank, numberOfPlayers, petEntity, missionsInfo, playerActiveObjects, home, gloryRank
 		}));
 	}
 }

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -150,6 +150,39 @@ function buildRankData(rank: number, numberOfPlayers: number, score: number): {
 	};
 }
 
+/**
+ * Build cooking data for profile (only if home has cooking slots)
+ */
+function buildCookingData(player: Player, home: Awaited<ReturnType<typeof Homes.getOfPlayer>>): {
+	cookingLevel: number;
+	cookingGrade: string;
+} | undefined {
+	const hasCooking = home?.getLevel()?.features.cookingSlots;
+	if (!hasCooking) {
+		return undefined;
+	}
+	return {
+		cookingLevel: player.cookingLevel,
+		cookingGrade: getCookingGrade(player.cookingLevel).id
+	};
+}
+
+/**
+ * Build token data for profile (only if player level is high enough)
+ */
+function buildTokenData(player: Player): {
+	tokens: number;
+	tokensMax: number;
+} | undefined {
+	if (player.level < TokensConstants.LEVEL_TO_UNLOCK) {
+		return undefined;
+	}
+	return {
+		tokens: player.tokens,
+		tokensMax: TokensConstants.MAX
+	};
+}
+
 export default class ProfileCommand {
 	@commandRequires(CommandProfilePacketReq, {
 		notBlocked: false,
@@ -191,6 +224,8 @@ export default class ProfileCommand {
 		const petData = petEntity && petModel ? buildPetData(petEntity, petModel) : undefined;
 		const destinationId = toCheckPlayer.getDestinationId();
 		const badges = await PlayerBadgesManager.getOfPlayer(toCheckPlayer.id);
+		const cookingData = buildCookingData(toCheckPlayer, home);
+		const tokenData = buildTokenData(toCheckPlayer);
 
 		response.push(makePacket(CommandProfilePacketRes, {
 			keycloakId: toCheckPlayer.keycloakId,
@@ -220,10 +255,10 @@ export default class ProfileCommand {
 					max: toCheckPlayer.getMaxHealthBase()
 				},
 				money: toCheckPlayer.money,
-				tokens: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? toCheckPlayer.tokens : undefined,
-				tokensMax: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? TokensConstants.MAX : undefined,
-				cookingLevel: home?.getLevel()?.features.cookingSlots ? toCheckPlayer.cookingLevel : undefined,
-				cookingGrade: home?.getLevel()?.features.cookingSlots ? getCookingGrade(toCheckPlayer.cookingLevel).id : undefined
+				tokens: tokenData?.tokens,
+				tokensMax: tokenData?.tokensMax,
+				cookingLevel: cookingData?.cookingLevel,
+				cookingGrade: cookingData?.cookingGrade
 			}
 		}));
 	}

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -237,6 +237,13 @@ interface ProfileFetchedData {
 }
 
 /**
+ * Build guild data for profile (guild name)
+ */
+function buildGuildData(guild: Guild | null): string | undefined {
+	return guild?.name ?? undefined;
+}
+
+/**
  * Build the full profile response packet from fetched data
  */
 async function buildProfilePacket(
@@ -253,7 +260,7 @@ async function buildProfilePacket(
 		keycloakId: toCheckPlayer.keycloakId,
 		playerData: {
 			badges,
-			guild: data.guild?.name ?? undefined,
+			guild: buildGuildData(data.guild),
 			level: toCheckPlayer.level,
 			rank: buildRankData(data.rank, data.numberOfPlayers, toCheckPlayer.score),
 			classId: toCheckPlayer.class,

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -32,6 +32,8 @@ import { ClassConstants } from "../../../../Lib/src/constants/ClassConstants";
 import { Effect } from "../../../../Lib/src/types/Effect";
 import { TokensConstants } from "../../../../Lib/src/constants/TokensConstants";
 import { PlayerBadgesManager } from "../../core/database/game/models/PlayerBadges";
+import { getCookingGrade } from "../../../../Lib/src/constants/CookingConstants";
+import { Homes } from "../../core/database/game/models/Home";
 
 /**
  * Get the current campaign progression of the player
@@ -169,14 +171,16 @@ export default class ProfileCommand {
 			numberOfPlayers,
 			petEntity,
 			missionsInfo,
-			playerActiveObjects
+			playerActiveObjects,
+			home
 		] = await Promise.all([
 			toCheckPlayer.guildId ? Guilds.getById(toCheckPlayer.guildId) : null,
 			Players.getRankById(toCheckPlayer.id),
 			Players.getNbPlayersHaveStartedTheAdventure(),
 			toCheckPlayer.petId ? PetEntities.getById(toCheckPlayer.petId) : null,
 			PlayerMissionsInfos.getOfPlayer(toCheckPlayer.id),
-			InventorySlots.getPlayerActiveObjects(toCheckPlayer.id)
+			InventorySlots.getPlayerActiveObjects(toCheckPlayer.id),
+			Homes.getOfPlayer(toCheckPlayer.id)
 		]);
 
 		const gloryRank = toCheckPlayer.fightCountdown > FightConstants.FIGHT_COUNTDOWN_MAXIMAL_VALUE
@@ -217,7 +221,9 @@ export default class ProfileCommand {
 				},
 				money: toCheckPlayer.money,
 				tokens: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? toCheckPlayer.tokens : undefined,
-				tokensMax: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? TokensConstants.MAX : undefined
+				tokensMax: toCheckPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK ? TokensConstants.MAX : undefined,
+				cookingLevel: home?.getLevel()?.features.cookingSlots ? toCheckPlayer.cookingLevel : undefined,
+				cookingGrade: home?.getLevel()?.features.cookingSlots ? getCookingGrade(toCheckPlayer.cookingLevel).name : undefined
 			}
 		}));
 	}

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -36,7 +36,9 @@ import {
 	getUniqueRecipesForSlots,
 	isRecipeSecret
 } from "./CookingSlotRotation";
-import { CookingSlotData } from "../../../../Lib/src/packets/commands/CommandReportPacket";
+import {
+	CookingSlotData, RecipeSlotData
+} from "../../../../Lib/src/types/CookingTypes";
 import { RecipeDiscoveryService } from "./RecipeDiscoveryService";
 import {
 	getTomorrowMidnight, getDayNumber
@@ -241,7 +243,7 @@ export class CookingService {
 		slotIndex: number,
 		recipe: CookingRecipe,
 		context: RecipeSlotContext
-	): NonNullable<CookingSlotData["recipe"]> {
+	): RecipeSlotData {
 		const secret = isRecipeSecret({
 			slotIndex,
 			furnacePosition: context.furnacePosition,

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -336,11 +336,17 @@ export class CookingService {
 	/**
 	 * Add cooking XP to player, handle level up
 	 */
-	static async addCookingXp(player: Player, xp: number): Promise<{
+	static async addCookingXp(params: {
+		player: Player;
+		xp: number;
+	}): Promise<{
 		levelUp: boolean;
 		newLevel?: number;
 		newGrade?: string;
 	}> {
+		const {
+			player, xp
+		} = params;
 		player.cookingExperience += xp;
 
 		let levelUp = false;
@@ -394,8 +400,12 @@ export class CookingService {
 
 		// Calculate result and XP
 		const success = !RandomUtils.crowniclesRandom.bool(Math.min(CookingService.getFailureRate(grade, recipe.level), 1));
-		const xp = CookingService.computeCraftXp(success, recipe, grade);
-		const levelResult = await CookingService.addCookingXp(player, xp);
+		const xp = CookingService.computeCraftXp({
+			success, recipe, grade
+		});
+		const levelResult = await CookingService.addCookingXp({
+			player, xp
+		});
 
 		// Discover cooking-level recipes on level up
 		const discoveredRecipeIds = levelResult.levelUp
@@ -423,8 +433,9 @@ export class CookingService {
 		} = params;
 		let materialSaved: number | undefined;
 		const materialsToConsume = [...materials];
+		const shouldSaveMaterial = materialSaveChance > 0 && materialsToConsume.length > 0 && RandomUtils.crowniclesRandom.bool(materialSaveChance);
 
-		if (materialSaveChance > 0 && materialsToConsume.length > 0 && RandomUtils.crowniclesRandom.bool(materialSaveChance)) {
+		if (shouldSaveMaterial) {
 			const savedIndex = RandomUtils.crowniclesRandom.integer(0, materialsToConsume.length - 1);
 			materialSaved = materialsToConsume[savedIndex].materialId;
 			materialsToConsume.splice(savedIndex, 1);
@@ -437,7 +448,14 @@ export class CookingService {
 		return materialSaved;
 	}
 
-	private static computeCraftXp(success: boolean, recipe: CookingRecipe, grade: CookingGradeDefinition): number {
+	private static computeCraftXp(params: {
+		success: boolean;
+		recipe: CookingRecipe;
+		grade: CookingGradeDefinition;
+	}): number {
+		const {
+			success, recipe, grade
+		} = params;
 		const levelDiff = recipe.level - grade.maxRecipeLevelWithoutPenalty;
 		if (levelDiff >= NO_XP_LEVEL_THRESHOLD) {
 			return 0;

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -27,7 +27,6 @@ import {
 	NO_XP_LEVEL_THRESHOLD,
 	FURNACE_MAX_USES_PER_DAY,
 	FURNACE_MIN_OVERHEAT_HOURS,
-	SLOT_CONFIGS,
 	CookingOutputType
 } from "../../../../Lib/src/constants/CookingConstants";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
@@ -54,6 +53,15 @@ interface CraftResult {
 	newLevel: number | undefined;
 	newGrade: string | undefined;
 	discoveredRecipeIds: string[];
+}
+
+interface RecipeSlotContext {
+	furnacePosition: number;
+	daySeed: number;
+	grade: CookingGradeDefinition;
+	plantStorageMap: Map<number, number>;
+	materialMap: Map<number, number>;
+	guild: Guild | null;
 }
 
 export class CookingService {
@@ -189,11 +197,14 @@ export class CookingService {
 	/**
 	 * Get all slot recipes for the current furnace state
 	 */
-	static async getSlotRecipes(
-		player: Player,
-		homeId: number,
-		cookingSlots: number
-	): Promise<CookingSlotData[]> {
+	static async getSlotRecipes(params: {
+		player: Player;
+		homeId: number;
+		cookingSlots: number;
+	}): Promise<CookingSlotData[]> {
+		const {
+			player, homeId, cookingSlots
+		} = params;
 		const discoveredIds = await PlayerCookingRecipe.getDiscoveredRecipeIds(player);
 		const daySeed = getCurrentDaySeed();
 		const grade = getCookingGrade(player.cookingLevel);
@@ -209,69 +220,69 @@ export class CookingService {
 			maxRecipeLevelWithoutPenalty: grade.maxRecipeLevelWithoutPenalty
 		});
 
-		const slots: CookingSlotData[] = [];
-
 		// Load all plant storages once to avoid N+1 queries
 		const allPlantStorages = await HomePlantStorages.getOfHome(homeId);
 		const plantStorageMap = new Map(allPlantStorages.map(s => [s.plantId, s.quantity]));
 
-		for (let i = 0; i < cookingSlots && i < SLOT_CONFIGS.length; i++) {
-			const recipe = slotRecipes[i];
-			if (!recipe) {
-				slots.push({
-					slotIndex: i,
-					recipe: null
-				});
-				continue;
-			}
+		const context: RecipeSlotContext = {
+			furnacePosition: player.furnacePosition,
+			daySeed,
+			grade,
+			plantStorageMap,
+			materialMap,
+			guild
+		};
 
-			const secret = isRecipeSecret({
-				slotIndex: i,
-				furnacePosition: player.furnacePosition,
-				daySeed,
-				secretRate: grade.secretRecipeRate
-			});
+		return slotRecipes.map((recipe, i) => ({
+			slotIndex: i,
+			recipe: recipe ? CookingService.buildRecipeSlotData(i, recipe, context) : null
+		}));
+	}
 
-			// Check ingredient availability
-			const plantAvailability = recipe.plants.map(p => ({
-				plantId: p.plantId,
-				quantity: p.quantity,
-				playerHas: plantStorageMap.get(p.plantId) ?? 0
-			}));
+	private static buildRecipeSlotData(
+		slotIndex: number,
+		recipe: CookingRecipe,
+		context: RecipeSlotContext
+	): NonNullable<CookingSlotData["recipe"]> {
+		const secret = isRecipeSecret({
+			slotIndex,
+			furnacePosition: context.furnacePosition,
+			daySeed: context.daySeed,
+			secretRate: context.grade.secretRecipeRate
+		});
 
-			const materialAvailability = recipe.materials.map(m => ({
-				materialId: m.materialId,
-				quantity: m.quantity,
-				playerHas: materialMap.get(m.materialId) ?? 0
-			}));
+		const plantAvailability = recipe.plants.map(p => ({
+			plantId: p.plantId,
+			quantity: p.quantity,
+			playerHas: context.plantStorageMap.get(p.plantId) ?? 0
+		}));
 
-			const hasIngredients = plantAvailability.every(p => p.playerHas >= p.quantity)
-				&& materialAvailability.every(m => m.playerHas >= m.quantity);
-			const canCraftOutput = recipe.outputType === CookingOutputType.PET_FOOD
-				? Boolean(guild)
-				: true;
-			const canCraft = hasIngredients && canCraftOutput;
+		const materialAvailability = recipe.materials.map(m => ({
+			materialId: m.materialId,
+			quantity: m.quantity,
+			playerHas: context.materialMap.get(m.materialId) ?? 0
+		}));
 
-			slots.push({
-				slotIndex: i,
-				recipe: {
-					id: recipe.id,
-					level: recipe.level,
-					isSecret: secret,
-					outputDescription: secret ? "???" : recipe.id,
-					outputType: recipe.outputType,
-					recipeType: recipe.recipeType,
-					petFoodType: recipe.petFoodType,
-					ingredients: {
-						plants: plantAvailability,
-						materials: materialAvailability
-					},
-					canCraft
-				}
-			});
-		}
+		const hasIngredients = plantAvailability.every(p => p.playerHas >= p.quantity)
+			&& materialAvailability.every(m => m.playerHas >= m.quantity);
+		const canCraftOutput = recipe.outputType === CookingOutputType.PET_FOOD
+			? Boolean(context.guild)
+			: true;
 
-		return slots;
+		return {
+			id: recipe.id,
+			level: recipe.level,
+			isSecret: secret,
+			outputDescription: secret ? "???" : recipe.id,
+			outputType: recipe.outputType,
+			recipeType: recipe.recipeType,
+			petFoodType: recipe.petFoodType,
+			ingredients: {
+				plants: plantAvailability,
+				materials: materialAvailability
+			},
+			canCraft: hasIngredients && canCraftOutput
+		};
 	}
 
 	/**
@@ -355,11 +366,14 @@ export class CookingService {
 	/**
 	 * Execute a craft: consume ingredients, calculate result, give XP
 	 */
-	static async executeCraft(
-		player: Player,
-		recipe: CookingRecipe,
-		homeId: number
-	): Promise<CraftResult> {
+	static async executeCraft(params: {
+		player: Player;
+		recipe: CookingRecipe;
+		homeId: number;
+	}): Promise<CraftResult> {
+		const {
+			player, recipe, homeId
+		} = params;
 		const grade = getCookingGrade(player.cookingLevel);
 
 		// Consume plants (batched per plant type)
@@ -372,7 +386,11 @@ export class CookingService {
 		}
 
 		// Consume materials (with possible material save buff)
-		const materialSaved = await CookingService.consumeMaterialsWithSaveBuff(player.id, recipe.materials, grade.materialSaveChance);
+		const materialSaved = await CookingService.consumeMaterialsWithSaveBuff({
+			playerId: player.id,
+			materials: recipe.materials,
+			materialSaveChance: grade.materialSaveChance
+		});
 
 		// Calculate result and XP
 		const success = !RandomUtils.crowniclesRandom.bool(Math.min(CookingService.getFailureRate(grade, recipe.level), 1));
@@ -395,11 +413,14 @@ export class CookingService {
 		};
 	}
 
-	private static async consumeMaterialsWithSaveBuff(
-		playerId: number,
-		materials: CookingRecipe["materials"],
-		materialSaveChance: number
-	): Promise<number | undefined> {
+	private static async consumeMaterialsWithSaveBuff(params: {
+		playerId: number;
+		materials: CookingRecipe["materials"];
+		materialSaveChance: number;
+	}): Promise<number | undefined> {
+		const {
+			playerId, materials, materialSaveChance
+		} = params;
 		let materialSaved: number | undefined;
 		const materialsToConsume = [...materials];
 

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -66,11 +66,12 @@ export class CookingService {
 			return true;
 		}
 
-		if (!guild || !recipe.petFoodType || recipe.petFoodQuantity === undefined) {
+		const hasPetFoodConfig = guild && recipe.petFoodType && recipe.petFoodQuantity !== undefined;
+		if (!hasPetFoodConfig) {
 			return false;
 		}
 
-		return !guild.isStorageFullFor(recipe.petFoodType, recipe.petFoodQuantity);
+		return !guild.isStorageFullFor(recipe.petFoodType!, recipe.petFoodQuantity!);
 	}
 
 	/**
@@ -78,26 +79,41 @@ export class CookingService {
 	 */
 	static async getWoodToConsume(playerId: number): Promise<WoodSelection | null> {
 		const playerMaterials = await Materials.getPlayerMaterials(playerId);
-		const woodMaterials = MaterialDataController.instance.getMaterialsFromType(MaterialType.WOOD);
+		const woodByRarity = CookingService.groupWoodByRarity(playerMaterials);
+		return CookingService.selectBestWood(woodByRarity);
+	}
 
-		// Group wood by rarity
+	private static groupWoodByRarity(playerMaterials: {
+		materialId: number; quantity: number;
+	}[]): Map<number, {
+		materialId: number; quantity: number;
+	}[]> {
+		const woodMaterials = MaterialDataController.instance.getMaterialsFromType(MaterialType.WOOD);
+		const playerMaterialMap = new Map(playerMaterials.map(m => [m.materialId, m.quantity]));
 		const woodByRarity = new Map<number, {
-			materialId: number;
-			quantity: number;
+			materialId: number; quantity: number;
 		}[]>();
+
 		for (const wood of woodMaterials) {
 			const id = parseInt(wood.id, 10);
-			const playerMat = playerMaterials.find(m => m.materialId === id);
-			if (playerMat && playerMat.quantity > 0) {
-				const existing = woodByRarity.get(wood.rarity) ?? [];
-				existing.push({
-					materialId: id,
-					quantity: playerMat.quantity
-				});
-				woodByRarity.set(wood.rarity, existing);
+			const quantity = playerMaterialMap.get(id) ?? 0;
+			if (quantity <= 0) {
+				continue;
 			}
+			const existing = woodByRarity.get(wood.rarity) ?? [];
+			existing.push({
+				materialId: id,
+				quantity
+			});
+			woodByRarity.set(wood.rarity, existing);
 		}
 
+		return woodByRarity;
+	}
+
+	private static selectBestWood(woodByRarity: Map<number, {
+		materialId: number; quantity: number;
+	}[]>): WoodSelection | null {
 		// Priority: Common (1) → Uncommon (2) → Rare (3)
 		for (const rarity of [
 			MaterialRarity.COMMON,
@@ -195,6 +211,10 @@ export class CookingService {
 
 		const slots: CookingSlotData[] = [];
 
+		// Load all plant storages once to avoid N+1 queries
+		const allPlantStorages = await HomePlantStorages.getOfHome(homeId);
+		const plantStorageMap = new Map(allPlantStorages.map(s => [s.plantId, s.quantity]));
+
 		for (let i = 0; i < cookingSlots && i < SLOT_CONFIGS.length; i++) {
 			const recipe = slotRecipes[i];
 			if (!recipe) {
@@ -208,16 +228,11 @@ export class CookingService {
 			const secret = isRecipeSecret(i, player.furnacePosition, daySeed, grade.secretRecipeRate);
 
 			// Check ingredient availability
-			const plantAvailability = await Promise.all(
-				recipe.plants.map(async p => {
-					const storage = await HomePlantStorages.getForPlant(homeId, p.plantId);
-					return {
-						plantId: p.plantId,
-						quantity: p.quantity,
-						playerHas: storage?.quantity ?? 0
-					};
-				})
-			);
+			const plantAvailability = recipe.plants.map(p => ({
+				plantId: p.plantId,
+				quantity: p.quantity,
+				playerHas: plantStorageMap.get(p.plantId) ?? 0
+			}));
 
 			const materialAvailability = recipe.materials.map(m => ({
 				materialId: m.materialId,
@@ -267,7 +282,7 @@ export class CookingService {
 		for (const mat of recipe.materials) {
 			const matData = MaterialDataController.instance.getById(mat.materialId.toString());
 			if (matData) {
-				materialXp += MATERIAL_RARITY_COOKING_XP[matData.rarity] ?? 0;
+				materialXp += (MATERIAL_RARITY_COOKING_XP[matData.rarity] ?? 0) * mat.quantity;
 			}
 		}
 
@@ -342,49 +357,27 @@ export class CookingService {
 	): Promise<CraftResult> {
 		const grade = getCookingGrade(player.cookingLevel);
 
-		// Consume plants
+		// Consume plants (batched per plant type)
 		for (const plant of recipe.plants) {
-			for (let i = 0; i < plant.quantity; i++) {
-				await HomePlantStorages.removePlant(homeId, plant.plantId);
+			const storage = await HomePlantStorages.getForPlant(homeId, plant.plantId);
+			if (storage) {
+				storage.quantity = Math.max(0, storage.quantity - plant.quantity);
+				await storage.save();
 			}
 		}
 
 		// Consume materials (with possible material save buff)
-		let materialSaved: number | undefined;
-		const materialsToConsume = [...recipe.materials];
+		const materialSaved = await CookingService.consumeMaterialsWithSaveBuff(player.id, recipe.materials, grade.materialSaveChance);
 
-		if (grade.materialSaveChance > 0 && materialsToConsume.length > 0) {
-			if (RandomUtils.crowniclesRandom.bool(grade.materialSaveChance)) {
-				const savedIndex = RandomUtils.crowniclesRandom.integer(0, materialsToConsume.length - 1);
-				materialSaved = materialsToConsume[savedIndex].materialId;
-				materialsToConsume.splice(savedIndex, 1);
-			}
-		}
-
-		if (materialsToConsume.length > 0) {
-			await Materials.consumeMaterials(player.id, materialsToConsume);
-		}
-
-		// Calculate failure
-		const failureRate = CookingService.getFailureRate(grade, recipe.level);
-		const success = !RandomUtils.crowniclesRandom.bool(Math.min(failureRate, 1));
-
-		// Calculate XP (0 if recipe is too far above grade level)
-		const levelDiff = recipe.level - grade.maxRecipeLevelWithoutPenalty;
-		const xp = levelDiff >= NO_XP_LEVEL_THRESHOLD
-			? 0
-			: success
-				? CookingService.calculateCookingXp(recipe)
-				: CookingService.calculateFailureXp(recipe.level);
-
+		// Calculate result and XP
+		const success = !RandomUtils.crowniclesRandom.bool(Math.min(CookingService.getFailureRate(grade, recipe.level), 1));
+		const xp = CookingService.computeCraftXp(success, recipe, grade);
 		const levelResult = await CookingService.addCookingXp(player, xp);
 
 		// Discover cooking-level recipes on level up
-		let discoveredRecipeIds: string[] = [];
-		if (levelResult.levelUp) {
-			const discovered = await RecipeDiscoveryService.discoverCookingLevelRecipes(player);
-			discoveredRecipeIds = discovered.map(r => r.id);
-		}
+		const discoveredRecipeIds = levelResult.levelUp
+			? (await RecipeDiscoveryService.discoverCookingLevelRecipes(player)).map(r => r.id)
+			: [];
 
 		return {
 			success,
@@ -395,6 +388,37 @@ export class CookingService {
 			newGrade: levelResult.newGrade,
 			discoveredRecipeIds
 		};
+	}
+
+	private static async consumeMaterialsWithSaveBuff(
+		playerId: number,
+		materials: CookingRecipe["materials"],
+		materialSaveChance: number
+	): Promise<number | undefined> {
+		let materialSaved: number | undefined;
+		const materialsToConsume = [...materials];
+
+		if (materialSaveChance > 0 && materialsToConsume.length > 0 && RandomUtils.crowniclesRandom.bool(materialSaveChance)) {
+			const savedIndex = RandomUtils.crowniclesRandom.integer(0, materialsToConsume.length - 1);
+			materialSaved = materialsToConsume[savedIndex].materialId;
+			materialsToConsume.splice(savedIndex, 1);
+		}
+
+		if (materialsToConsume.length > 0) {
+			await Materials.consumeMaterials(playerId, materialsToConsume);
+		}
+
+		return materialSaved;
+	}
+
+	private static computeCraftXp(success: boolean, recipe: CookingRecipe, grade: CookingGradeDefinition): number {
+		const levelDiff = recipe.level - grade.maxRecipeLevelWithoutPenalty;
+		if (levelDiff >= NO_XP_LEVEL_THRESHOLD) {
+			return 0;
+		}
+		return success
+			? CookingService.calculateCookingXp(recipe)
+			: CookingService.calculateFailureXp(recipe.level);
 	}
 
 	/**

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -225,7 +225,12 @@ export class CookingService {
 				continue;
 			}
 
-			const secret = isRecipeSecret(i, player.furnacePosition, daySeed, grade.secretRecipeRate);
+			const secret = isRecipeSecret({
+				slotIndex: i,
+				furnacePosition: player.furnacePosition,
+				daySeed,
+				secretRate: grade.secretRecipeRate
+			});
 
 			// Check ingredient availability
 			const plantAvailability = recipe.plants.map(p => ({

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -23,11 +23,12 @@ import {
 	PLANT_COOKING_XP,
 	MATERIAL_RARITY_COOKING_XP,
 	CookingXpConstants,
-	FAILURE_PENALTY_BASE,
+	FAILURE_LEVEL_OFFSET,
 	NO_XP_LEVEL_THRESHOLD,
 	FURNACE_MAX_USES_PER_DAY,
 	FURNACE_MIN_OVERHEAT_HOURS,
-	SLOT_CONFIGS
+	SLOT_CONFIGS,
+	CookingOutputType
 } from "../../../../Lib/src/constants/CookingConstants";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { PlayerCookingRecipe } from "../database/game/models/PlayerCookingRecipe";
@@ -41,7 +42,7 @@ import { RecipeDiscoveryService } from "./RecipeDiscoveryService";
 
 interface WoodSelection {
 	materialId: number;
-	rarity: number;
+	rarity: MaterialRarity;
 	needsConfirmation: boolean;
 }
 
@@ -61,7 +62,7 @@ export class CookingService {
 	}
 
 	static canStorePetFoodReward(recipe: CookingRecipe, guild: Guild | null): boolean {
-		if (recipe.outputType !== "petFood") {
+		if (recipe.outputType !== CookingOutputType.PET_FOOD) {
 			return true;
 		}
 
@@ -226,7 +227,7 @@ export class CookingService {
 
 			const hasIngredients = plantAvailability.every(p => p.playerHas >= p.quantity)
 				&& materialAvailability.every(m => m.playerHas >= m.quantity);
-			const canCraftOutput = recipe.outputType === "petFood"
+			const canCraftOutput = recipe.outputType === CookingOutputType.PET_FOOD
 				? Boolean(guild)
 				: true;
 			const canCraft = hasIngredients && canCraftOutput;
@@ -289,7 +290,7 @@ export class CookingService {
 		if (recipeLevel <= grade.maxRecipeLevelWithoutPenalty) {
 			return grade.failureRate;
 		}
-		return grade.failureRate * (FAILURE_PENALTY_BASE + recipeLevel);
+		return grade.failureRate * (FAILURE_LEVEL_OFFSET + recipeLevel);
 	}
 
 	/**

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -42,6 +42,11 @@ import {
 	getTomorrowMidnight, getDayNumber
 } from "../../../../Lib/src/utils/TimeUtils";
 
+interface MaterialStock {
+	materialId: number;
+	quantity: number;
+}
+
 interface WoodSelection {
 	materialId: number;
 	rarity: MaterialRarity;
@@ -74,10 +79,6 @@ interface CookingLevelUpResult {
 }
 
 export class CookingService {
-	static async getPlayerGuild(player: Player): Promise<Guild | null> {
-		return player.guildId ? await Guilds.getById(player.guildId) : null;
-	}
-
 	static canStorePetFoodReward(recipe: CookingRecipe, guild: Guild | null): boolean {
 		if (recipe.outputType !== CookingOutputType.PET_FOOD) {
 			return true;
@@ -99,16 +100,10 @@ export class CookingService {
 		return CookingService.selectBestWood(woodByRarity);
 	}
 
-	private static groupWoodByRarity(playerMaterials: {
-		materialId: number; quantity: number;
-	}[]): Map<number, {
-		materialId: number; quantity: number;
-	}[]> {
+	private static groupWoodByRarity(playerMaterials: MaterialStock[]): Map<number, MaterialStock[]> {
 		const woodMaterials = MaterialDataController.instance.getMaterialsFromType(MaterialType.WOOD);
 		const playerMaterialMap = new Map(playerMaterials.map(m => [m.materialId, m.quantity]));
-		const woodByRarity = new Map<number, {
-			materialId: number; quantity: number;
-		}[]>();
+		const woodByRarity = new Map<number, MaterialStock[]>();
 
 		for (const wood of woodMaterials) {
 			const id = parseInt(wood.id, 10);
@@ -127,9 +122,7 @@ export class CookingService {
 		return woodByRarity;
 	}
 
-	private static selectBestWood(woodByRarity: Map<number, {
-		materialId: number; quantity: number;
-	}[]>): WoodSelection | null {
+	private static selectBestWood(woodByRarity: Map<number, MaterialStock[]>): WoodSelection | null {
 		// Priority: Common (1) → Uncommon (2) → Rare (3)
 		for (const rarity of [
 			MaterialRarity.COMMON,
@@ -215,7 +208,7 @@ export class CookingService {
 		const grade = getCookingGrade(player.cookingLevel);
 		const playerMaterials = await Materials.getPlayerMaterials(player.id);
 		const materialMap = new Map(playerMaterials.map(m => [m.materialId, m.quantity]));
-		const guild = await CookingService.getPlayerGuild(player);
+		const guild = player.guildId ? await Guilds.getById(player.guildId) : null;
 		const slotRecipes = getUniqueRecipesForSlots({
 			cookingSlots,
 			furnacePosition: player.furnacePosition,

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -1,0 +1,484 @@
+import Player from "../database/game/models/Player";
+import { Materials } from "../database/game/models/Material";
+import { HomePlantStorages } from "../database/game/models/HomePlantStorage";
+import {
+	Guilds, Guild
+} from "../database/game/models/Guild";
+import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
+import { MaterialType } from "../../../../Lib/src/types/MaterialType";
+import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
+import { MaterialDataController } from "../../data/Material";
+import { Constants } from "../../../../Lib/src/constants/Constants";
+import {
+	PetEntities, PetEntity
+} from "../database/game/models/PetEntity";
+import { PetDataController } from "../../data/Pet";
+import { PetConstants } from "../../../../Lib/src/constants/PetConstants";
+import { GuildConstants } from "../../../../Lib/src/constants/GuildConstants";
+import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
+import { getFoodIndexOf } from "../utils/FoodUtils";
+import {
+	getCookingGrade,
+	CookingGradeDefinition,
+	PLANT_COOKING_XP,
+	MATERIAL_RARITY_COOKING_XP,
+	CookingXpConstants,
+	FAILURE_PENALTY_BASE,
+	NO_XP_LEVEL_THRESHOLD,
+	FURNACE_MAX_USES_PER_DAY,
+	FURNACE_MIN_OVERHEAT_HOURS,
+	SLOT_CONFIGS
+} from "../../../../Lib/src/constants/CookingConstants";
+import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
+import { PlayerCookingRecipe } from "../database/game/models/PlayerCookingRecipe";
+import {
+	getUniqueRecipesForSlots,
+	isRecipeSecret,
+	getCurrentDaySeed
+} from "./CookingSlotRotation";
+import { CookingSlotData } from "../../../../Lib/src/packets/commands/CommandReportPacket";
+import { RecipeDiscoveryService } from "./RecipeDiscoveryService";
+
+interface WoodSelection {
+	materialId: number;
+	rarity: number;
+	needsConfirmation: boolean;
+}
+
+interface CraftResult {
+	success: boolean;
+	xpGained: number;
+	materialSaved: number | undefined;
+	levelUp: boolean;
+	newLevel: number | undefined;
+	newGrade: string | undefined;
+	discoveredRecipeIds: string[];
+}
+
+export class CookingService {
+	static async getPlayerGuild(player: Player): Promise<Guild | null> {
+		return player.guildId ? await Guilds.getById(player.guildId) : null;
+	}
+
+	static canStorePetFoodReward(recipe: CookingRecipe, guild: Guild | null): boolean {
+		if (recipe.outputType !== "petFood") {
+			return true;
+		}
+
+		if (!guild || !recipe.petFoodType || recipe.petFoodQuantity === undefined) {
+			return false;
+		}
+
+		return !guild.isStorageFullFor(recipe.petFoodType, recipe.petFoodQuantity);
+	}
+
+	/**
+	 * Get wood to consume for furnace, with priority system
+	 */
+	static async getWoodToConsume(playerId: number): Promise<WoodSelection | null> {
+		const playerMaterials = await Materials.getPlayerMaterials(playerId);
+		const woodMaterials = MaterialDataController.instance.getMaterialsFromType(MaterialType.WOOD);
+
+		// Group wood by rarity
+		const woodByRarity = new Map<number, {
+			materialId: number;
+			quantity: number;
+		}[]>();
+		for (const wood of woodMaterials) {
+			const id = parseInt(wood.id, 10);
+			const playerMat = playerMaterials.find(m => m.materialId === id);
+			if (playerMat && playerMat.quantity > 0) {
+				const existing = woodByRarity.get(wood.rarity) ?? [];
+				existing.push({
+					materialId: id,
+					quantity: playerMat.quantity
+				});
+				woodByRarity.set(wood.rarity, existing);
+			}
+		}
+
+		// Priority: Common (1) → Uncommon (2) → Rare (3)
+		for (const rarity of [
+			MaterialRarity.COMMON,
+			MaterialRarity.UNCOMMON,
+			MaterialRarity.RARE
+		]) {
+			const available = woodByRarity.get(rarity);
+			if (available && available.length > 0) {
+				// Pick the one with the highest stock
+				available.sort((a, b) => b.quantity - a.quantity);
+				return {
+					materialId: available[0].materialId,
+					rarity,
+					needsConfirmation: rarity !== MaterialRarity.COMMON
+				};
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check if furnace is overheated
+	 */
+	static isFurnaceOverheated(player: Player): boolean {
+		if (!player.furnaceOverheatUntil) {
+			return false;
+		}
+		return new Date() < new Date(player.furnaceOverheatUntil);
+	}
+
+	/**
+	 * Reset daily furnace counter if day changed
+	 */
+	static async resetDailyCounterIfNeeded(player: Player): Promise<void> {
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+
+		if (!player.furnaceLastUseDate || new Date(player.furnaceLastUseDate) < today) {
+			player.furnaceUsesToday = 0;
+			player.furnaceLastUseDate = new Date();
+			await player.save();
+		}
+	}
+
+	/**
+	 * Increment furnace usage and trigger overheat if limit reached
+	 */
+	static async incrementFurnaceUsage(player: Player): Promise<boolean> {
+		await CookingService.resetDailyCounterIfNeeded(player);
+
+		player.furnaceUsesToday++;
+		player.furnaceLastUseDate = new Date();
+
+		if (player.furnaceUsesToday >= FURNACE_MAX_USES_PER_DAY) {
+			const now = new Date();
+			const tomorrow = new Date(now);
+			tomorrow.setDate(tomorrow.getDate() + 1);
+			tomorrow.setHours(0, 0, 0, 0);
+
+			const msUntilTomorrow = tomorrow.getTime() - now.getTime();
+			const minOverheatMs = FURNACE_MIN_OVERHEAT_HOURS * 60 * 60 * 1000;
+
+			player.furnaceOverheatUntil = new Date(
+				now.getTime() + Math.max(msUntilTomorrow, minOverheatMs)
+			);
+		}
+
+		await player.save();
+		return player.furnaceUsesToday >= FURNACE_MAX_USES_PER_DAY;
+	}
+
+	/**
+	 * Get all slot recipes for the current furnace state
+	 */
+	static async getSlotRecipes(
+		player: Player,
+		homeId: number,
+		cookingSlots: number
+	): Promise<CookingSlotData[]> {
+		const discoveredIds = await PlayerCookingRecipe.getDiscoveredRecipeIds(player);
+		const daySeed = getCurrentDaySeed();
+		const grade = getCookingGrade(player.cookingLevel);
+		const playerMaterials = await Materials.getPlayerMaterials(player.id);
+		const materialMap = new Map(playerMaterials.map(m => [m.materialId, m.quantity]));
+		const guild = await CookingService.getPlayerGuild(player);
+		const slotRecipes = getUniqueRecipesForSlots({
+			cookingSlots,
+			furnacePosition: player.furnacePosition,
+			daySeed,
+			discoveredRecipeIds: discoveredIds,
+			allowPetFoodRecipes: Boolean(guild)
+		});
+
+		const slots: CookingSlotData[] = [];
+
+		for (let i = 0; i < cookingSlots && i < SLOT_CONFIGS.length; i++) {
+			const recipe = slotRecipes[i];
+			if (!recipe) {
+				slots.push({
+					slotIndex: i,
+					recipe: null
+				});
+				continue;
+			}
+
+			const secret = isRecipeSecret(i, player.furnacePosition, daySeed, grade.secretRecipeRate);
+
+			// Check ingredient availability
+			const plantAvailability = await Promise.all(
+				recipe.plants.map(async p => {
+					const storage = await HomePlantStorages.getForPlant(homeId, p.plantId);
+					return {
+						plantId: p.plantId,
+						quantity: p.quantity,
+						playerHas: storage?.quantity ?? 0
+					};
+				})
+			);
+
+			const materialAvailability = recipe.materials.map(m => ({
+				materialId: m.materialId,
+				quantity: m.quantity,
+				playerHas: materialMap.get(m.materialId) ?? 0
+			}));
+
+			const hasIngredients = plantAvailability.every(p => p.playerHas >= p.quantity)
+				&& materialAvailability.every(m => m.playerHas >= m.quantity);
+			const canCraftOutput = recipe.outputType === "petFood"
+				? Boolean(guild)
+				: true;
+			const canCraft = hasIngredients && canCraftOutput;
+
+			slots.push({
+				slotIndex: i,
+				recipe: {
+					id: recipe.id,
+					level: recipe.level,
+					isSecret: secret,
+					outputDescription: secret ? "???" : recipe.id,
+					outputType: recipe.outputType,
+					recipeType: recipe.recipeType,
+					petFoodType: recipe.petFoodType,
+					ingredients: {
+						plants: plantAvailability,
+						materials: materialAvailability
+					},
+					canCraft
+				}
+			});
+		}
+
+		return slots;
+	}
+
+	/**
+	 * Calculate cooking XP for a recipe
+	 */
+	static calculateCookingXp(recipe: CookingRecipe): number {
+		let plantXp = 0;
+		for (const plant of recipe.plants) {
+			plantXp += (PLANT_COOKING_XP[plant.plantId] ?? 0) * plant.quantity;
+		}
+
+		let materialXp = 0;
+		for (const mat of recipe.materials) {
+			const matData = MaterialDataController.instance.getById(mat.materialId.toString());
+			if (matData) {
+				materialXp += MATERIAL_RARITY_COOKING_XP[matData.rarity] ?? 0;
+			}
+		}
+
+		return Math.round(
+			plantXp * CookingXpConstants.PLANT_WEIGHT + materialXp * CookingXpConstants.MATERIAL_WEIGHT
+		);
+	}
+
+	/**
+	 * Calculate failure XP (fixed amount per recipe level)
+	 */
+	static calculateFailureXp(recipeLevel: number): number {
+		return CookingXpConstants.FAILURE_XP_PER_LEVEL * recipeLevel;
+	}
+
+	/**
+	 * Calculate effective failure rate based on grade and recipe level
+	 */
+	static getFailureRate(grade: CookingGradeDefinition, recipeLevel: number): number {
+		if (recipeLevel <= grade.maxRecipeLevelWithoutPenalty) {
+			return grade.failureRate;
+		}
+		return grade.failureRate * (FAILURE_PENALTY_BASE + recipeLevel);
+	}
+
+	/**
+	 * Get XP needed for a cooking level
+	 */
+	static getXpNeededForLevel(level: number): number {
+		return Math.round(
+			Constants.XP.BASE_VALUE * Math.pow(Constants.XP.COEFFICIENT, level + 1)
+		) - Constants.XP.MINUS;
+	}
+
+	/**
+	 * Add cooking XP to player, handle level up
+	 */
+	static async addCookingXp(player: Player, xp: number): Promise<{
+		levelUp: boolean;
+		newLevel?: number;
+		newGrade?: string;
+	}> {
+		player.cookingExperience += xp;
+
+		let levelUp = false;
+		let newLevel: number | undefined;
+		let newGrade: string | undefined;
+
+		while (player.cookingExperience >= CookingService.getXpNeededForLevel(player.cookingLevel)) {
+			player.cookingExperience -= CookingService.getXpNeededForLevel(player.cookingLevel);
+			player.cookingLevel++;
+			levelUp = true;
+			newLevel = player.cookingLevel;
+			newGrade = getCookingGrade(player.cookingLevel).name;
+		}
+
+		await player.save();
+		return {
+			levelUp,
+			newLevel,
+			newGrade
+		};
+	}
+
+	/**
+	 * Execute a craft: consume ingredients, calculate result, give XP
+	 */
+	static async executeCraft(
+		player: Player,
+		recipe: CookingRecipe,
+		homeId: number
+	): Promise<CraftResult> {
+		const grade = getCookingGrade(player.cookingLevel);
+
+		// Consume plants
+		for (const plant of recipe.plants) {
+			for (let i = 0; i < plant.quantity; i++) {
+				await HomePlantStorages.removePlant(homeId, plant.plantId);
+			}
+		}
+
+		// Consume materials (with possible material save buff)
+		let materialSaved: number | undefined;
+		const materialsToConsume = [...recipe.materials];
+
+		if (grade.materialSaveChance > 0 && materialsToConsume.length > 0) {
+			if (RandomUtils.crowniclesRandom.bool(grade.materialSaveChance)) {
+				const savedIndex = RandomUtils.crowniclesRandom.integer(0, materialsToConsume.length - 1);
+				materialSaved = materialsToConsume[savedIndex].materialId;
+				materialsToConsume.splice(savedIndex, 1);
+			}
+		}
+
+		if (materialsToConsume.length > 0) {
+			await Materials.consumeMaterials(player.id, materialsToConsume);
+		}
+
+		// Calculate failure
+		const failureRate = CookingService.getFailureRate(grade, recipe.level);
+		const success = !RandomUtils.crowniclesRandom.bool(Math.min(failureRate, 1));
+
+		// Calculate XP (0 if recipe is too far above grade level)
+		const levelDiff = recipe.level - grade.maxRecipeLevelWithoutPenalty;
+		const xp = levelDiff >= NO_XP_LEVEL_THRESHOLD
+			? 0
+			: success
+				? CookingService.calculateCookingXp(recipe)
+				: CookingService.calculateFailureXp(recipe.level);
+
+		const levelResult = await CookingService.addCookingXp(player, xp);
+
+		// Discover cooking-level recipes on level up
+		let discoveredRecipeIds: string[] = [];
+		if (levelResult.levelUp) {
+			const discovered = await RecipeDiscoveryService.discoverCookingLevelRecipes(player);
+			discoveredRecipeIds = discovered.map(r => r.id);
+		}
+
+		return {
+			success,
+			xpGained: xp,
+			materialSaved,
+			levelUp: levelResult.levelUp,
+			newLevel: levelResult.newLevel,
+			newGrade: levelResult.newGrade,
+			discoveredRecipeIds
+		};
+	}
+
+	/**
+	 * Get available food space in guild for a given food type
+	 */
+	static getAvailableFoodSpace(guild: Guild, foodType: string): number {
+		const foodIndex = getFoodIndexOf(foodType);
+		const max = GuildConstants.MAX_PET_FOOD[foodIndex];
+		const current = guild.getDataValue(foodType) as number;
+		return Math.max(0, max - current);
+	}
+
+	/**
+	 * Check if a pet food type is compatible with a pet's diet
+	 */
+	static isFoodCompatibleWithPet(foodType: string, petEntity: PetEntity): boolean {
+		const petModel = PetDataController.instance.getById(petEntity.typeId);
+		if (!petModel) {
+			return false;
+		}
+
+		if (foodType === PetConstants.PET_FOOD.COMMON_FOOD || foodType === PetConstants.PET_FOOD.ULTIMATE_FOOD) {
+			return true;
+		}
+		if (foodType === PetConstants.PET_FOOD.HERBIVOROUS_FOOD) {
+			return petModel.canEatVegetables();
+		}
+		if (foodType === PetConstants.PET_FOOD.CARNIVOROUS_FOOD) {
+			return petModel.canEatMeat();
+		}
+		return false;
+	}
+
+	/**
+	 * Check if the player's pet is hungry and can eat the given food type
+	 */
+	static async getHungryCompatiblePet(player: Player, foodType: string): Promise<PetEntity | null> {
+		if (!player.petId) {
+			return null;
+		}
+
+		const petEntity = await PetEntities.getById(player.petId);
+		if (!petEntity) {
+			return null;
+		}
+
+		const petModel = PetDataController.instance.getById(petEntity.typeId);
+		if (!petModel) {
+			return null;
+		}
+
+		const cooldown = petEntity.getFeedCooldown(petModel);
+		if (cooldown > 0) {
+			return null;
+		}
+
+		if (!CookingService.isFoodCompatibleWithPet(foodType, petEntity)) {
+			return null;
+		}
+
+		return petEntity;
+	}
+
+	/**
+	 * Feed the player's pet from surplus cooking food
+	 */
+	static async feedPetFromSurplus(player: Player, petEntity: PetEntity, foodType: string): Promise<void> {
+		const foodIndex = getFoodIndexOf(foodType);
+		petEntity.hungrySince = new Date();
+		await petEntity.changeLovePoints({
+			response: [],
+			player,
+			amount: PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[foodIndex],
+			reason: NumberChangeReason.PET_FEED
+		});
+		await petEntity.save();
+	}
+
+	/**
+	 * Get the material to return when recycling surplus pet food.
+	 * Returns the first material from the recipe's ingredient list.
+	 */
+	static getSurplusRecycleMaterial(recipe: CookingRecipe): number | undefined {
+		if (recipe.materials.length === 0) {
+			return undefined;
+		}
+		return recipe.materials[0].materialId;
+	}
+}

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -26,8 +26,9 @@ import {
 	FAILURE_LEVEL_OFFSET,
 	NO_XP_LEVEL_THRESHOLD,
 	FURNACE_MAX_USES_PER_DAY,
-	FURNACE_MIN_OVERHEAT_HOURS,
-	CookingOutputType
+	FURNACE_MIN_OVERHEAT_MS,
+	CookingOutputType,
+	SECRET_RECIPE_PLACEHOLDER
 } from "../../../../Lib/src/constants/CookingConstants";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { PlayerCookingRecipe } from "../database/game/models/PlayerCookingRecipe";
@@ -38,6 +39,7 @@ import {
 } from "./CookingSlotRotation";
 import { CookingSlotData } from "../../../../Lib/src/packets/commands/CommandReportPacket";
 import { RecipeDiscoveryService } from "./RecipeDiscoveryService";
+import { getTomorrowMidnight } from "../../../../Lib/src/utils/TimeUtils";
 
 interface WoodSelection {
 	materialId: number;
@@ -64,6 +66,12 @@ interface RecipeSlotContext {
 	guild: Guild | null;
 }
 
+interface CookingLevelUpResult {
+	levelUp: boolean;
+	newLevel?: number;
+	newGrade?: string;
+}
+
 export class CookingService {
 	static async getPlayerGuild(player: Player): Promise<Guild | null> {
 		return player.guildId ? await Guilds.getById(player.guildId) : null;
@@ -74,12 +82,11 @@ export class CookingService {
 			return true;
 		}
 
-		const hasPetFoodConfig = guild && recipe.petFoodType && recipe.petFoodQuantity !== undefined;
-		if (!hasPetFoodConfig) {
+		if (!guild || !recipe.petFood) {
 			return false;
 		}
 
-		return !guild.isStorageFullFor(recipe.petFoodType!, recipe.petFoodQuantity!);
+		return !guild.isStorageFullFor(recipe.petFood.type, recipe.petFood.quantity);
 	}
 
 	/**
@@ -178,15 +185,12 @@ export class CookingService {
 
 		if (player.furnaceUsesToday >= FURNACE_MAX_USES_PER_DAY) {
 			const now = new Date();
-			const tomorrow = new Date(now);
-			tomorrow.setDate(tomorrow.getDate() + 1);
-			tomorrow.setHours(0, 0, 0, 0);
+			const tomorrow = getTomorrowMidnight();
 
 			const msUntilTomorrow = tomorrow.getTime() - now.getTime();
-			const minOverheatMs = FURNACE_MIN_OVERHEAT_HOURS * 60 * 60 * 1000;
 
 			player.furnaceOverheatUntil = new Date(
-				now.getTime() + Math.max(msUntilTomorrow, minOverheatMs)
+				now.getTime() + Math.max(msUntilTomorrow, FURNACE_MIN_OVERHEAT_MS)
 			);
 		}
 
@@ -273,10 +277,10 @@ export class CookingService {
 			id: recipe.id,
 			level: recipe.level,
 			isSecret: secret,
-			outputDescription: secret ? "???" : recipe.id,
+			outputDescription: secret ? SECRET_RECIPE_PLACEHOLDER : recipe.id,
 			outputType: recipe.outputType,
 			recipeType: recipe.recipeType,
-			petFoodType: recipe.petFoodType,
+			petFoodType: recipe.petFood?.type,
 			ingredients: {
 				plants: plantAvailability,
 				materials: materialAvailability
@@ -339,11 +343,7 @@ export class CookingService {
 	static async addCookingXp(params: {
 		player: Player;
 		xp: number;
-	}): Promise<{
-		levelUp: boolean;
-		newLevel?: number;
-		newGrade?: string;
-	}> {
+	}): Promise<CookingLevelUpResult> {
 		const {
 			player, xp
 		} = params;
@@ -416,9 +416,7 @@ export class CookingService {
 			success,
 			xpGained: xp,
 			materialSaved,
-			levelUp: levelResult.levelUp,
-			newLevel: levelResult.newLevel,
-			newGrade: levelResult.newGrade,
+			...levelResult,
 			discoveredRecipeIds
 		};
 	}
@@ -476,27 +474,6 @@ export class CookingService {
 	}
 
 	/**
-	 * Check if a pet food type is compatible with a pet's diet
-	 */
-	static isFoodCompatibleWithPet(foodType: string, petEntity: PetEntity): boolean {
-		const petModel = PetDataController.instance.getById(petEntity.typeId);
-		if (!petModel) {
-			return false;
-		}
-
-		if (foodType === PetConstants.PET_FOOD.COMMON_FOOD || foodType === PetConstants.PET_FOOD.ULTIMATE_FOOD) {
-			return true;
-		}
-		if (foodType === PetConstants.PET_FOOD.HERBIVOROUS_FOOD) {
-			return petModel.canEatVegetables();
-		}
-		if (foodType === PetConstants.PET_FOOD.CARNIVOROUS_FOOD) {
-			return petModel.canEatMeat();
-		}
-		return false;
-	}
-
-	/**
 	 * Check if the player's pet is hungry and can eat the given food type
 	 */
 	static async getHungryCompatiblePet(player: Player, foodType: string): Promise<PetEntity | null> {
@@ -519,7 +496,7 @@ export class CookingService {
 			return null;
 		}
 
-		if (!CookingService.isFoodCompatibleWithPet(foodType, petEntity)) {
+		if (!petModel.canEatFood(foodType)) {
 			return null;
 		}
 

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -34,12 +34,13 @@ import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { PlayerCookingRecipe } from "../database/game/models/PlayerCookingRecipe";
 import {
 	getUniqueRecipesForSlots,
-	isRecipeSecret,
-	getCurrentDaySeed
+	isRecipeSecret
 } from "./CookingSlotRotation";
 import { CookingSlotData } from "../../../../Lib/src/packets/commands/CommandReportPacket";
 import { RecipeDiscoveryService } from "./RecipeDiscoveryService";
-import { getTomorrowMidnight } from "../../../../Lib/src/utils/TimeUtils";
+import {
+	getTomorrowMidnight, getDayNumber
+} from "../../../../Lib/src/utils/TimeUtils";
 
 interface WoodSelection {
 	materialId: number;
@@ -210,7 +211,7 @@ export class CookingService {
 			player, homeId, cookingSlots
 		} = params;
 		const discoveredIds = await PlayerCookingRecipe.getDiscoveredRecipeIds(player);
-		const daySeed = getCurrentDaySeed();
+		const daySeed = getDayNumber();
 		const grade = getCookingGrade(player.cookingLevel);
 		const playerMaterials = await Materials.getPlayerMaterials(player.id);
 		const materialMap = new Map(playerMaterials.map(m => [m.materialId, m.quantity]));
@@ -273,13 +274,17 @@ export class CookingService {
 			? Boolean(context.guild)
 			: true;
 
+		const {
+			id, level, outputType, recipeType
+		} = recipe;
+
 		return {
-			id: recipe.id,
-			level: recipe.level,
+			id,
+			level,
+			outputType,
+			recipeType,
 			isSecret: secret,
-			outputDescription: secret ? SECRET_RECIPE_PLACEHOLDER : recipe.id,
-			outputType: recipe.outputType,
-			recipeType: recipe.recipeType,
+			outputDescription: secret ? SECRET_RECIPE_PLACEHOLDER : id,
 			petFoodType: recipe.petFood?.type,
 			ingredients: {
 				plants: plantAvailability,
@@ -487,16 +492,7 @@ export class CookingService {
 		}
 
 		const petModel = PetDataController.instance.getById(petEntity.typeId);
-		if (!petModel) {
-			return null;
-		}
-
-		const cooldown = petEntity.getFeedCooldown(petModel);
-		if (cooldown > 0) {
-			return null;
-		}
-
-		if (!petModel.canEatFood(foodType)) {
+		if (!petModel || !petEntity.canBeFed(petModel, foodType)) {
 			return null;
 		}
 

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -188,7 +188,8 @@ export class CookingService {
 			furnacePosition: player.furnacePosition,
 			daySeed,
 			discoveredRecipeIds: discoveredIds,
-			allowPetFoodRecipes: Boolean(guild)
+			allowPetFoodRecipes: Boolean(guild),
+			maxRecipeLevelWithoutPenalty: grade.maxRecipeLevelWithoutPenalty
 		});
 
 		const slots: CookingSlotData[] = [];
@@ -319,7 +320,7 @@ export class CookingService {
 			player.cookingLevel++;
 			levelUp = true;
 			newLevel = player.cookingLevel;
-			newGrade = getCookingGrade(player.cookingLevel).name;
+			newGrade = getCookingGrade(player.cookingLevel).id;
 		}
 
 		await player.save();

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -6,6 +6,26 @@ import { getDayNumber } from "../../../../Lib/src/utils/TimeUtils";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 
+// Hash mixing primes for deterministic seed derivation
+const CANDIDATE_INDEX_PRIMES = {
+	DAY: 7,
+	FURNACE: 13,
+	SLOT: 97
+} as const;
+
+const SECRET_SEED_PRIMES = {
+	DAY: 11,
+	FURNACE: 23,
+	SLOT: 131
+} as const;
+
+// LCG (Linear Congruential Generator) constants for pseudo-random generation
+const LCG = {
+	MULTIPLIER: 1103515245,
+	INCREMENT: 12345,
+	MAX_VALUE: 0x7fffffff
+} as const;
+
 interface SlotRecipeSelectionOptions {
 	slotIndex: number;
 	furnacePosition: number;
@@ -72,7 +92,7 @@ function getBaseCandidateIndex({
 	daySeed,
 	candidatesLength
 }: BaseCandidateIndexOptions): number {
-	const tierSeed = daySeed * 7 + furnacePosition * 13 + slotIndex * 97;
+	const tierSeed = daySeed * CANDIDATE_INDEX_PRIMES.DAY + furnacePosition * CANDIDATE_INDEX_PRIMES.FURNACE + slotIndex * CANDIDATE_INDEX_PRIMES.SLOT;
 	return Math.abs(tierSeed) % candidatesLength;
 }
 
@@ -217,21 +237,6 @@ export function getUniqueRecipesForSlots({
 	return recipes;
 }
 
-/**
- * Determine which recipe should appear in a slot at a given furnace position
- */
-export function getRecipeForSlot(options: {
-	slotIndex: number;
-	furnacePosition: number;
-	daySeed: number;
-	discoveredRecipeIds: string[];
-}): CookingRecipe | null {
-	return getRecipeForSlotExcluding({
-		...options,
-		excludedRecipeIds: new Set<string>()
-	});
-}
-
 interface RecipeSecretOptions {
 	slotIndex: number;
 	furnacePosition: number;
@@ -248,8 +253,8 @@ export function isRecipeSecret({
 	daySeed,
 	secretRate
 }: RecipeSecretOptions): boolean {
-	const secretSeed = daySeed * 11 + furnacePosition * 23 + slotIndex * 131;
-	const pseudoRandom = ((secretSeed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+	const secretSeed = daySeed * SECRET_SEED_PRIMES.DAY + furnacePosition * SECRET_SEED_PRIMES.FURNACE + slotIndex * SECRET_SEED_PRIMES.SLOT;
+	const pseudoRandom = ((secretSeed * LCG.MULTIPLIER + LCG.INCREMENT) & LCG.MAX_VALUE) / LCG.MAX_VALUE;
 	return pseudoRandom < secretRate;
 }
 

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -2,7 +2,6 @@ import {
 	SLOT_CONFIGS, SLOT_SEED_OFFSETS, RecipeType, SlotConfig, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES, CookingOutputType
 } from "../../../../Lib/src/constants/CookingConstants";
 import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
-import { getDayNumber } from "../../../../Lib/src/utils/TimeUtils";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 
@@ -258,9 +257,3 @@ export function isRecipeSecret({
 	return pseudoRandom < secretRate;
 }
 
-/**
- * Get the current day seed (changes daily)
- */
-export function getCurrentDaySeed(): number {
-	return getDayNumber();
-}

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -34,13 +34,21 @@ export function getSlotCycle(slotIndex: number, daySeed: number): RecipeType[] {
 	return RandomUtils.deterministicShuffle([...config.eligibleTypes], slotSeed);
 }
 
-function getCandidatesForSlotType(
-	slotIndex: number,
-	recipeType: RecipeType,
-	discoveredRecipeIds: string[],
-	allowPetFoodRecipes: boolean,
-	maxLevelOverride?: number
-): CookingRecipe[] {
+interface CandidateFilterOptions {
+	slotIndex: number;
+	recipeType: RecipeType;
+	discoveredRecipeIds: string[];
+	allowPetFoodRecipes: boolean;
+	maxLevelOverride?: number;
+}
+
+function getCandidatesForSlotType({
+	slotIndex,
+	recipeType,
+	discoveredRecipeIds,
+	allowPetFoodRecipes,
+	maxLevelOverride
+}: CandidateFilterOptions): CookingRecipe[] {
 	const slotConfig: SlotConfig = SLOT_CONFIGS[slotIndex];
 	const effectiveMaxLevel = maxLevelOverride !== undefined
 		? Math.min(maxLevelOverride, slotConfig.maxLevel)
@@ -91,7 +99,13 @@ export function getRecipeForSlotExcluding({
 	// Try each type in the cycle starting from the current rotation position
 	for (let offset = 0; offset < cycle.length; offset++) {
 		const recipeType = cycle[(startTypeIndex + offset) % cycle.length];
-		const candidates = getCandidatesForSlotType(slotIndex, recipeType, discoveredRecipeIds, allowPetFoodRecipes, maxRecipeLevel);
+		const candidates = getCandidatesForSlotType({
+			slotIndex,
+			recipeType,
+			discoveredRecipeIds,
+			allowPetFoodRecipes,
+			maxLevelOverride: maxRecipeLevel
+		});
 
 		if (candidates.length === 0) {
 			continue;
@@ -107,6 +121,37 @@ export function getRecipeForSlotExcluding({
 	return null;
 }
 
+function guaranteePlayerLevelRecipes(
+	recipes: Array<CookingRecipe | null>,
+	usedRecipeIds: Set<string>,
+	slotCount: number,
+	maxRecipeLevelWithoutPenalty: number | undefined,
+	baseOptions: Pick<SlotRecipeSelectionOptions, "furnacePosition" | "daySeed" | "discoveredRecipeIds" | "allowPetFoodRecipes">
+): void {
+	if (maxRecipeLevelWithoutPenalty === undefined) {
+		return;
+	}
+	let guaranteed = 0;
+	for (let slotIndex = 0; slotIndex < slotCount && guaranteed < MIN_GUARANTEED_PLAYER_LEVEL_RECIPES; slotIndex++) {
+		if (SLOT_CONFIGS[slotIndex].minLevel > maxRecipeLevelWithoutPenalty) {
+			continue;
+		}
+
+		const recipe = getRecipeForSlotExcluding({
+			slotIndex,
+			...baseOptions,
+			excludedRecipeIds: usedRecipeIds,
+			maxRecipeLevel: maxRecipeLevelWithoutPenalty
+		});
+
+		if (recipe) {
+			recipes[slotIndex] = recipe;
+			usedRecipeIds.add(recipe.id);
+			guaranteed++;
+		}
+	}
+}
+
 export function getUniqueRecipesForSlots({
 	cookingSlots,
 	furnacePosition,
@@ -119,31 +164,15 @@ export function getUniqueRecipesForSlots({
 	const recipes: Array<CookingRecipe | null> = new Array(slotCount).fill(null);
 	const usedRecipeIds = new Set<string>();
 
+	const baseOptions = {
+		furnacePosition,
+		daySeed,
+		discoveredRecipeIds,
+		allowPetFoodRecipes
+	};
+
 	// Pass 1: guarantee player-level recipes in eligible slots
-	if (maxRecipeLevelWithoutPenalty !== undefined) {
-		let guaranteed = 0;
-		for (let slotIndex = 0; slotIndex < slotCount && guaranteed < MIN_GUARANTEED_PLAYER_LEVEL_RECIPES; slotIndex++) {
-			if (SLOT_CONFIGS[slotIndex].minLevel > maxRecipeLevelWithoutPenalty) {
-				continue;
-			}
-
-			const recipe = getRecipeForSlotExcluding({
-				slotIndex,
-				furnacePosition,
-				daySeed,
-				discoveredRecipeIds,
-				excludedRecipeIds: usedRecipeIds,
-				allowPetFoodRecipes,
-				maxRecipeLevel: maxRecipeLevelWithoutPenalty
-			});
-
-			if (recipe) {
-				recipes[slotIndex] = recipe;
-				usedRecipeIds.add(recipe.id);
-				guaranteed++;
-			}
-		}
-	}
+	guaranteePlayerLevelRecipes(recipes, usedRecipeIds, slotCount, maxRecipeLevelWithoutPenalty, baseOptions);
 
 	// Pass 2: normal selection for remaining slots
 	for (let slotIndex = 0; slotIndex < slotCount; slotIndex++) {
@@ -153,11 +182,8 @@ export function getUniqueRecipesForSlots({
 
 		const recipe = getRecipeForSlotExcluding({
 			slotIndex,
-			furnacePosition,
-			daySeed,
-			discoveredRecipeIds,
-			excludedRecipeIds: usedRecipeIds,
-			allowPetFoodRecipes
+			...baseOptions,
+			excludedRecipeIds: usedRecipeIds
 		});
 
 		recipes[slotIndex] = recipe;

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -1,8 +1,9 @@
 import {
-	SLOT_CONFIGS, SLOT_SEED_OFFSETS, RecipeType, SlotConfig, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES
+	SLOT_CONFIGS, SLOT_SEED_OFFSETS, RecipeType, SlotConfig, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES, CookingOutputType
 } from "../../../../Lib/src/constants/CookingConstants";
 import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
 import { getDayNumber } from "../../../../Lib/src/utils/TimeUtils";
+import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 
 interface SlotRecipeSelectionOptions {
@@ -25,26 +26,12 @@ interface UniqueSlotRecipesOptions {
 }
 
 /**
- * Deterministic Fisher-Yates shuffle using a simple LCG seeded PRNG
- */
-function deterministicShuffle<T>(array: T[], seed: number): T[] {
-	const result = [...array];
-	let s = Math.abs(seed) | 1;
-	for (let i = result.length - 1; i > 0; i--) {
-		s = (s * 1103515245 + 12345) & 0x7fffffff;
-		const j = s % (i + 1);
-		[result[i], result[j]] = [result[j], result[i]];
-	}
-	return result;
-}
-
-/**
  * Get the ordered cycle of recipe types for a given slot on a given day
  */
 export function getSlotCycle(slotIndex: number, daySeed: number): RecipeType[] {
 	const config = SLOT_CONFIGS[slotIndex];
 	const slotSeed = daySeed + SLOT_SEED_OFFSETS[slotIndex];
-	return deterministicShuffle([...config.eligibleTypes], slotSeed);
+	return RandomUtils.deterministicShuffle([...config.eligibleTypes], slotSeed);
 }
 
 function getCandidatesForSlotType(
@@ -61,7 +48,7 @@ function getCandidatesForSlotType(
 	return CookingRecipeDataController.instance
 		.getByTypeAndLevelRange(recipeType, slotConfig.minLevel, effectiveMaxLevel)
 		.filter(recipe => (recipe.discoveredByDefault || discoveredRecipeIds.includes(recipe.id))
-			&& (allowPetFoodRecipes || recipe.outputType !== "petFood"));
+			&& (allowPetFoodRecipes || recipe.outputType !== CookingOutputType.PET_FOOD));
 }
 
 function getBaseCandidateIndex(

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -1,9 +1,9 @@
 import {
-	SLOT_CONFIGS, SLOT_SEED_OFFSETS, RecipeType, SlotConfig
+	SLOT_CONFIGS, SLOT_SEED_OFFSETS, RecipeType, SlotConfig, MIN_GUARANTEED_PLAYER_LEVEL_RECIPES
 } from "../../../../Lib/src/constants/CookingConstants";
 import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
 import { getDayNumber } from "../../../../Lib/src/utils/TimeUtils";
-import { recipeRegistry } from "./RecipeRegistry";
+import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 
 interface SlotRecipeSelectionOptions {
 	slotIndex: number;
@@ -12,6 +12,7 @@ interface SlotRecipeSelectionOptions {
 	discoveredRecipeIds: string[];
 	excludedRecipeIds: ReadonlySet<string>;
 	allowPetFoodRecipes?: boolean;
+	maxRecipeLevel?: number;
 }
 
 interface UniqueSlotRecipesOptions {
@@ -20,6 +21,7 @@ interface UniqueSlotRecipesOptions {
 	daySeed: number;
 	discoveredRecipeIds: string[];
 	allowPetFoodRecipes?: boolean;
+	maxRecipeLevelWithoutPenalty?: number;
 }
 
 /**
@@ -49,11 +51,15 @@ function getCandidatesForSlotType(
 	slotIndex: number,
 	recipeType: RecipeType,
 	discoveredRecipeIds: string[],
-	allowPetFoodRecipes: boolean
+	allowPetFoodRecipes: boolean,
+	maxLevelOverride?: number
 ): CookingRecipe[] {
 	const slotConfig: SlotConfig = SLOT_CONFIGS[slotIndex];
-	return recipeRegistry
-		.getByTypeAndLevelRange(recipeType, slotConfig.minLevel, slotConfig.maxLevel)
+	const effectiveMaxLevel = maxLevelOverride !== undefined
+		? Math.min(maxLevelOverride, slotConfig.maxLevel)
+		: slotConfig.maxLevel;
+	return CookingRecipeDataController.instance
+		.getByTypeAndLevelRange(recipeType, slotConfig.minLevel, effectiveMaxLevel)
 		.filter(recipe => (recipe.discoveredByDefault || discoveredRecipeIds.includes(recipe.id))
 			&& (allowPetFoodRecipes || recipe.outputType !== "petFood"));
 }
@@ -89,7 +95,8 @@ export function getRecipeForSlotExcluding({
 	daySeed,
 	discoveredRecipeIds,
 	excludedRecipeIds,
-	allowPetFoodRecipes = true
+	allowPetFoodRecipes = true,
+	maxRecipeLevel
 }: SlotRecipeSelectionOptions): CookingRecipe | null {
 	const cycle = getSlotCycle(slotIndex, daySeed);
 	const startTypeIndex = furnacePosition % cycle.length;
@@ -97,7 +104,7 @@ export function getRecipeForSlotExcluding({
 	// Try each type in the cycle starting from the current rotation position
 	for (let offset = 0; offset < cycle.length; offset++) {
 		const recipeType = cycle[(startTypeIndex + offset) % cycle.length];
-		const candidates = getCandidatesForSlotType(slotIndex, recipeType, discoveredRecipeIds, allowPetFoodRecipes);
+		const candidates = getCandidatesForSlotType(slotIndex, recipeType, discoveredRecipeIds, allowPetFoodRecipes, maxRecipeLevel);
 
 		if (candidates.length === 0) {
 			continue;
@@ -118,12 +125,45 @@ export function getUniqueRecipesForSlots({
 	furnacePosition,
 	daySeed,
 	discoveredRecipeIds,
-	allowPetFoodRecipes = true
+	allowPetFoodRecipes = true,
+	maxRecipeLevelWithoutPenalty
 }: UniqueSlotRecipesOptions): Array<CookingRecipe | null> {
-	const recipes: Array<CookingRecipe | null> = [];
+	const slotCount = Math.min(cookingSlots, SLOT_CONFIGS.length);
+	const recipes: Array<CookingRecipe | null> = new Array(slotCount).fill(null);
 	const usedRecipeIds = new Set<string>();
 
-	for (let slotIndex = 0; slotIndex < cookingSlots && slotIndex < SLOT_CONFIGS.length; slotIndex++) {
+	// Pass 1: guarantee player-level recipes in eligible slots
+	if (maxRecipeLevelWithoutPenalty !== undefined) {
+		let guaranteed = 0;
+		for (let slotIndex = 0; slotIndex < slotCount && guaranteed < MIN_GUARANTEED_PLAYER_LEVEL_RECIPES; slotIndex++) {
+			if (SLOT_CONFIGS[slotIndex].minLevel > maxRecipeLevelWithoutPenalty) {
+				continue;
+			}
+
+			const recipe = getRecipeForSlotExcluding({
+				slotIndex,
+				furnacePosition,
+				daySeed,
+				discoveredRecipeIds,
+				excludedRecipeIds: usedRecipeIds,
+				allowPetFoodRecipes,
+				maxRecipeLevel: maxRecipeLevelWithoutPenalty
+			});
+
+			if (recipe) {
+				recipes[slotIndex] = recipe;
+				usedRecipeIds.add(recipe.id);
+				guaranteed++;
+			}
+		}
+	}
+
+	// Pass 2: normal selection for remaining slots
+	for (let slotIndex = 0; slotIndex < slotCount; slotIndex++) {
+		if (recipes[slotIndex] !== null) {
+			continue;
+		}
+
 		const recipe = getRecipeForSlotExcluding({
 			slotIndex,
 			furnacePosition,
@@ -133,7 +173,7 @@ export function getUniqueRecipesForSlots({
 			allowPetFoodRecipes
 		});
 
-		recipes.push(recipe);
+		recipes[slotIndex] = recipe;
 		if (recipe) {
 			usedRecipeIds.add(recipe.id);
 		}

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -1,0 +1,182 @@
+import {
+	SLOT_CONFIGS, SLOT_SEED_OFFSETS, RecipeType, SlotConfig
+} from "../../../../Lib/src/constants/CookingConstants";
+import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
+import { getDayNumber } from "../../../../Lib/src/utils/TimeUtils";
+import { recipeRegistry } from "./RecipeRegistry";
+
+interface SlotRecipeSelectionOptions {
+	slotIndex: number;
+	furnacePosition: number;
+	daySeed: number;
+	discoveredRecipeIds: string[];
+	excludedRecipeIds: ReadonlySet<string>;
+	allowPetFoodRecipes?: boolean;
+}
+
+interface UniqueSlotRecipesOptions {
+	cookingSlots: number;
+	furnacePosition: number;
+	daySeed: number;
+	discoveredRecipeIds: string[];
+	allowPetFoodRecipes?: boolean;
+}
+
+/**
+ * Deterministic Fisher-Yates shuffle using a simple LCG seeded PRNG
+ */
+function deterministicShuffle<T>(array: T[], seed: number): T[] {
+	const result = [...array];
+	let s = Math.abs(seed) | 1;
+	for (let i = result.length - 1; i > 0; i--) {
+		s = (s * 1103515245 + 12345) & 0x7fffffff;
+		const j = s % (i + 1);
+		[result[i], result[j]] = [result[j], result[i]];
+	}
+	return result;
+}
+
+/**
+ * Get the ordered cycle of recipe types for a given slot on a given day
+ */
+export function getSlotCycle(slotIndex: number, daySeed: number): RecipeType[] {
+	const config = SLOT_CONFIGS[slotIndex];
+	const slotSeed = daySeed + SLOT_SEED_OFFSETS[slotIndex];
+	return deterministicShuffle([...config.eligibleTypes], slotSeed);
+}
+
+function getCandidatesForSlotType(
+	slotIndex: number,
+	recipeType: RecipeType,
+	discoveredRecipeIds: string[],
+	allowPetFoodRecipes: boolean
+): CookingRecipe[] {
+	const slotConfig: SlotConfig = SLOT_CONFIGS[slotIndex];
+	return recipeRegistry
+		.getByTypeAndLevelRange(recipeType, slotConfig.minLevel, slotConfig.maxLevel)
+		.filter(recipe => (recipe.discoveredByDefault || discoveredRecipeIds.includes(recipe.id))
+			&& (allowPetFoodRecipes || recipe.outputType !== "petFood"));
+}
+
+function getBaseCandidateIndex(
+	slotIndex: number,
+	furnacePosition: number,
+	daySeed: number,
+	candidatesLength: number
+): number {
+	const tierSeed = daySeed * 7 + furnacePosition * 13 + slotIndex * 97;
+	return Math.abs(tierSeed) % candidatesLength;
+}
+
+function pickCandidateWithoutDuplicates(
+	candidates: CookingRecipe[],
+	baseIndex: number,
+	excludedRecipeIds: ReadonlySet<string>
+): CookingRecipe | null {
+	for (let offset = 0; offset < candidates.length; offset++) {
+		const candidate = candidates[(baseIndex + offset) % candidates.length];
+		if (!excludedRecipeIds.has(candidate.id)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+export function getRecipeForSlotExcluding({
+	slotIndex,
+	furnacePosition,
+	daySeed,
+	discoveredRecipeIds,
+	excludedRecipeIds,
+	allowPetFoodRecipes = true
+}: SlotRecipeSelectionOptions): CookingRecipe | null {
+	const cycle = getSlotCycle(slotIndex, daySeed);
+	const startTypeIndex = furnacePosition % cycle.length;
+
+	// Try each type in the cycle starting from the current rotation position
+	for (let offset = 0; offset < cycle.length; offset++) {
+		const recipeType = cycle[(startTypeIndex + offset) % cycle.length];
+		const candidates = getCandidatesForSlotType(slotIndex, recipeType, discoveredRecipeIds, allowPetFoodRecipes);
+
+		if (candidates.length === 0) {
+			continue;
+		}
+
+		const baseIndex = getBaseCandidateIndex(slotIndex, furnacePosition, daySeed, candidates.length);
+		const recipe = pickCandidateWithoutDuplicates(candidates, baseIndex, excludedRecipeIds);
+		if (recipe) {
+			return recipe;
+		}
+	}
+
+	return null;
+}
+
+export function getUniqueRecipesForSlots({
+	cookingSlots,
+	furnacePosition,
+	daySeed,
+	discoveredRecipeIds,
+	allowPetFoodRecipes = true
+}: UniqueSlotRecipesOptions): Array<CookingRecipe | null> {
+	const recipes: Array<CookingRecipe | null> = [];
+	const usedRecipeIds = new Set<string>();
+
+	for (let slotIndex = 0; slotIndex < cookingSlots && slotIndex < SLOT_CONFIGS.length; slotIndex++) {
+		const recipe = getRecipeForSlotExcluding({
+			slotIndex,
+			furnacePosition,
+			daySeed,
+			discoveredRecipeIds,
+			excludedRecipeIds: usedRecipeIds,
+			allowPetFoodRecipes
+		});
+
+		recipes.push(recipe);
+		if (recipe) {
+			usedRecipeIds.add(recipe.id);
+		}
+	}
+
+	return recipes;
+}
+
+/**
+ * Determine which recipe should appear in a slot at a given furnace position
+ */
+export function getRecipeForSlot(
+	slotIndex: number,
+	furnacePosition: number,
+	daySeed: number,
+	discoveredRecipeIds: string[]
+): CookingRecipe | null {
+	return getRecipeForSlotExcluding({
+		slotIndex,
+		furnacePosition,
+		daySeed,
+		discoveredRecipeIds,
+		excludedRecipeIds: new Set<string>()
+	});
+}
+
+/**
+ * Determine if a recipe in a slot should be secret (output hidden)
+ */
+export function isRecipeSecret(
+	slotIndex: number,
+	furnacePosition: number,
+	daySeed: number,
+	secretRate: number
+): boolean {
+	const secretSeed = daySeed * 11 + furnacePosition * 23 + slotIndex * 131;
+	const pseudoRandom = ((secretSeed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+	return pseudoRandom < secretRate;
+}
+
+/**
+ * Get the current day seed (changes daily)
+ */
+export function getCurrentDaySeed(): number {
+	return getDayNumber();
+}

--- a/Core/src/core/cooking/CookingSlotRotation.ts
+++ b/Core/src/core/cooking/CookingSlotRotation.ts
@@ -59,12 +59,19 @@ function getCandidatesForSlotType({
 			&& (allowPetFoodRecipes || recipe.outputType !== CookingOutputType.PET_FOOD));
 }
 
-function getBaseCandidateIndex(
-	slotIndex: number,
-	furnacePosition: number,
-	daySeed: number,
-	candidatesLength: number
-): number {
+interface BaseCandidateIndexOptions {
+	slotIndex: number;
+	furnacePosition: number;
+	daySeed: number;
+	candidatesLength: number;
+}
+
+function getBaseCandidateIndex({
+	slotIndex,
+	furnacePosition,
+	daySeed,
+	candidatesLength
+}: BaseCandidateIndexOptions): number {
 	const tierSeed = daySeed * 7 + furnacePosition * 13 + slotIndex * 97;
 	return Math.abs(tierSeed) % candidatesLength;
 }
@@ -111,7 +118,12 @@ export function getRecipeForSlotExcluding({
 			continue;
 		}
 
-		const baseIndex = getBaseCandidateIndex(slotIndex, furnacePosition, daySeed, candidates.length);
+		const baseIndex = getBaseCandidateIndex({
+			slotIndex,
+			furnacePosition,
+			daySeed,
+			candidatesLength: candidates.length
+		});
 		const recipe = pickCandidateWithoutDuplicates(candidates, baseIndex, excludedRecipeIds);
 		if (recipe) {
 			return recipe;
@@ -121,13 +133,21 @@ export function getRecipeForSlotExcluding({
 	return null;
 }
 
-function guaranteePlayerLevelRecipes(
-	recipes: Array<CookingRecipe | null>,
-	usedRecipeIds: Set<string>,
-	slotCount: number,
-	maxRecipeLevelWithoutPenalty: number | undefined,
-	baseOptions: Pick<SlotRecipeSelectionOptions, "furnacePosition" | "daySeed" | "discoveredRecipeIds" | "allowPetFoodRecipes">
-): void {
+interface GuaranteePlayerLevelRecipesOptions {
+	recipes: Array<CookingRecipe | null>;
+	usedRecipeIds: Set<string>;
+	slotCount: number;
+	maxRecipeLevelWithoutPenalty: number | undefined;
+	baseOptions: Pick<SlotRecipeSelectionOptions, "furnacePosition" | "daySeed" | "discoveredRecipeIds" | "allowPetFoodRecipes">;
+}
+
+function guaranteePlayerLevelRecipes({
+	recipes,
+	usedRecipeIds,
+	slotCount,
+	maxRecipeLevelWithoutPenalty,
+	baseOptions
+}: GuaranteePlayerLevelRecipesOptions): void {
 	if (maxRecipeLevelWithoutPenalty === undefined) {
 		return;
 	}
@@ -172,7 +192,9 @@ export function getUniqueRecipesForSlots({
 	};
 
 	// Pass 1: guarantee player-level recipes in eligible slots
-	guaranteePlayerLevelRecipes(recipes, usedRecipeIds, slotCount, maxRecipeLevelWithoutPenalty, baseOptions);
+	guaranteePlayerLevelRecipes({
+		recipes, usedRecipeIds, slotCount, maxRecipeLevelWithoutPenalty, baseOptions
+	});
 
 	// Pass 2: normal selection for remaining slots
 	for (let slotIndex = 0; slotIndex < slotCount; slotIndex++) {
@@ -198,30 +220,34 @@ export function getUniqueRecipesForSlots({
 /**
  * Determine which recipe should appear in a slot at a given furnace position
  */
-export function getRecipeForSlot(
-	slotIndex: number,
-	furnacePosition: number,
-	daySeed: number,
-	discoveredRecipeIds: string[]
-): CookingRecipe | null {
+export function getRecipeForSlot(options: {
+	slotIndex: number;
+	furnacePosition: number;
+	daySeed: number;
+	discoveredRecipeIds: string[];
+}): CookingRecipe | null {
 	return getRecipeForSlotExcluding({
-		slotIndex,
-		furnacePosition,
-		daySeed,
-		discoveredRecipeIds,
+		...options,
 		excludedRecipeIds: new Set<string>()
 	});
+}
+
+interface RecipeSecretOptions {
+	slotIndex: number;
+	furnacePosition: number;
+	daySeed: number;
+	secretRate: number;
 }
 
 /**
  * Determine if a recipe in a slot should be secret (output hidden)
  */
-export function isRecipeSecret(
-	slotIndex: number,
-	furnacePosition: number,
-	daySeed: number,
-	secretRate: number
-): boolean {
+export function isRecipeSecret({
+	slotIndex,
+	furnacePosition,
+	daySeed,
+	secretRate
+}: RecipeSecretOptions): boolean {
 	const secretSeed = daySeed * 11 + furnacePosition * 23 + slotIndex * 131;
 	const pseudoRandom = ((secretSeed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
 	return pseudoRandom < secretRate;

--- a/Core/src/core/database/game/models/PetEntity.ts
+++ b/Core/src/core/database/game/models/PetEntity.ts
@@ -67,6 +67,13 @@ export class PetEntity extends Model {
 	}
 
 	/**
+	 * Check if this pet can be fed with the given food type (not on cooldown + compatible diet)
+	 */
+	public canBeFed(petModel: Pet, foodType: string): boolean {
+		return this.getFeedCooldown(petModel) <= 0 && petModel.canEatFood(foodType);
+	}
+
+	/**
 	 * Get the love level of the pet
 	 */
 	public getLoveLevelNumber(): number {

--- a/Core/src/core/missions/Campaign.ts
+++ b/Core/src/core/missions/Campaign.ts
@@ -7,6 +7,8 @@ import { CampaignData } from "../../data/Campaign";
 import {
 	CompletedMission, MissionType
 } from "../../../../Lib/src/types/CompletedMission";
+import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
+import { RecipeDiscoverySource } from "../../../../Lib/src/constants/CookingConstants";
 
 export class Campaign {
 	private static maxCampaignCache = -1;
@@ -84,7 +86,11 @@ export class Campaign {
 		const campaign = await MissionSlots.getCampaignOfPlayer(player.id);
 		const missionsInfo = await PlayerMissionsInfos.getOfPlayer(player.id);
 		if (Campaign.hasNextCampaign(missionsInfo.campaignBlob)) {
-			return await this.completeCampaignMissions(player, missionsInfo, completedCampaign, campaign);
+			const completedMissions = await this.completeCampaignMissions(player, missionsInfo, completedCampaign, campaign);
+			if (completedMissions.length > 0) {
+				await RecipeDiscoveryService.discoverFromSource(player, RecipeDiscoverySource.CAMPAIGN_MILESTONE);
+			}
+			return completedMissions;
 		}
 		return [];
 	}

--- a/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
+++ b/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
@@ -93,6 +93,6 @@ export default class CoreHandlers {
 
 	@packetHandler(CommandReportCookingCraftReq)
 	async cookingCraft(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportCookingCraftReq): Promise<void> {
-		response.push(...await handleCookingCraft(context, context.keycloakId!, packet));
+		response.push(...await handleCookingCraft(context.keycloakId!, packet, context));
 	}
 }

--- a/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
+++ b/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
@@ -13,7 +13,11 @@ import {
 	CommandReportHomeChestActionReq, CommandReportHomeChestActionRes,
 	CommandReportGardenHarvestReq,
 	CommandReportGardenPlantReq,
-	CommandReportPlantTransferReq
+	CommandReportPlantTransferReq,
+	CommandReportCookingIgniteReq,
+	CommandReportCookingWoodConfirmRes,
+	CommandReportCookingReviveReq,
+	CommandReportCookingCraftReq
 } from "../../../../../Lib/src/packets/commands/CommandReportPacket";
 import {
 	handleChestAction
@@ -21,6 +25,9 @@ import {
 import {
 	handleGardenHarvest, handleGardenPlant, handlePlantTransfer
 } from "../../report/ReportGardenService";
+import {
+	handleCookingIgnite, handleCookingWoodConfirm, handleCookingRevive, handleCookingCraft
+} from "../../report/ReportCookingService";
 import {
 	CommandEquipActionReq, CommandEquipActionRes
 } from "../../../../../Lib/src/packets/commands/CommandEquipPacket";
@@ -67,5 +74,25 @@ export default class CoreHandlers {
 	@packetHandler(CommandReportPlantTransferReq)
 	async plantTransfer(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportPlantTransferReq): Promise<void> {
 		response.push(await handlePlantTransfer(context.keycloakId!, packet));
+	}
+
+	@packetHandler(CommandReportCookingIgniteReq)
+	async cookingIgnite(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportCookingIgniteReq): Promise<void> {
+		response.push(...await handleCookingIgnite(context.keycloakId!, packet));
+	}
+
+	@packetHandler(CommandReportCookingWoodConfirmRes)
+	async cookingWoodConfirm(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportCookingWoodConfirmRes): Promise<void> {
+		response.push(...await handleCookingWoodConfirm(context.keycloakId!, packet));
+	}
+
+	@packetHandler(CommandReportCookingReviveReq)
+	async cookingRevive(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportCookingReviveReq): Promise<void> {
+		response.push(...await handleCookingRevive(context.keycloakId!, packet));
+	}
+
+	@packetHandler(CommandReportCookingCraftReq)
+	async cookingCraft(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportCookingCraftReq): Promise<void> {
+		response.push(...await handleCookingCraft(context, context.keycloakId!, packet));
 	}
 }

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -10,7 +10,7 @@ import {
 } from "../database/game/models/Home";
 import { HomeLevel } from "../../../../Lib/src/types/HomeLevel";
 import {
-	ChestSlotsPerCategory, HomeFeatures
+	ChestSlotsPerCategory
 } from "../../../../Lib/src/types/HomeFeatures";
 import { ItemEnchantment } from "../../../../Lib/src/types/ItemEnchantment";
 import { MainItemDetails } from "../../../../Lib/src/types/MainItemDetails";
@@ -169,24 +169,11 @@ async function buildManageHomeData(params: {
 	const {
 		player, home, homeLevel, city
 	} = params;
+	const isHomeInCity = Boolean(home && home.cityId === city.id && homeLevel);
 	const homesCount = await Homes.getHomesCount();
 
-	// No home at all → only option is buying a new one
-	if (!home) {
-		return {
-			newPrice: city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount),
-			currentMoney: player.money
-		};
-	}
-
-	// Home but no level → should not happen, no options
-	if (!homeLevel) {
-		return undefined;
-	}
-
-	// Both home and homeLevel exist
 	const manageOptions = buildManageOptions({
-		home, homeLevel, city, player, homesCount
+		home, homeLevel, city, player, isHomeInCity, homesCount
 	});
 	if (manageOptions) {
 		return {
@@ -195,32 +182,37 @@ async function buildManageHomeData(params: {
 		};
 	}
 
-	return buildNoOptionsReason(home, homeLevel, city, player);
+	return homeLevel ? buildNoOptionsReason(isHomeInCity, homeLevel, player) : undefined;
 }
 
 interface ManageOptions {
 	newPrice?: number;
 	upgrade?: {
 		price: number;
-		oldFeatures: HomeFeatures;
-		newFeatures: HomeFeatures;
+		oldFeatures: HomeLevel["features"];
+		newFeatures: HomeLevel["features"];
 	};
 	movePrice?: number;
 }
 
-interface CityPopulationCount {
-	cityId: string;
-	count: number;
+interface BuildManageOptionsParams {
+	home: Home | null;
+	homeLevel: HomeLevel | null;
+	city: City;
+	player: Player;
+	isHomeInCity: boolean;
+	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>;
 }
 
 function getUpgradeOption(
 	homeLevel: HomeLevel,
 	player: Player,
+	isHomeInCity: boolean,
 	city: City,
-	homesCount: CityPopulationCount[]
+	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
 ): ManageOptions["upgrade"] {
 	const nextHomeUpgrade = HomeLevel.getNextUpgrade(homeLevel, player.level);
-	if (!nextHomeUpgrade) {
+	if (!nextHomeUpgrade || !isHomeInCity) {
 		return undefined;
 	}
 	return {
@@ -231,125 +223,63 @@ function getUpgradeOption(
 }
 
 function getMovePrice(
-	home: Home,
+	home: Home | null,
 	homeLevel: HomeLevel,
 	city: City,
-	homesCount: CityPopulationCount[]
+	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
 ): number | undefined {
-	if (home.cityId === city.id) {
+	const canMove = home && home.cityId !== city.id;
+	if (!canMove) {
 		return undefined;
 	}
 	return city.getHomeLevelPrice(homeLevel, homesCount);
 }
 
-interface BuildManageOptionsParams {
-	home: Home;
-	homeLevel: HomeLevel;
-	city: City;
-	player: Player;
-	homesCount: CityPopulationCount[];
-}
-
 function buildManageOptions({
-	home, homeLevel, city, player, homesCount
+	home,
+	homeLevel,
+	city,
+	player,
+	isHomeInCity,
+	homesCount
 }: BuildManageOptionsParams): ManageOptions | undefined {
-	const isHomeInCity = home.cityId === city.id;
-	const upgrade = isHomeInCity ? getUpgradeOption(homeLevel, player, city, homesCount) : undefined;
-	const movePrice = isHomeInCity ? undefined : getMovePrice(home, homeLevel, city, homesCount);
+	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
+	const upgrade = homeLevel ? getUpgradeOption(homeLevel, player, isHomeInCity, city, homesCount) : undefined;
+	const movePrice = homeLevel ? getMovePrice(home, homeLevel, city, homesCount) : undefined;
 
-	if (!upgrade && !movePrice) {
+	if (!newPrice && !upgrade && !movePrice) {
 		return undefined;
 	}
 	return {
+		newPrice,
 		upgrade,
 		movePrice
 	};
 }
 
 function buildNoOptionsReason(
-	home: Home,
+	isHomeInCity: boolean,
 	homeLevel: HomeLevel,
-	city: City,
 	player: Player
 ): HomeData["manage"] {
-	if (home.cityId !== city.id) {
+	if (!isHomeInCity) {
 		return undefined;
 	}
 
 	const nextLevel = HomeLevel.getNextLevelInfo(homeLevel);
 	return {
 		currentMoney: player.money,
-		isMaxLevel: nextLevel === null,
+		isMaxLevel: nextLevel === null || undefined,
 		requiredPlayerLevelForUpgrade: nextLevel && player.level < nextLevel.requiredPlayerLevel
 			? nextLevel.requiredPlayerLevel
 			: undefined
 	};
 }
 
-type UpgradeableItem = UpgradeStationData["upgradeableItems"][number];
-
-interface GetUpgradeableItemParams {
-	inventorySlot: InventorySlot;
-	playerMaterialMap: Map<number, number>;
-	maxUpgradeableRarity: number;
-	maxLevelAtHome: number;
-	player: Player;
-}
-
-function getUpgradeableItem({
-	inventorySlot, playerMaterialMap, maxUpgradeableRarity, maxLevelAtHome, player
-}: GetUpgradeableItemParams): UpgradeableItem | undefined {
-	if (!inventorySlot.isPrimaryEquipment()) {
-		return undefined;
-	}
-
-	const itemData = inventorySlot.isWeapon()
-		? WeaponDataController.instance.getById(inventorySlot.itemId)
-		: ArmorDataController.instance.getById(inventorySlot.itemId);
-
-	if (!itemData) {
-		return undefined;
-	}
-
-	const currentLevel = inventorySlot.itemLevel ?? 0;
-	if (currentLevel >= maxLevelAtHome || itemData.rarity > maxUpgradeableRarity) {
-		return undefined;
-	}
-
-	const nextLevel = currentLevel + 1;
-	const requiredMaterialsRaw = itemData.getUpgradeMaterials(nextLevel);
-
-	const materialAggregation = new Map<number, number>();
-	for (const material of requiredMaterialsRaw) {
-		const materialIdNum = parseInt(material.id, 10);
-		materialAggregation.set(materialIdNum, (materialAggregation.get(materialIdNum) ?? 0) + 1);
-	}
-
-	const requiredMaterials: UpgradeableItem["requiredMaterials"] = [];
-	let canUpgrade = true;
-
-	for (const [materialId, quantity] of materialAggregation) {
-		const playerQuantity = playerMaterialMap.get(materialId) ?? 0;
-		requiredMaterials.push({
-			materialId,
-			quantity,
-			playerQuantity
-		});
-		if (playerQuantity < quantity) {
-			canUpgrade = false;
-		}
-	}
-
-	return {
-		slot: inventorySlot.slot,
-		category: inventorySlot.itemCategory,
-		details: inventorySlot.itemWithDetails(player) as MainItemDetails,
-		nextLevel,
-		requiredMaterials,
-		canUpgrade
-	};
-}
-
+/**
+ * Build upgrade station data for the home feature in the city collector.
+ * Determines which items can be upgraded at home and their material requirements.
+ */
 export function buildUpgradeStationData(
 	playerInventory: InventorySlot[],
 	playerMaterialMap: Map<number, number>,
@@ -362,12 +292,64 @@ export function buildUpgradeStationData(
 	const upgradeableItems: UpgradeStationData["upgradeableItems"] = [];
 
 	for (const inventorySlot of playerInventory) {
-		const item = getUpgradeableItem({
-			inventorySlot, playerMaterialMap, maxUpgradeableRarity, maxLevelAtHome, player
-		});
-		if (item) {
-			upgradeableItems.push(item);
+		// Only process weapons and armors with a valid item
+		if (!inventorySlot.isPrimaryEquipment()) {
+			continue;
 		}
+
+		// Get the item data
+		const itemData = inventorySlot.isWeapon()
+			? WeaponDataController.instance.getById(inventorySlot.itemId)
+			: ArmorDataController.instance.getById(inventorySlot.itemId);
+
+		if (!itemData) {
+			continue;
+		}
+
+		// Check if item level allows upgrade at home (limited by home's maxItemUpgradeLevel)
+		const currentLevel = inventorySlot.itemLevel ?? 0;
+		if (currentLevel >= maxLevelAtHome) {
+			continue;
+		}
+
+		// Check if item rarity is allowed at this home level
+		if (itemData.rarity > maxUpgradeableRarity) {
+			continue;
+		}
+
+		const nextLevel = currentLevel + 1;
+		const requiredMaterialsRaw = itemData.getUpgradeMaterials(nextLevel);
+
+		// Aggregate materials (same material can appear multiple times)
+		const materialAggregation = new Map<number, number>();
+		for (const material of requiredMaterialsRaw) {
+			const materialIdNum = parseInt(material.id, 10);
+			materialAggregation.set(materialIdNum, (materialAggregation.get(materialIdNum) ?? 0) + 1);
+		}
+
+		const requiredMaterials: typeof upgradeableItems[number]["requiredMaterials"] = [];
+		let canUpgrade = true;
+
+		for (const [materialId, quantity] of materialAggregation) {
+			const playerQuantity = playerMaterialMap.get(materialId) ?? 0;
+			requiredMaterials.push({
+				materialId,
+				quantity,
+				playerQuantity
+			});
+			if (playerQuantity < quantity) {
+				canUpgrade = false;
+			}
+		}
+
+		upgradeableItems.push({
+			slot: inventorySlot.slot,
+			category: inventorySlot.itemCategory,
+			details: inventorySlot.itemWithDetails(player) as MainItemDetails,
+			nextLevel,
+			requiredMaterials,
+			canUpgrade
+		});
 	}
 
 	return {

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -185,7 +185,9 @@ async function buildManageHomeData(params: {
 	}
 
 	// Both home and homeLevel exist
-	const manageOptions = buildManageOptions(home, homeLevel, city, player, homesCount);
+	const manageOptions = buildManageOptions({
+		home, homeLevel, city, player, homesCount
+	});
 	if (manageOptions) {
 		return {
 			...manageOptions,
@@ -206,13 +208,16 @@ interface ManageOptions {
 	movePrice?: number;
 }
 
-type HomesCount = Awaited<ReturnType<typeof Homes.getHomesCount>>;
+interface CityPopulationCount {
+	cityId: string;
+	count: number;
+}
 
 function getUpgradeOption(
 	homeLevel: HomeLevel,
 	player: Player,
 	city: City,
-	homesCount: HomesCount
+	homesCount: CityPopulationCount[]
 ): ManageOptions["upgrade"] {
 	const nextHomeUpgrade = HomeLevel.getNextUpgrade(homeLevel, player.level);
 	if (!nextHomeUpgrade) {
@@ -229,7 +234,7 @@ function getMovePrice(
 	home: Home,
 	homeLevel: HomeLevel,
 	city: City,
-	homesCount: HomesCount
+	homesCount: CityPopulationCount[]
 ): number | undefined {
 	if (home.cityId === city.id) {
 		return undefined;
@@ -237,13 +242,17 @@ function getMovePrice(
 	return city.getHomeLevelPrice(homeLevel, homesCount);
 }
 
-function buildManageOptions(
-	home: Home,
-	homeLevel: HomeLevel,
-	city: City,
-	player: Player,
-	homesCount: HomesCount
-): ManageOptions | undefined {
+interface BuildManageOptionsParams {
+	home: Home;
+	homeLevel: HomeLevel;
+	city: City;
+	player: Player;
+	homesCount: CityPopulationCount[];
+}
+
+function buildManageOptions({
+	home, homeLevel, city, player, homesCount
+}: BuildManageOptionsParams): ManageOptions | undefined {
 	const isHomeInCity = home.cityId === city.id;
 	const upgrade = isHomeInCity ? getUpgradeOption(homeLevel, player, city, homesCount) : undefined;
 	const movePrice = isHomeInCity ? undefined : getMovePrice(home, homeLevel, city, homesCount);
@@ -279,13 +288,17 @@ function buildNoOptionsReason(
 
 type UpgradeableItem = UpgradeStationData["upgradeableItems"][number];
 
-function getUpgradeableItem(
-	inventorySlot: InventorySlot,
-	playerMaterialMap: Map<number, number>,
-	maxUpgradeableRarity: number,
-	maxLevelAtHome: number,
-	player: Player
-): UpgradeableItem | undefined {
+interface GetUpgradeableItemParams {
+	inventorySlot: InventorySlot;
+	playerMaterialMap: Map<number, number>;
+	maxUpgradeableRarity: number;
+	maxLevelAtHome: number;
+	player: Player;
+}
+
+function getUpgradeableItem({
+	inventorySlot, playerMaterialMap, maxUpgradeableRarity, maxLevelAtHome, player
+}: GetUpgradeableItemParams): UpgradeableItem | undefined {
 	if (!inventorySlot.isPrimaryEquipment()) {
 		return undefined;
 	}
@@ -349,7 +362,9 @@ export function buildUpgradeStationData(
 	const upgradeableItems: UpgradeStationData["upgradeableItems"] = [];
 
 	for (const inventorySlot of playerInventory) {
-		const item = getUpgradeableItem(inventorySlot, playerMaterialMap, maxUpgradeableRarity, maxLevelAtHome, player);
+		const item = getUpgradeableItem({
+			inventorySlot, playerMaterialMap, maxUpgradeableRarity, maxLevelAtHome, player
+		});
 		if (item) {
 			upgradeableItems.push(item);
 		}

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -187,14 +187,30 @@ async function buildManageHomeData(params: {
 
 	const hasManageOptions = newPrice || upgrade || movePrice;
 
-	return hasManageOptions
-		? {
+	if (hasManageOptions) {
+		return {
 			newPrice,
 			upgrade,
 			movePrice,
 			currentMoney: player.money
-		}
-		: undefined;
+		};
+	}
+
+	// When no actions are available but player has a home in this city, provide reason
+	if (isHomeInCity && homeLevel) {
+		const nextLevel = HomeLevel.getNextLevelInfo(homeLevel);
+		const isMaxLevel = nextLevel === null;
+
+		return {
+			currentMoney: player.money,
+			isMaxLevel: isMaxLevel || undefined,
+			requiredPlayerLevelForUpgrade: nextLevel && player.level < nextLevel.requiredPlayerLevel
+				? nextLevel.requiredPlayerLevel
+				: undefined
+		};
+	}
+
+	return undefined;
 }
 
 /**

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -47,8 +47,13 @@ export { handleChestAction } from "./ReportCityChestService";
 // Type aliases for commonly used nested types from ReactionCollectorCityData
 type EnchanterData = NonNullable<ReactionCollectorCityData["enchanter"]>;
 type HomeData = ReactionCollectorCityData["home"];
-type UpgradeStationData = NonNullable<NonNullable<HomeData["owned"]>["upgradeStation"]>;
-type ChestData = NonNullable<NonNullable<HomeData["owned"]>["chest"]>;
+type OwnedHomeData = NonNullable<HomeData["owned"]>;
+type UpgradeStationData = NonNullable<OwnedHomeData["upgradeStation"]>;
+type ChestData = NonNullable<OwnedHomeData["chest"]>;
+type HomesCount = {
+	cityId: string;
+	count: number;
+}[];
 
 /**
  * Build enchanter data for the city reaction collector
@@ -201,16 +206,16 @@ interface BuildManageOptionsParams {
 	city: City;
 	player: Player;
 	isHomeInCity: boolean;
-	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>;
+	homesCount: HomesCount;
 }
 
-function getUpgradeOption(
-	homeLevel: HomeLevel,
-	player: Player,
-	isHomeInCity: boolean,
-	city: City,
-	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
-): ManageOptions["upgrade"] {
+function getUpgradeOption(params: BuildManageOptionsParams): ManageOptions["upgrade"] {
+	const {
+		homeLevel, player, isHomeInCity, city, homesCount
+	} = params;
+	if (!homeLevel) {
+		return undefined;
+	}
 	const nextHomeUpgrade = HomeLevel.getNextUpgrade(homeLevel, player.level);
 	if (!nextHomeUpgrade || !isHomeInCity) {
 		return undefined;
@@ -222,30 +227,24 @@ function getUpgradeOption(
 	};
 }
 
-function getMovePrice(
-	home: Home | null,
-	homeLevel: HomeLevel,
-	city: City,
-	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
-): number | undefined {
-	const canMove = home && home.cityId !== city.id;
+function getMovePrice(params: BuildManageOptionsParams): number | undefined {
+	const {
+		home, homeLevel, city, homesCount
+	} = params;
+	const canMove = home && homeLevel && home.cityId !== city.id;
 	if (!canMove) {
 		return undefined;
 	}
 	return city.getHomeLevelPrice(homeLevel, homesCount);
 }
 
-function buildManageOptions({
-	home,
-	homeLevel,
-	city,
-	player,
-	isHomeInCity,
-	homesCount
-}: BuildManageOptionsParams): ManageOptions | undefined {
+function buildManageOptions(params: BuildManageOptionsParams): ManageOptions | undefined {
+	const {
+		home, city, homesCount
+	} = params;
 	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
-	const upgrade = homeLevel ? getUpgradeOption(homeLevel, player, isHomeInCity, city, homesCount) : undefined;
-	const movePrice = homeLevel ? getMovePrice(home, homeLevel, city, homesCount) : undefined;
+	const upgrade = getUpgradeOption(params);
+	const movePrice = getMovePrice(params);
 
 	if (!newPrice && !upgrade && !movePrice) {
 		return undefined;
@@ -269,7 +268,7 @@ function buildNoOptionsReason(
 	const nextLevel = HomeLevel.getNextLevelInfo(homeLevel);
 	return {
 		currentMoney: player.money,
-		isMaxLevel: nextLevel === null || undefined,
+		isMaxLevel: nextLevel === null,
 		requiredPlayerLevelForUpgrade: nextLevel && player.level < nextLevel.requiredPlayerLevel
 			? nextLevel.requiredPlayerLevel
 			: undefined

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -277,10 +277,64 @@ function buildNoOptionsReason(
 	};
 }
 
-/**
- * Build upgrade station data for the home feature in the city collector.
- * Determines which items can be upgraded at home and their material requirements.
- */
+function getUpgradeableItem(
+	inventorySlot: InventorySlot,
+	playerMaterialMap: Map<number, number>,
+	maxUpgradeableRarity: number,
+	maxLevelAtHome: number,
+	player: Player
+): UpgradeStationData["upgradeableItems"][number] | undefined {
+	if (!inventorySlot.isPrimaryEquipment()) {
+		return undefined;
+	}
+
+	const itemData = inventorySlot.isWeapon()
+		? WeaponDataController.instance.getById(inventorySlot.itemId)
+		: ArmorDataController.instance.getById(inventorySlot.itemId);
+
+	if (!itemData) {
+		return undefined;
+	}
+
+	const currentLevel = inventorySlot.itemLevel ?? 0;
+	if (currentLevel >= maxLevelAtHome || itemData.rarity > maxUpgradeableRarity) {
+		return undefined;
+	}
+
+	const nextLevel = currentLevel + 1;
+	const requiredMaterialsRaw = itemData.getUpgradeMaterials(nextLevel);
+
+	const materialAggregation = new Map<number, number>();
+	for (const material of requiredMaterialsRaw) {
+		const materialIdNum = parseInt(material.id, 10);
+		materialAggregation.set(materialIdNum, (materialAggregation.get(materialIdNum) ?? 0) + 1);
+	}
+
+	const requiredMaterials: UpgradeStationData["upgradeableItems"][number]["requiredMaterials"] = [];
+	let canUpgrade = true;
+
+	for (const [materialId, quantity] of materialAggregation) {
+		const playerQuantity = playerMaterialMap.get(materialId) ?? 0;
+		requiredMaterials.push({
+			materialId,
+			quantity,
+			playerQuantity
+		});
+		if (playerQuantity < quantity) {
+			canUpgrade = false;
+		}
+	}
+
+	return {
+		slot: inventorySlot.slot,
+		category: inventorySlot.itemCategory,
+		details: inventorySlot.itemWithDetails(player) as MainItemDetails,
+		nextLevel,
+		requiredMaterials,
+		canUpgrade
+	};
+}
+
 export function buildUpgradeStationData(
 	playerInventory: InventorySlot[],
 	playerMaterialMap: Map<number, number>,
@@ -293,64 +347,10 @@ export function buildUpgradeStationData(
 	const upgradeableItems: UpgradeStationData["upgradeableItems"] = [];
 
 	for (const inventorySlot of playerInventory) {
-		// Only process weapons and armors with a valid item
-		if (!inventorySlot.isPrimaryEquipment()) {
-			continue;
+		const item = getUpgradeableItem(inventorySlot, playerMaterialMap, maxUpgradeableRarity, maxLevelAtHome, player);
+		if (item) {
+			upgradeableItems.push(item);
 		}
-
-		// Get the item data
-		const itemData = inventorySlot.isWeapon()
-			? WeaponDataController.instance.getById(inventorySlot.itemId)
-			: ArmorDataController.instance.getById(inventorySlot.itemId);
-
-		if (!itemData) {
-			continue;
-		}
-
-		// Check if item level allows upgrade at home (limited by home's maxItemUpgradeLevel)
-		const currentLevel = inventorySlot.itemLevel ?? 0;
-		if (currentLevel >= maxLevelAtHome) {
-			continue;
-		}
-
-		// Check if item rarity is allowed at this home level
-		if (itemData.rarity > maxUpgradeableRarity) {
-			continue;
-		}
-
-		const nextLevel = currentLevel + 1;
-		const requiredMaterialsRaw = itemData.getUpgradeMaterials(nextLevel);
-
-		// Aggregate materials (same material can appear multiple times)
-		const materialAggregation = new Map<number, number>();
-		for (const material of requiredMaterialsRaw) {
-			const materialIdNum = parseInt(material.id, 10);
-			materialAggregation.set(materialIdNum, (materialAggregation.get(materialIdNum) ?? 0) + 1);
-		}
-
-		const requiredMaterials: typeof upgradeableItems[number]["requiredMaterials"] = [];
-		let canUpgrade = true;
-
-		for (const [materialId, quantity] of materialAggregation) {
-			const playerQuantity = playerMaterialMap.get(materialId) ?? 0;
-			requiredMaterials.push({
-				materialId,
-				quantity,
-				playerQuantity
-			});
-			if (playerQuantity < quantity) {
-				canUpgrade = false;
-			}
-		}
-
-		upgradeableItems.push({
-			slot: inventorySlot.slot,
-			category: inventorySlot.itemCategory,
-			details: inventorySlot.itemWithDetails(player) as MainItemDetails,
-			nextLevel,
-			requiredMaterials,
-			canUpgrade
-		});
 	}
 
 	return {

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -10,7 +10,7 @@ import {
 } from "../database/game/models/Home";
 import { HomeLevel } from "../../../../Lib/src/types/HomeLevel";
 import {
-	ChestSlotsPerCategory
+	ChestSlotsPerCategory, HomeFeatures
 } from "../../../../Lib/src/types/HomeFeatures";
 import { ItemEnchantment } from "../../../../Lib/src/types/ItemEnchantment";
 import { MainItemDetails } from "../../../../Lib/src/types/MainItemDetails";
@@ -169,12 +169,23 @@ async function buildManageHomeData(params: {
 	const {
 		player, home, homeLevel, city
 	} = params;
-	const isHomeInCity = Boolean(home && home.cityId === city.id && homeLevel);
 	const homesCount = await Homes.getHomesCount();
 
-	const manageOptions = buildManageOptions({
-		home, homeLevel, city, player, isHomeInCity, homesCount
-	});
+	// No home at all → only option is buying a new one
+	if (!home) {
+		return {
+			newPrice: city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount),
+			currentMoney: player.money
+		};
+	}
+
+	// Home but no level → should not happen, no options
+	if (!homeLevel) {
+		return undefined;
+	}
+
+	// Both home and homeLevel exist
+	const manageOptions = buildManageOptions(home, homeLevel, city, player, homesCount);
 	if (manageOptions) {
 		return {
 			...manageOptions,
@@ -182,100 +193,91 @@ async function buildManageHomeData(params: {
 		};
 	}
 
-	return buildNoOptionsReason(isHomeInCity, homeLevel, player);
+	return buildNoOptionsReason(home, homeLevel, city, player);
 }
 
 interface ManageOptions {
 	newPrice?: number;
 	upgrade?: {
 		price: number;
-		oldFeatures: HomeLevel["features"];
-		newFeatures: HomeLevel["features"];
+		oldFeatures: HomeFeatures;
+		newFeatures: HomeFeatures;
 	};
 	movePrice?: number;
 }
 
-interface BuildManageOptionsParams {
-	home: Home | null;
-	homeLevel: HomeLevel | null;
-	city: City;
-	player: Player;
-	isHomeInCity: boolean;
-	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>;
-}
+type HomesCount = Awaited<ReturnType<typeof Homes.getHomesCount>>;
 
 function getUpgradeOption(
-	homeLevel: HomeLevel | null,
+	homeLevel: HomeLevel,
 	player: Player,
-	isHomeInCity: boolean,
 	city: City,
-	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
+	homesCount: HomesCount
 ): ManageOptions["upgrade"] {
-	const nextHomeUpgrade = homeLevel ? HomeLevel.getNextUpgrade(homeLevel, player.level) : null;
-	if (!nextHomeUpgrade || !isHomeInCity) {
+	const nextHomeUpgrade = HomeLevel.getNextUpgrade(homeLevel, player.level);
+	if (!nextHomeUpgrade) {
 		return undefined;
 	}
 	return {
 		price: city.getHomeLevelPrice(nextHomeUpgrade, homesCount),
-		oldFeatures: homeLevel!.features,
+		oldFeatures: homeLevel.features,
 		newFeatures: nextHomeUpgrade.features
 	};
 }
 
 function getMovePrice(
-	home: Home | null,
-	homeLevel: HomeLevel | null,
+	home: Home,
+	homeLevel: HomeLevel,
 	city: City,
-	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
+	homesCount: HomesCount
 ): number | undefined {
-	const canMove = home && home.cityId !== city.id && homeLevel;
-	if (!canMove) {
+	if (home.cityId === city.id) {
 		return undefined;
 	}
-	return city.getHomeLevelPrice(homeLevel!, homesCount);
+	return city.getHomeLevelPrice(homeLevel, homesCount);
 }
 
-function buildManageOptions({
-	home,
-	homeLevel,
-	city,
-	player,
-	isHomeInCity,
-	homesCount
-}: BuildManageOptionsParams): ManageOptions | undefined {
-	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
-	const upgrade = getUpgradeOption(homeLevel, player, isHomeInCity, city, homesCount);
-	const movePrice = getMovePrice(home, homeLevel, city, homesCount);
-	const hasAnyOption = newPrice || upgrade || movePrice;
+function buildManageOptions(
+	home: Home,
+	homeLevel: HomeLevel,
+	city: City,
+	player: Player,
+	homesCount: HomesCount
+): ManageOptions | undefined {
+	const isHomeInCity = home.cityId === city.id;
+	const upgrade = isHomeInCity ? getUpgradeOption(homeLevel, player, city, homesCount) : undefined;
+	const movePrice = isHomeInCity ? undefined : getMovePrice(home, homeLevel, city, homesCount);
 
-	if (!hasAnyOption) {
+	if (!upgrade && !movePrice) {
 		return undefined;
 	}
 	return {
-		newPrice,
 		upgrade,
 		movePrice
 	};
 }
 
 function buildNoOptionsReason(
-	isHomeInCity: boolean,
-	homeLevel: HomeLevel | null,
+	home: Home,
+	homeLevel: HomeLevel,
+	city: City,
 	player: Player
 ): HomeData["manage"] {
-	if (!isHomeInCity || !homeLevel) {
+	if (home.cityId !== city.id) {
 		return undefined;
 	}
 
 	const nextLevel = HomeLevel.getNextLevelInfo(homeLevel);
 	return {
 		currentMoney: player.money,
-		isMaxLevel: nextLevel === null || undefined,
+		isMaxLevel: nextLevel === null,
 		requiredPlayerLevelForUpgrade: nextLevel && player.level < nextLevel.requiredPlayerLevel
 			? nextLevel.requiredPlayerLevel
 			: undefined
 	};
 }
+
+type UpgradeableItem = UpgradeStationData["upgradeableItems"][number];
 
 function getUpgradeableItem(
 	inventorySlot: InventorySlot,
@@ -283,7 +285,7 @@ function getUpgradeableItem(
 	maxUpgradeableRarity: number,
 	maxLevelAtHome: number,
 	player: Player
-): UpgradeStationData["upgradeableItems"][number] | undefined {
+): UpgradeableItem | undefined {
 	if (!inventorySlot.isPrimaryEquipment()) {
 		return undefined;
 	}
@@ -310,7 +312,7 @@ function getUpgradeableItem(
 		materialAggregation.set(materialIdNum, (materialAggregation.get(materialIdNum) ?? 0) + 1);
 	}
 
-	const requiredMaterials: UpgradeStationData["upgradeableItems"][number]["requiredMaterials"] = [];
+	const requiredMaterials: UpgradeableItem["requiredMaterials"] = [];
 	let canUpgrade = true;
 
 	for (const [materialId, quantity] of materialAggregation) {

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -172,7 +172,9 @@ async function buildManageHomeData(params: {
 	const isHomeInCity = Boolean(home && home.cityId === city.id && homeLevel);
 	const homesCount = await Homes.getHomesCount();
 
-	const manageOptions = buildManageOptions(home, homeLevel, city, player, isHomeInCity, homesCount);
+	const manageOptions = buildManageOptions({
+		home, homeLevel, city, player, isHomeInCity, homesCount
+	});
 	if (manageOptions) {
 		return {
 			...manageOptions,
@@ -193,26 +195,57 @@ interface ManageOptions {
 	movePrice?: number;
 }
 
-function buildManageOptions(
+interface BuildManageOptionsParams {
+	home: Home | null;
+	homeLevel: HomeLevel | null;
+	city: City;
+	player: Player;
+	isHomeInCity: boolean;
+	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>;
+}
+
+function getUpgradeOption(
+	homeLevel: HomeLevel | null,
+	player: Player,
+	isHomeInCity: boolean,
+	city: City,
+	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
+): ManageOptions["upgrade"] {
+	const nextHomeUpgrade = homeLevel ? HomeLevel.getNextUpgrade(homeLevel, player.level) : null;
+	if (!nextHomeUpgrade || !isHomeInCity) {
+		return undefined;
+	}
+	return {
+		price: city.getHomeLevelPrice(nextHomeUpgrade, homesCount),
+		oldFeatures: homeLevel!.features,
+		newFeatures: nextHomeUpgrade.features
+	};
+}
+
+function getMovePrice(
 	home: Home | null,
 	homeLevel: HomeLevel | null,
 	city: City,
-	player: Player,
-	isHomeInCity: boolean,
 	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
-): ManageOptions | undefined {
-	const nextHomeUpgrade = homeLevel ? HomeLevel.getNextUpgrade(homeLevel, player.level) : null;
+): number | undefined {
+	const canMove = home && home.cityId !== city.id && homeLevel;
+	if (!canMove) {
+		return undefined;
+	}
+	return city.getHomeLevelPrice(homeLevel!, homesCount);
+}
+
+function buildManageOptions({
+	home,
+	homeLevel,
+	city,
+	player,
+	isHomeInCity,
+	homesCount
+}: BuildManageOptionsParams): ManageOptions | undefined {
 	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
-	const upgrade = nextHomeUpgrade && isHomeInCity
-		? {
-			price: city.getHomeLevelPrice(nextHomeUpgrade, homesCount),
-			oldFeatures: homeLevel!.features,
-			newFeatures: nextHomeUpgrade.features
-		}
-		: undefined;
-	const movePrice = home && home.cityId !== city.id && homeLevel
-		? city.getHomeLevelPrice(homeLevel, homesCount)
-		: undefined;
+	const upgrade = getUpgradeOption(homeLevel, player, isHomeInCity, city, homesCount);
+	const movePrice = getMovePrice(home, homeLevel, city, homesCount);
 
 	if (!newPrice && !upgrade && !movePrice) {
 		return undefined;

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -200,22 +200,19 @@ interface ManageOptions {
 	movePrice?: number;
 }
 
-interface BuildManageOptionsParams {
-	home: Home | null;
-	homeLevel: HomeLevel | null;
+interface ExistingHomeManageParams {
+	home: Home;
+	homeLevel: HomeLevel;
 	city: City;
 	player: Player;
 	isHomeInCity: boolean;
 	homesCount: HomesCount;
 }
 
-function getUpgradeOption(params: BuildManageOptionsParams): ManageOptions["upgrade"] {
+function getUpgradeOption(params: ExistingHomeManageParams): ManageOptions["upgrade"] {
 	const {
 		homeLevel, player, isHomeInCity, city, homesCount
 	} = params;
-	if (!homeLevel) {
-		return undefined;
-	}
 	const nextHomeUpgrade = HomeLevel.getNextUpgrade(homeLevel, player.level);
 	if (!nextHomeUpgrade || !isHomeInCity) {
 		return undefined;
@@ -227,33 +224,52 @@ function getUpgradeOption(params: BuildManageOptionsParams): ManageOptions["upgr
 	};
 }
 
-function getMovePrice(params: BuildManageOptionsParams): number | undefined {
+function getMovePrice(params: ExistingHomeManageParams): number | undefined {
 	const {
 		home, homeLevel, city, homesCount
 	} = params;
-	const canMove = home && homeLevel && home.cityId !== city.id;
-	if (!canMove) {
+	if (home.cityId === city.id) {
 		return undefined;
 	}
 	return city.getHomeLevelPrice(homeLevel, homesCount);
 }
 
-function buildManageOptions(params: BuildManageOptionsParams): ManageOptions | undefined {
-	const {
-		home, city, homesCount
-	} = params;
-	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
+function buildExistingHomeOptions(params: ExistingHomeManageParams): ManageOptions | undefined {
 	const upgrade = getUpgradeOption(params);
 	const movePrice = getMovePrice(params);
 
-	if (!newPrice && !upgrade && !movePrice) {
+	if (!upgrade && !movePrice) {
 		return undefined;
 	}
 	return {
-		newPrice,
 		upgrade,
 		movePrice
 	};
+}
+
+function buildManageOptions(params: {
+	home: Home | null;
+	homeLevel: HomeLevel | null;
+	city: City;
+	player: Player;
+	isHomeInCity: boolean;
+	homesCount: HomesCount;
+}): ManageOptions | undefined {
+	const {
+		home, homeLevel, city, player, isHomeInCity, homesCount
+	} = params;
+
+	if (!home) {
+		return { newPrice: city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount) };
+	}
+
+	if (!homeLevel) {
+		return undefined;
+	}
+
+	return buildExistingHomeOptions({
+		home, homeLevel, city, player, isHomeInCity, homesCount
+	});
 }
 
 function buildNoOptionsReason(

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -246,8 +246,9 @@ function buildManageOptions({
 	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
 	const upgrade = getUpgradeOption(homeLevel, player, isHomeInCity, city, homesCount);
 	const movePrice = getMovePrice(home, homeLevel, city, homesCount);
+	const hasAnyOption = newPrice || upgrade || movePrice;
 
-	if (!newPrice && !upgrade && !movePrice) {
+	if (!hasAnyOption) {
 		return undefined;
 	}
 	return {

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -170,9 +170,38 @@ async function buildManageHomeData(params: {
 		player, home, homeLevel, city
 	} = params;
 	const isHomeInCity = Boolean(home && home.cityId === city.id && homeLevel);
-	const nextHomeUpgrade = homeLevel ? HomeLevel.getNextUpgrade(homeLevel, player.level) : null;
 	const homesCount = await Homes.getHomesCount();
 
+	const manageOptions = buildManageOptions(home, homeLevel, city, player, isHomeInCity, homesCount);
+	if (manageOptions) {
+		return {
+			...manageOptions,
+			currentMoney: player.money
+		};
+	}
+
+	return buildNoOptionsReason(isHomeInCity, homeLevel, player);
+}
+
+interface ManageOptions {
+	newPrice?: number;
+	upgrade?: {
+		price: number;
+		oldFeatures: HomeLevel["features"];
+		newFeatures: HomeLevel["features"];
+	};
+	movePrice?: number;
+}
+
+function buildManageOptions(
+	home: Home | null,
+	homeLevel: HomeLevel | null,
+	city: City,
+	player: Player,
+	isHomeInCity: boolean,
+	homesCount: Awaited<ReturnType<typeof Homes.getHomesCount>>
+): ManageOptions | undefined {
+	const nextHomeUpgrade = homeLevel ? HomeLevel.getNextUpgrade(homeLevel, player.level) : null;
 	const newPrice = home ? undefined : city.getHomeLevelPrice(HomeLevel.getInitialLevel(), homesCount);
 	const upgrade = nextHomeUpgrade && isHomeInCity
 		? {
@@ -185,32 +214,33 @@ async function buildManageHomeData(params: {
 		? city.getHomeLevelPrice(homeLevel, homesCount)
 		: undefined;
 
-	const hasManageOptions = newPrice || upgrade || movePrice;
+	if (!newPrice && !upgrade && !movePrice) {
+		return undefined;
+	}
+	return {
+		newPrice,
+		upgrade,
+		movePrice
+	};
+}
 
-	if (hasManageOptions) {
-		return {
-			newPrice,
-			upgrade,
-			movePrice,
-			currentMoney: player.money
-		};
+function buildNoOptionsReason(
+	isHomeInCity: boolean,
+	homeLevel: HomeLevel | null,
+	player: Player
+): HomeData["manage"] {
+	if (!isHomeInCity || !homeLevel) {
+		return undefined;
 	}
 
-	// When no actions are available but player has a home in this city, provide reason
-	if (isHomeInCity && homeLevel) {
-		const nextLevel = HomeLevel.getNextLevelInfo(homeLevel);
-		const isMaxLevel = nextLevel === null;
-
-		return {
-			currentMoney: player.money,
-			isMaxLevel: isMaxLevel || undefined,
-			requiredPlayerLevelForUpgrade: nextLevel && player.level < nextLevel.requiredPlayerLevel
-				? nextLevel.requiredPlayerLevel
-				: undefined
-		};
-	}
-
-	return undefined;
+	const nextLevel = HomeLevel.getNextLevelInfo(homeLevel);
+	return {
+		currentMoney: player.money,
+		isMaxLevel: nextLevel === null || undefined,
+		requiredPlayerLevelForUpgrade: nextLevel && player.level < nextLevel.requiredPlayerLevel
+			? nextLevel.requiredPlayerLevel
+			: undefined
+	};
 }
 
 /**

--- a/Core/src/core/report/ReportCityShopService.ts
+++ b/Core/src/core/report/ReportCityShopService.ts
@@ -5,7 +5,9 @@ import {
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { ShopItemType } from "../../../../Lib/src/constants/LogsConstants";
 import { ShopUtils } from "../utils/ShopUtils";
-import { ShopCurrency } from "../../../../Lib/src/constants/ShopConstants";
+import {
+	ShopConstants, ShopCurrency
+} from "../../../../Lib/src/constants/ShopConstants";
 import {
 	ShopCategory, CommandShopNoPlantSlotAvailable
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorShop";
@@ -33,7 +35,9 @@ import {
 	PlantConstants, PlantType
 } from "../../../../Lib/src/constants/PlantConstants";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
-import { MaterialDataController } from "../../data/Material";
+import {
+	Material, MaterialDataController
+} from "../../data/Material";
 import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
 import { MaterialType } from "../../../../Lib/src/types/MaterialType";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
@@ -241,7 +245,22 @@ export async function openHerbalist(player: Player, context: PacketContext, resp
 }
 
 /**
- * Open the lumberjack shop for the player (wood bundles)
+ * Distribute a total quantity randomly among a list of wood materials and give them to the player.
+ */
+async function distributeWoodRandomly(playerId: number, woods: Material[], totalQuantity: number): Promise<void> {
+	const distribution = new Map<number, number>();
+	for (let i = 0; i < totalQuantity; i++) {
+		const picked = RandomUtils.crowniclesRandom.pick(woods);
+		const materialId = parseInt(picked.id as string, 10);
+		distribution.set(materialId, (distribution.get(materialId) ?? 0) + 1);
+	}
+	for (const [materialId, quantity] of distribution) {
+		await Materials.giveMaterial(playerId, materialId, quantity);
+	}
+}
+
+/**
+ * Open the lumberjack shop for the player (wood by rarity with quantity selection)
  */
 export async function openLumberjack(player: Player, context: PacketContext, response: CrowniclesPacket[]): Promise<void> {
 	const woodMaterials = MaterialDataController.instance.getMaterialsFromType(MaterialType.WOOD);
@@ -256,31 +275,28 @@ export async function openLumberjack(player: Player, context: PacketContext, res
 			items: [
 				{
 					id: ShopItemType.WOOD_COMMON_BUNDLE,
-					price: 50,
-					amounts: [1],
-					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number): Promise<boolean> => {
-						const picked = RandomUtils.crowniclesRandom.pick(commonWoods);
-						await Materials.giveMaterial(playerId, parseInt(picked.id as string, 10), 5);
+					price: ShopConstants.LUMBERJACK_PRICES.COMMON,
+					amounts: [...ShopConstants.LUMBERJACK_AMOUNTS],
+					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number, _context: PacketContext, amount: number): Promise<boolean> => {
+						await distributeWoodRandomly(playerId, commonWoods, amount);
 						return true;
 					}
 				},
 				{
 					id: ShopItemType.WOOD_UNCOMMON_BUNDLE,
-					price: 100,
-					amounts: [1],
-					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number): Promise<boolean> => {
-						const picked = RandomUtils.crowniclesRandom.pick(uncommonWoods);
-						await Materials.giveMaterial(playerId, parseInt(picked.id as string, 10), 3);
+					price: ShopConstants.LUMBERJACK_PRICES.UNCOMMON,
+					amounts: [...ShopConstants.LUMBERJACK_AMOUNTS],
+					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number, _context: PacketContext, amount: number): Promise<boolean> => {
+						await distributeWoodRandomly(playerId, uncommonWoods, amount);
 						return true;
 					}
 				},
 				{
 					id: ShopItemType.WOOD_RARE_BUNDLE,
-					price: 200,
-					amounts: [1],
-					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number): Promise<boolean> => {
-						const picked = RandomUtils.crowniclesRandom.pick(rareWoods);
-						await Materials.giveMaterial(playerId, parseInt(picked.id as string, 10), 2);
+					price: ShopConstants.LUMBERJACK_PRICES.RARE,
+					amounts: [...ShopConstants.LUMBERJACK_AMOUNTS],
+					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number, _context: PacketContext, amount: number): Promise<boolean> => {
+						await distributeWoodRandomly(playerId, rareWoods, amount);
 						return true;
 					}
 				}

--- a/Core/src/core/report/ReportCityShopService.ts
+++ b/Core/src/core/report/ReportCityShopService.ts
@@ -33,6 +33,11 @@ import {
 	PlantConstants, PlantType
 } from "../../../../Lib/src/constants/PlantConstants";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { MaterialDataController } from "../../data/Material";
+import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
+import { MaterialType } from "../../../../Lib/src/types/MaterialType";
+import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
+import { Materials } from "../database/game/models/Material";
 
 /**
  * Parameters for handleCityShopReaction
@@ -69,6 +74,9 @@ export async function handleCityShopReaction(params: CityShopReactionParams): Pr
 			break;
 		case "herbalist":
 			await openHerbalist(player, context, response);
+			break;
+		case "lumberjack":
+			await openLumberjack(player, context, response);
 			break;
 		default:
 			CrowniclesLogger.error(`Unhandled city shop ${shopId}`);
@@ -229,5 +237,60 @@ export async function openHerbalist(player: Player, context: PacketContext, resp
 		additionalShopData: {
 			weeklyPlants: weeklyPlants.map((p: PlantType) => p.id)
 		}
+	});
+}
+
+/**
+ * Open the lumberjack shop for the player (wood bundles)
+ */
+export async function openLumberjack(player: Player, context: PacketContext, response: CrowniclesPacket[]): Promise<void> {
+	const woodMaterials = MaterialDataController.instance.getMaterialsFromType(MaterialType.WOOD);
+
+	const commonWoods = woodMaterials.filter(m => m.rarity === MaterialRarity.COMMON);
+	const uncommonWoods = woodMaterials.filter(m => m.rarity === MaterialRarity.UNCOMMON);
+	const rareWoods = woodMaterials.filter(m => m.rarity === MaterialRarity.RARE);
+
+	const shopCategories: ShopCategory[] = [
+		{
+			id: "woodBundles",
+			items: [
+				{
+					id: ShopItemType.WOOD_COMMON_BUNDLE,
+					price: 50,
+					amounts: [1],
+					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number): Promise<boolean> => {
+						const picked = RandomUtils.crowniclesRandom.pick(commonWoods);
+						await Materials.giveMaterial(playerId, parseInt(picked.id as string, 10), 5);
+						return true;
+					}
+				},
+				{
+					id: ShopItemType.WOOD_UNCOMMON_BUNDLE,
+					price: 100,
+					amounts: [1],
+					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number): Promise<boolean> => {
+						const picked = RandomUtils.crowniclesRandom.pick(uncommonWoods);
+						await Materials.giveMaterial(playerId, parseInt(picked.id as string, 10), 3);
+						return true;
+					}
+				},
+				{
+					id: ShopItemType.WOOD_RARE_BUNDLE,
+					price: 200,
+					amounts: [1],
+					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number): Promise<boolean> => {
+						const picked = RandomUtils.crowniclesRandom.pick(rareWoods);
+						await Materials.giveMaterial(playerId, parseInt(picked.id as string, 10), 2);
+						return true;
+					}
+				}
+			]
+		}
+	];
+
+	await ShopUtils.createAndSendShopCollector(context, response, {
+		shopCategories,
+		player,
+		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase)
 	});
 }

--- a/Core/src/core/report/ReportCityShopService.ts
+++ b/Core/src/core/report/ReportCityShopService.ts
@@ -89,10 +89,31 @@ export async function handleCityShopReaction(params: CityShopReactionParams): Pr
 }
 
 /**
+ * Open a gem-based shop with gemToMoneyRatio in additional data
+ */
+async function openGemShop(
+	player: Player,
+	context: PacketContext,
+	response: CrowniclesPacket[],
+	shopCategories: ShopCategory[],
+	additionalShopData?: Record<string, unknown>
+): Promise<void> {
+	await ShopUtils.createAndSendShopCollector(context, response, {
+		shopCategories,
+		player,
+		logger: crowniclesInstance?.logsDatabase.logMissionShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		additionalShopData: {
+			gemToMoneyRatio: calculateGemsToMoneyRatio(),
+			...additionalShopData
+		}
+	});
+}
+
+/**
  * Open the royal market shop for the player
  */
 export async function openRoyalMarket(player: Player, context: PacketContext, response: CrowniclesPacket[]): Promise<void> {
-	const shopCategories: ShopCategory[] = [
+	await openGemShop(player, context, response, [
 		{
 			id: "resources",
 			items: [
@@ -104,17 +125,7 @@ export async function openRoyalMarket(player: Player, context: PacketContext, re
 			id: "prestige",
 			items: [getAThousandPointsShopItem()]
 		}
-	];
-
-	await ShopUtils.createAndSendShopCollector(context, response, {
-		shopCategories,
-		player,
-		logger: crowniclesInstance?.logsDatabase.logMissionShopBuyout.bind(crowniclesInstance?.logsDatabase),
-		additionalShopData: {
-			currency: ShopCurrency.GEM,
-			gemToMoneyRatio: calculateGemsToMoneyRatio()
-		}
-	});
+	], { currency: ShopCurrency.GEM });
 }
 
 /**
@@ -151,7 +162,7 @@ export async function openGeneralShop(player: Player, context: PacketContext, re
  * Open the stock exchange shop for the player (money mouth badge + gem exchange rate info)
  */
 export async function openStockExchange(player: Player, context: PacketContext, response: CrowniclesPacket[]): Promise<void> {
-	const shopCategories: ShopCategory[] = [
+	await openGemShop(player, context, response, [
 		{
 			id: "permanentItem",
 			items: [getBadgeShopItem()]
@@ -160,16 +171,7 @@ export async function openStockExchange(player: Player, context: PacketContext, 
 			id: "services",
 			items: [getMarketAnalysisShopItem()]
 		}
-	];
-
-	await ShopUtils.createAndSendShopCollector(context, response, {
-		shopCategories,
-		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
-		additionalShopData: {
-			gemToMoneyRatio: calculateGemsToMoneyRatio()
-		}
-	});
+	]);
 }
 
 /**

--- a/Core/src/core/report/ReportCityShopService.ts
+++ b/Core/src/core/report/ReportCityShopService.ts
@@ -54,6 +54,15 @@ export interface CityShopReactionParams {
 	response: CrowniclesPacket[];
 }
 
+const SHOP_HANDLERS: Record<string, (player: Player, context: PacketContext, response: CrowniclesPacket[]) => Promise<void>> = {
+	royalMarket: openRoyalMarket,
+	generalShop: openGeneralShop,
+	stockExchange: openStockExchange,
+	tanner: openTanner,
+	herbalist: openHerbalist,
+	lumberjack: openLumberjack
+};
+
 export async function handleCityShopReaction(params: CityShopReactionParams): Promise<void> {
 	const {
 		player, city, shopId, context, response
@@ -63,41 +72,32 @@ export async function handleCityShopReaction(params: CityShopReactionParams): Pr
 		return;
 	}
 
-	switch (shopId) {
-		case "royalMarket":
-			await openRoyalMarket(player, context, response);
-			break;
-		case "generalShop":
-			await openGeneralShop(player, context, response);
-			break;
-		case "stockExchange":
-			await openStockExchange(player, context, response);
-			break;
-		case "tanner":
-			await openTanner(player, context, response);
-			break;
-		case "herbalist":
-			await openHerbalist(player, context, response);
-			break;
-		case "lumberjack":
-			await openLumberjack(player, context, response);
-			break;
-		default:
-			CrowniclesLogger.error(`Unhandled city shop ${shopId}`);
-			break;
+	const handler = SHOP_HANDLERS[shopId];
+	if (!handler) {
+		CrowniclesLogger.error(`Unhandled city shop ${shopId}`);
+		return;
 	}
+	await handler(player, context, response);
+}
+
+interface GemShopOptions {
+	player: Player;
+	context: PacketContext;
+	response: CrowniclesPacket[];
+	shopCategories: ShopCategory[];
+	additionalShopData?: Record<string, unknown>;
 }
 
 /**
  * Open a gem-based shop with gemToMoneyRatio in additional data
  */
-async function openGemShop(
-	player: Player,
-	context: PacketContext,
-	response: CrowniclesPacket[],
-	shopCategories: ShopCategory[],
-	additionalShopData?: Record<string, unknown>
-): Promise<void> {
+async function openGemShop({
+	player,
+	context,
+	response,
+	shopCategories,
+	additionalShopData
+}: GemShopOptions): Promise<void> {
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
@@ -113,19 +113,25 @@ async function openGemShop(
  * Open the royal market shop for the player
  */
 export async function openRoyalMarket(player: Player, context: PacketContext, response: CrowniclesPacket[]): Promise<void> {
-	await openGemShop(player, context, response, [
-		{
-			id: "resources",
-			items: [
-				getMoneyShopItem(),
-				getValuableItemShopItem()
-			]
-		},
-		{
-			id: "prestige",
-			items: [getAThousandPointsShopItem()]
-		}
-	], { currency: ShopCurrency.GEM });
+	await openGemShop({
+		player,
+		context,
+		response,
+		shopCategories: [
+			{
+				id: "resources",
+				items: [
+					getMoneyShopItem(),
+					getValuableItemShopItem()
+				]
+			},
+			{
+				id: "prestige",
+				items: [getAThousandPointsShopItem()]
+			}
+		],
+		additionalShopData: { currency: ShopCurrency.GEM }
+	});
 }
 
 /**
@@ -162,16 +168,21 @@ export async function openGeneralShop(player: Player, context: PacketContext, re
  * Open the stock exchange shop for the player (money mouth badge + gem exchange rate info)
  */
 export async function openStockExchange(player: Player, context: PacketContext, response: CrowniclesPacket[]): Promise<void> {
-	await openGemShop(player, context, response, [
-		{
-			id: "permanentItem",
-			items: [getBadgeShopItem()]
-		},
-		{
-			id: "services",
-			items: [getMarketAnalysisShopItem()]
-		}
-	]);
+	await openGemShop({
+		player,
+		context,
+		response,
+		shopCategories: [
+			{
+				id: "permanentItem",
+				items: [getBadgeShopItem()]
+			},
+			{
+				id: "services",
+				items: [getMarketAnalysisShopItem()]
+			}
+		]
+	});
 }
 
 /**

--- a/Core/src/core/report/ReportCityShopService.ts
+++ b/Core/src/core/report/ReportCityShopService.ts
@@ -289,7 +289,7 @@ export async function openLumberjack(player: Player, context: PacketContext, res
 				{
 					id: ShopItemType.WOOD_COMMON_BUNDLE,
 					price: ShopConstants.LUMBERJACK_PRICES.COMMON,
-					amounts: [...ShopConstants.LUMBERJACK_AMOUNTS],
+					amounts: ShopConstants.LUMBERJACK_AMOUNTS,
 					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number, _context: PacketContext, amount: number): Promise<boolean> => {
 						await distributeWoodRandomly(playerId, commonWoods, amount);
 						return true;
@@ -298,7 +298,7 @@ export async function openLumberjack(player: Player, context: PacketContext, res
 				{
 					id: ShopItemType.WOOD_UNCOMMON_BUNDLE,
 					price: ShopConstants.LUMBERJACK_PRICES.UNCOMMON,
-					amounts: [...ShopConstants.LUMBERJACK_AMOUNTS],
+					amounts: ShopConstants.LUMBERJACK_AMOUNTS,
 					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number, _context: PacketContext, amount: number): Promise<boolean> => {
 						await distributeWoodRandomly(playerId, uncommonWoods, amount);
 						return true;
@@ -307,7 +307,7 @@ export async function openLumberjack(player: Player, context: PacketContext, res
 				{
 					id: ShopItemType.WOOD_RARE_BUNDLE,
 					price: ShopConstants.LUMBERJACK_PRICES.RARE,
-					amounts: [...ShopConstants.LUMBERJACK_AMOUNTS],
+					amounts: ShopConstants.LUMBERJACK_AMOUNTS,
 					buyCallback: async (_buyResponse: CrowniclesPacket[], playerId: number, _context: PacketContext, amount: number): Promise<boolean> => {
 						await distributeWoodRandomly(playerId, rareWoods, amount);
 						return true;

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -381,6 +381,35 @@ interface CraftOutputParams {
 	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>;
 }
 
+function processSuccessfulCraftOutput(
+	context: PacketContext,
+	player: CraftOutputParams["player"],
+	recipe: CookingRecipeData,
+	guild: CraftOutputParams["guild"]
+): Promise<CraftOutputResult> | CraftOutputResult {
+	switch (recipe.outputType) {
+		case CookingOutputType.POTION:
+			return handlePotionOutput(context, player, recipe);
+		case CookingOutputType.PET_FOOD:
+			return guild ? handlePetFoodOutput(player, recipe, guild) : {};
+		case CookingOutputType.MATERIAL:
+			return handleMaterialOutput(player, recipe);
+		default:
+			return {};
+	}
+}
+
+function processFailedCraftOutput(
+	context: PacketContext,
+	player: CraftOutputParams["player"],
+	recipe: CookingRecipeData
+): Promise<CraftOutputResult> | CraftOutputResult {
+	if (recipe.outputType === CookingOutputType.POTION) {
+		return handleFailedPotionOutput(context, player);
+	}
+	return {};
+}
+
 function processCraftOutput({
 	context,
 	player,
@@ -388,19 +417,27 @@ function processCraftOutput({
 	result,
 	guild
 }: CraftOutputParams): Promise<CraftOutputResult> | CraftOutputResult {
-	if (result.success && recipe.outputType === CookingOutputType.POTION) {
-		return handlePotionOutput(context, player, recipe);
+	if (!result.success) {
+		return processFailedCraftOutput(context, player, recipe);
 	}
-	if (result.success && recipe.outputType === CookingOutputType.PET_FOOD && guild) {
-		return handlePetFoodOutput(player, recipe, guild);
+	return processSuccessfulCraftOutput(context, player, recipe, guild);
+}
+
+function validateCraftRequest(
+	slot: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>[number] | undefined,
+	recipe: CookingRecipeData | undefined,
+	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>
+): CookingCraftError | null {
+	if (!slot?.recipe || !recipe) {
+		return CookingCraftErrors.CRAFT_UNAVAILABLE;
 	}
-	if (result.success && recipe.outputType === CookingOutputType.MATERIAL) {
-		return handleMaterialOutput(player, recipe);
+	if (recipe.outputType === CookingOutputType.PET_FOOD && !guild) {
+		return CookingCraftErrors.GUILD_REQUIRED;
 	}
-	if (!result.success && recipe.outputType === CookingOutputType.POTION) {
-		return handleFailedPotionOutput(context, player);
+	if (!slot.recipe.canCraft) {
+		return CookingCraftErrors.CRAFT_UNAVAILABLE;
 	}
-	return {};
+	return null;
 }
 
 export async function handleCookingCraft(
@@ -420,55 +457,29 @@ export async function handleCookingCraft(
 	// Get the current slots to find the recipe at the requested slot
 	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
 	const slot = slots.find(s => s.slotIndex === packet.slotIndex);
-	if (!slot?.recipe) {
-		response.push(makePacket(CommandReportCookingCraftRes, {
-			success: false,
-			recipeId: "",
-			wasSecret: false,
-			outputType: CookingOutputType.POTION,
-			cookingXpGained: 0,
-			cookingLevelUp: false,
-			error: CookingCraftErrors.CRAFT_UNAVAILABLE,
-			updatedSlots: slots
-		}));
-		return response;
-	}
-
-	const recipe = CookingRecipeDataController.instance.getById(slot.recipe.id);
-	if (!recipe) {
-		return response;
-	}
-
+	const recipe = slot?.recipe ? CookingRecipeDataController.instance.getById(slot.recipe.id) : undefined;
 	const guild = await CookingService.getPlayerGuild(player);
-	if (recipe.outputType === CookingOutputType.PET_FOOD && !guild) {
+
+	const validationError = validateCraftRequest(slot, recipe, guild);
+	if (validationError) {
 		response.push(await buildBlockedCraftResponse({
 			player,
 			homeId: home.id,
 			cookingSlots,
-			error: CookingCraftErrors.GUILD_REQUIRED,
-			recipeId: recipe.id,
-			wasSecret: slot.recipe.isSecret,
-			outputType: recipe.outputType
+			error: validationError,
+			recipeId: recipe?.id ?? "",
+			wasSecret: slot?.recipe?.isSecret ?? false,
+			outputType: recipe?.outputType ?? CookingOutputType.POTION
 		}));
 		return response;
 	}
 
-	// Verify ingredients are still available
-	if (!slot.recipe.canCraft) {
-		response.push(await buildBlockedCraftResponse({
-			player,
-			homeId: home.id,
-			cookingSlots,
-			error: CookingCraftErrors.CRAFT_UNAVAILABLE,
-			recipeId: recipe.id,
-			wasSecret: slot.recipe.isSecret,
-			outputType: recipe.outputType
-		}));
-		return response;
-	}
+	// After validation, recipe and slot.recipe are guaranteed to exist
+	const validatedRecipe = recipe!;
+	const validatedSlotRecipe = slot!.recipe!;
 
 	// Execute the craft
-	const result = await CookingService.executeCraft(player, recipe, home.id);
+	const result = await CookingService.executeCraft(player, validatedRecipe, home.id);
 
 	// Determine and apply output
 	const {
@@ -476,7 +487,7 @@ export async function handleCookingCraft(
 	} = await processCraftOutput({
 		context,
 		player,
-		recipe,
+		recipe: validatedRecipe,
 		result,
 		guild
 	});
@@ -485,9 +496,9 @@ export async function handleCookingCraft(
 
 	response.push(makePacket(CommandReportCookingCraftRes, {
 		success: result.success,
-		recipeId: recipe.id,
-		wasSecret: slot.recipe.isSecret,
-		outputType: recipe.outputType,
+		recipeId: validatedRecipe.id,
+		wasSecret: validatedSlotRecipe.isSecret,
+		outputType: validatedRecipe.outputType,
 		...outputFields,
 		cookingXpGained: result.xpGained,
 		cookingLevelUp: result.levelUp,

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -2,6 +2,7 @@ import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { PetFood } from "../../../../Lib/src/types/PetFood";
+import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
 import {
 	CommandReportCookingIgniteReq,
 	CommandReportCookingIgniteRes,
@@ -35,13 +36,45 @@ import { giveItemToPlayer } from "../utils/ItemUtils";
 
 /**
  * Temporary in-memory store for pending wood confirmations.
- * Maps keycloakId → { materialId, rarity } so that when a player
+ * Maps keycloakId → { materialId, rarity, timeout } so that when a player
  * confirms, we know which wood was originally selected.
+ * Entries auto-expire after 5 minutes to prevent memory leaks.
  */
+const WOOD_CONFIRMATION_TTL_MS = 5 * 60 * 1000;
 const pendingWoodConfirmations = new Map<string, {
 	materialId: number;
-	rarity: number;
+	rarity: MaterialRarity;
+	timeout: ReturnType<typeof setTimeout>;
 }>();
+
+function setPendingWoodConfirmation(keycloakId: string, materialId: number, rarity: MaterialRarity): void {
+	const existing = pendingWoodConfirmations.get(keycloakId);
+	if (existing) {
+		clearTimeout(existing.timeout);
+	}
+	const timeout = setTimeout(() => pendingWoodConfirmations.delete(keycloakId), WOOD_CONFIRMATION_TTL_MS);
+	pendingWoodConfirmations.set(keycloakId, {
+		materialId,
+		rarity,
+		timeout
+	});
+}
+
+function consumePendingWoodConfirmation(keycloakId: string): {
+	materialId: number;
+	rarity: MaterialRarity;
+} | undefined {
+	const pending = pendingWoodConfirmations.get(keycloakId);
+	if (!pending) {
+		return undefined;
+	}
+	clearTimeout(pending.timeout);
+	pendingWoodConfirmations.delete(keycloakId);
+	return {
+		materialId: pending.materialId,
+		rarity: pending.rarity
+	};
+}
 
 async function getPlayerAndHome(keycloakId: string): Promise<{
 	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
@@ -138,10 +171,7 @@ async function igniteOrReviveFurnace(
 
 	// Non-common wood needs confirmation
 	if (wood.needsConfirmation) {
-		pendingWoodConfirmations.set(keycloakId, {
-			materialId: wood.materialId,
-			rarity: wood.rarity
-		});
+		setPendingWoodConfirmation(keycloakId, wood.materialId, wood.rarity);
 		response.push(makePacket(CommandReportCookingWoodConfirmReq, {
 			woodMaterialId: wood.materialId,
 			woodRarity: wood.rarity
@@ -179,8 +209,7 @@ export async function handleCookingWoodConfirm(
 	packet: CommandReportCookingWoodConfirmRes
 ): Promise<CrowniclesPacket[]> {
 	const response: CrowniclesPacket[] = [];
-	const pending = pendingWoodConfirmations.get(keycloakId);
-	pendingWoodConfirmations.delete(keycloakId);
+	const pending = consumePendingWoodConfirmation(keycloakId);
 
 	if (!packet.accepted || !pending) {
 		// Cancelled — return empty so Discord goes back to cooking menu

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -1,7 +1,6 @@
 import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
-import { PetFood } from "../../../../Lib/src/types/PetFood";
 import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
 import {
 	CommandReportCookingIgniteReq,
@@ -15,7 +14,10 @@ import {
 	CommandReportCookingCraftReq,
 	CommandReportCookingCraftRes,
 	CookingCraftErrors,
-	CookingCraftError
+	CookingCraftError,
+	CookingSlotData,
+	CraftPetFoodResult,
+	CraftMaterialResult
 } from "../../../../Lib/src/packets/commands/CommandReportPacket";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { CookingService } from "../cooking/CookingService";
@@ -28,6 +30,7 @@ import {
 import {
 	Home, Homes
 } from "../database/game/models/Home";
+import { Guild } from "../database/game/models/Guild";
 import { Materials } from "../database/game/models/Material";
 import { PotionDataController } from "../../data/Potion";
 import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
@@ -35,9 +38,7 @@ import {
 	getCookingGrade, FURNACE_MAX_USES_PER_DAY, CookingOutputType, CookingOutputTypeValue
 } from "../../../../Lib/src/constants/CookingConstants";
 import { giveItemToPlayer } from "../utils/ItemUtils";
-
-type CookingSlots = Awaited<ReturnType<typeof CookingService.getSlotRecipes>>;
-type PlayerGuild = NonNullable<Awaited<ReturnType<typeof CookingService.getPlayerGuild>>>;
+import { minutesToMilliseconds } from "../../../../Lib/src/utils/TimeUtils";
 
 interface PlayerAndHome {
 	player: Player;
@@ -51,7 +52,8 @@ interface PlayerAndHome {
  * confirms, we know which wood was originally selected.
  * Entries auto-expire after 5 minutes to prevent memory leaks.
  */
-const WOOD_CONFIRMATION_TTL_MS = 5 * 60 * 1000;
+const WOOD_CONFIRMATION_TTL_MINUTES = 5;
+const WOOD_CONFIRMATION_TTL_MS = minutesToMilliseconds(WOOD_CONFIRMATION_TTL_MINUTES);
 
 interface PendingWoodConfirmation {
 	materialId: number;
@@ -60,7 +62,7 @@ interface PendingWoodConfirmation {
 }
 
 const pendingWoodConfirmations = new Map<string, PendingWoodConfirmation & {
-	timeout: ReturnType<typeof setTimeout>;
+	timeout: NodeJS.Timeout;
 }>();
 
 function setPendingWoodConfirmation(keycloakId: string, materialId: number, rarity: MaterialRarity, isRevive: boolean): void {
@@ -109,7 +111,7 @@ async function getPlayerAndHome(keycloakId: string): Promise<PlayerAndHome | nul
 }
 
 interface IgniteOrReviveParams {
-	slots: CookingSlots;
+	slots: CookingSlotData[];
 	woodConsumed: boolean;
 	woodMaterialId: number;
 	furnaceUsesToday: number;
@@ -270,32 +272,18 @@ export async function handleCookingRevive(
 	return response;
 }
 
-interface PetFoodOutput {
-	type: PetFood;
-	quantity: number;
-	storedQuantity: number;
-	fedFromSurplus?: boolean;
-	surplusMaterialId?: number;
-	surplusMaterialQuantity?: number;
-}
-
-interface MaterialOutput {
-	materialId: number;
-	quantity: number;
-}
-
 interface CraftOutputResult {
 	potionId?: number;
-	petFood?: PetFoodOutput;
-	material?: MaterialOutput;
+	petFood?: CraftPetFoodResult;
+	material?: CraftMaterialResult;
 	failedPotionId?: number;
 	inventorySwapPackets?: CrowniclesPacket[];
 }
 
 async function handlePotionOutput(
-	context: PacketContext,
 	player: Player,
-	recipe: CookingRecipeData
+	recipe: CookingRecipeData,
+	context: PacketContext
 ): Promise<CraftOutputResult> {
 	if (recipe.potionNature === undefined || recipe.potionRarity === undefined) {
 		return {};
@@ -313,7 +301,7 @@ async function handlePotionOutput(
 async function handlePetFoodOutput(
 	player: Player,
 	recipe: CookingRecipeData,
-	guild: PlayerGuild
+	guild: Guild
 ): Promise<CraftOutputResult> {
 	if (!recipe.petFood) {
 		return {};
@@ -346,8 +334,8 @@ async function handlePetFoodSurplus(
 	player: Player,
 	recipe: CookingRecipeData,
 	surplus: number
-): Promise<Partial<PetFoodOutput>> {
-	const result: Partial<PetFoodOutput> = {};
+): Promise<Partial<CraftPetFoodResult>> {
+	const result: Partial<CraftPetFoodResult> = {};
 	let remaining = surplus;
 
 	const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFood!.type);
@@ -386,8 +374,8 @@ async function handleMaterialOutput(
 }
 
 async function handleFailedPotionOutput(
-	context: PacketContext,
-	player: Player
+	player: Player,
+	context: PacketContext
 ): Promise<CraftOutputResult> {
 	const noEffectPotion = PotionDataController.instance.getById(0);
 	if (!noEffectPotion) {
@@ -407,52 +395,44 @@ interface CraftOutputParams {
 	player: Player;
 	recipe: CookingRecipeData;
 	result: { success: boolean };
-	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>;
+	guild: Guild | null;
 }
 
-function processSuccessfulCraftOutput(
-	context: PacketContext,
-	player: Player,
-	recipe: CookingRecipeData,
-	guild: CraftOutputParams["guild"]
-): Promise<CraftOutputResult> | CraftOutputResult {
-	switch (recipe.outputType) {
-		case CookingOutputType.POTION:
-			return handlePotionOutput(context, player, recipe);
-		case CookingOutputType.PET_FOOD:
-			return guild ? handlePetFoodOutput(player, recipe, guild) : {};
-		case CookingOutputType.MATERIAL:
-			return handleMaterialOutput(player, recipe);
-		default:
-			return {};
-	}
-}
-
-function processFailedCraftOutput(
-	context: PacketContext,
-	player: Player,
-	recipe: CookingRecipeData
-): Promise<CraftOutputResult> | CraftOutputResult {
-	if (recipe.outputType === CookingOutputType.POTION) {
-		return handleFailedPotionOutput(context, player);
-	}
-	return {};
-}
-
-function processCraftOutput({
+function processSuccessfulCraftOutput({
 	context,
 	player,
 	recipe,
-	result,
 	guild
-}: CraftOutputParams): Promise<CraftOutputResult> | CraftOutputResult {
-	if (!result.success) {
-		return processFailedCraftOutput(context, player, recipe);
+}: Omit<CraftOutputParams, "result">): Promise<CraftOutputResult> {
+	switch (recipe.outputType) {
+		case CookingOutputType.POTION:
+			return handlePotionOutput(player, recipe, context);
+		case CookingOutputType.PET_FOOD:
+			return guild ? handlePetFoodOutput(player, recipe, guild) : Promise.resolve({});
+		case CookingOutputType.MATERIAL:
+			return handleMaterialOutput(player, recipe);
+		default:
+			return Promise.resolve({});
 	}
-	return processSuccessfulCraftOutput(context, player, recipe, guild);
 }
 
-type CookingSlotEntry = CookingSlots[number];
+function processFailedCraftOutput({
+	context,
+	player,
+	recipe
+}: Omit<CraftOutputParams, "result" | "guild">): Promise<CraftOutputResult> {
+	if (recipe.outputType === CookingOutputType.POTION) {
+		return handleFailedPotionOutput(player, context);
+	}
+	return Promise.resolve({});
+}
+
+function processCraftOutput(params: CraftOutputParams): Promise<CraftOutputResult> {
+	if (!params.result.success) {
+		return processFailedCraftOutput(params);
+	}
+	return processSuccessfulCraftOutput(params);
+}
 
 interface CraftErrorInfo {
 	recipeId: string;
@@ -461,7 +441,7 @@ interface CraftErrorInfo {
 }
 
 function getCraftErrorInfo(
-	slot: CookingSlotEntry | undefined,
+	slot: CookingSlotData | undefined,
 	recipe: CookingRecipeData | undefined
 ): CraftErrorInfo {
 	return {
@@ -472,9 +452,9 @@ function getCraftErrorInfo(
 }
 
 function validateCraftRequest(
-	slot: CookingSlotEntry | undefined,
+	slot: CookingSlotData | undefined,
 	recipe: CookingRecipeData | undefined,
-	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>
+	guild: Guild | null
 ): CookingCraftError | null {
 	if (!slot?.recipe || !recipe) {
 		return CookingCraftErrors.CRAFT_UNAVAILABLE;
@@ -489,9 +469,9 @@ function validateCraftRequest(
 }
 
 export async function handleCookingCraft(
-	context: PacketContext,
 	keycloakId: string,
-	packet: CommandReportCookingCraftReq
+	packet: CommandReportCookingCraftReq,
+	context: PacketContext
 ): Promise<CrowniclesPacket[]> {
 	const response: CrowniclesPacket[] = [];
 	const data = await getPlayerAndHome(keycloakId);
@@ -549,16 +529,7 @@ export async function handleCookingCraft(
 		recipeId: validatedRecipe.id,
 		wasSecret: validatedSlotRecipe.isSecret,
 		outputType: validatedRecipe.outputType,
-		potionId: outputResult.potionId,
-		failedPotionId: outputResult.failedPotionId,
-		petFoodType: outputResult.petFood?.type,
-		petFoodQuantity: outputResult.petFood?.quantity,
-		petFoodStoredQuantity: outputResult.petFood?.storedQuantity,
-		petFedFromSurplus: outputResult.petFood?.fedFromSurplus,
-		surplusMaterialId: outputResult.petFood?.surplusMaterialId,
-		surplusMaterialQuantity: outputResult.petFood?.surplusMaterialQuantity,
-		craftedMaterialId: outputResult.material?.materialId,
-		craftedMaterialQuantity: outputResult.material?.quantity,
+		...outputResult,
 		cookingXpGained: result.xpGained,
 		cookingLevelUp: result.levelUp,
 		newCookingLevel: result.newLevel,

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -30,7 +30,9 @@ import {
 import {
 	Home, Homes
 } from "../database/game/models/Home";
-import { Guild } from "../database/game/models/Guild";
+import {
+	Guilds, Guild
+} from "../database/game/models/Guild";
 import { Materials } from "../database/game/models/Material";
 import { PotionDataController } from "../../data/Potion";
 import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
@@ -52,8 +54,7 @@ interface PlayerAndHome {
  * confirms, we know which wood was originally selected.
  * Entries auto-expire after 5 minutes to prevent memory leaks.
  */
-const WOOD_CONFIRMATION_TTL_MINUTES = 5;
-const WOOD_CONFIRMATION_TTL_MS = minutesToMilliseconds(WOOD_CONFIRMATION_TTL_MINUTES);
+const WOOD_CONFIRMATION_TTL = minutesToMilliseconds(5);
 
 interface PendingWoodConfirmation {
 	materialId: number;
@@ -70,7 +71,7 @@ function setPendingWoodConfirmation(keycloakId: string, materialId: number, rari
 	if (existing) {
 		clearTimeout(existing.timeout);
 	}
-	const timeout = setTimeout(() => pendingWoodConfirmations.delete(keycloakId), WOOD_CONFIRMATION_TTL_MS);
+	const timeout = setTimeout(() => pendingWoodConfirmations.delete(keycloakId), WOOD_CONFIRMATION_TTL);
 	pendingWoodConfirmations.set(keycloakId, {
 		materialId,
 		rarity,
@@ -398,7 +399,7 @@ interface CraftOutputParams {
 	guild: Guild | null;
 }
 
-function processSuccessfulCraftOutput({
+async function processSuccessfulCraftOutput({
 	context,
 	player,
 	recipe,
@@ -406,32 +407,32 @@ function processSuccessfulCraftOutput({
 }: Omit<CraftOutputParams, "result">): Promise<CraftOutputResult> {
 	switch (recipe.outputType) {
 		case CookingOutputType.POTION:
-			return handlePotionOutput(player, recipe, context);
+			return await handlePotionOutput(player, recipe, context);
 		case CookingOutputType.PET_FOOD:
-			return guild ? handlePetFoodOutput(player, recipe, guild) : Promise.resolve({});
+			return guild ? await handlePetFoodOutput(player, recipe, guild) : {};
 		case CookingOutputType.MATERIAL:
-			return handleMaterialOutput(player, recipe);
+			return await handleMaterialOutput(player, recipe);
 		default:
-			return Promise.resolve({});
+			return {};
 	}
 }
 
-function processFailedCraftOutput({
+async function processFailedCraftOutput({
 	context,
 	player,
 	recipe
 }: Omit<CraftOutputParams, "result" | "guild">): Promise<CraftOutputResult> {
 	if (recipe.outputType === CookingOutputType.POTION) {
-		return handleFailedPotionOutput(player, context);
+		return await handleFailedPotionOutput(player, context);
 	}
-	return Promise.resolve({});
+	return {};
 }
 
-function processCraftOutput(params: CraftOutputParams): Promise<CraftOutputResult> {
+async function processCraftOutput(params: CraftOutputParams): Promise<CraftOutputResult> {
 	if (!params.result.success) {
-		return processFailedCraftOutput(params);
+		return await processFailedCraftOutput(params);
 	}
-	return processSuccessfulCraftOutput(params);
+	return await processSuccessfulCraftOutput(params);
 }
 
 interface CraftErrorInfo {
@@ -488,7 +489,7 @@ export async function handleCookingCraft(
 	});
 	const slot = slots.find(s => s.slotIndex === packet.slotIndex);
 	const recipe = slot?.recipe ? CookingRecipeDataController.instance.getById(slot.recipe.id) : undefined;
-	const guild = await CookingService.getPlayerGuild(player);
+	const guild = player.guildId ? await Guilds.getById(player.guildId) : null;
 
 	const validationError = validateCraftRequest(slot, recipe, guild);
 	if (validationError) {

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -1,6 +1,7 @@
 import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
+import { PetFood } from "../../../../Lib/src/types/PetFood";
 import {
 	CommandReportCookingIgniteReq,
 	CommandReportCookingIgniteRes,
@@ -17,7 +18,7 @@ import {
 } from "../../../../Lib/src/packets/commands/CommandReportPacket";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { CookingService } from "../cooking/CookingService";
-import { recipeRegistry } from "../cooking/RecipeRegistry";
+import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 import {
 	Players
 } from "../database/game/models/Player";
@@ -79,7 +80,7 @@ function buildIgniteOrReviveResponse(
 		woodConsumed,
 		woodMaterialId,
 		furnaceUsesRemaining: FURNACE_MAX_USES_PER_DAY - furnaceUsesToday,
-		cookingGrade: getCookingGrade(cookingLevel).name,
+		cookingGrade: getCookingGrade(cookingLevel).id,
 		cookingLevel
 	});
 }
@@ -246,7 +247,7 @@ export async function handleCookingCraft(
 		return response;
 	}
 
-	const recipe = recipeRegistry.getById(slot.recipe.id);
+	const recipe = CookingRecipeDataController.instance.getById(slot.recipe.id);
 	if (!recipe) {
 		return response;
 	}
@@ -284,7 +285,7 @@ export async function handleCookingCraft(
 
 	// Determine output
 	let potionId: number | undefined;
-	let petFoodType: string | undefined;
+	let petFoodType: PetFood | undefined;
 	let petFoodQuantity: number | undefined;
 	let petFoodStoredQuantity: number | undefined;
 	let petFedFromSurplus: boolean | undefined;

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -133,7 +133,11 @@ async function buildBlockedCraftResponse(params: {
 	wasSecret: boolean;
 	outputType: CookingOutputTypeValue;
 }): Promise<CommandReportCookingCraftRes> {
-	const updatedSlots = await CookingService.getSlotRecipes(params.player, params.homeId, params.cookingSlots);
+	const updatedSlots = await CookingService.getSlotRecipes({
+		player: params.player,
+		homeId: params.homeId,
+		cookingSlots: params.cookingSlots
+	});
 
 	return makePacket(CommandReportCookingCraftRes, {
 		success: false,
@@ -198,7 +202,9 @@ async function igniteOrReviveFurnace(
 	player.furnacePosition++;
 	await CookingService.incrementFurnaceUsage(player);
 
-	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	const slots = await CookingService.getSlotRecipes({
+		player, homeId: home.id, cookingSlots
+	});
 	response.push(buildIgniteOrReviveResponse(PacketClass, slots, !woodSaved, wood.materialId, player.furnaceUsesToday, player.cookingLevel));
 }
 
@@ -238,7 +244,9 @@ export async function handleCookingWoodConfirm(
 	player.furnacePosition++;
 	await CookingService.incrementFurnaceUsage(player);
 
-	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	const slots = await CookingService.getSlotRecipes({
+		player, homeId: home.id, cookingSlots
+	});
 	const ResponseClass = pending.isRevive ? CommandReportCookingReviveRes : CommandReportCookingIgniteRes;
 	response.push(buildIgniteOrReviveResponse(ResponseClass, slots, true, pending.materialId, player.furnaceUsesToday, player.cookingLevel));
 	return response;
@@ -423,6 +431,21 @@ function processCraftOutput({
 	return processSuccessfulCraftOutput(context, player, recipe, guild);
 }
 
+function getCraftErrorInfo(
+	slot: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>[number] | undefined,
+	recipe: CookingRecipeData | undefined
+): {
+	recipeId: string;
+	wasSecret: boolean;
+	outputType: CookingOutputTypeValue;
+} {
+	return {
+		recipeId: recipe?.id ?? "",
+		wasSecret: slot?.recipe?.isSecret ?? false,
+		outputType: recipe?.outputType ?? CookingOutputType.POTION
+	};
+}
+
 function validateCraftRequest(
 	slot: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>[number] | undefined,
 	recipe: CookingRecipeData | undefined,
@@ -455,7 +478,9 @@ export async function handleCookingCraft(
 	} = data;
 
 	// Get the current slots to find the recipe at the requested slot
-	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	const slots = await CookingService.getSlotRecipes({
+		player, homeId: home.id, cookingSlots
+	});
 	const slot = slots.find(s => s.slotIndex === packet.slotIndex);
 	const recipe = slot?.recipe ? CookingRecipeDataController.instance.getById(slot.recipe.id) : undefined;
 	const guild = await CookingService.getPlayerGuild(player);
@@ -467,9 +492,7 @@ export async function handleCookingCraft(
 			homeId: home.id,
 			cookingSlots,
 			error: validationError,
-			recipeId: recipe?.id ?? "",
-			wasSecret: slot?.recipe?.isSecret ?? false,
-			outputType: recipe?.outputType ?? CookingOutputType.POTION
+			...getCraftErrorInfo(slot, recipe)
 		}));
 		return response;
 	}
@@ -479,7 +502,9 @@ export async function handleCookingCraft(
 	const validatedSlotRecipe = slot!.recipe!;
 
 	// Execute the craft
-	const result = await CookingService.executeCraft(player, validatedRecipe, home.id);
+	const result = await CookingService.executeCraft({
+		player, recipe: validatedRecipe, homeId: home.id
+	});
 
 	// Determine and apply output
 	const {
@@ -492,7 +517,9 @@ export async function handleCookingCraft(
 		guild
 	});
 
-	const updatedSlots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	const updatedSlots = await CookingService.getSlotRecipes({
+		player, homeId: home.id, cookingSlots
+	});
 
 	response.push(makePacket(CommandReportCookingCraftRes, {
 		success: result.success,

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -1,0 +1,390 @@
+import {
+	CrowniclesPacket, makePacket, PacketContext
+} from "../../../../Lib/src/packets/CrowniclesPacket";
+import {
+	CommandReportCookingIgniteReq,
+	CommandReportCookingIgniteRes,
+	CommandReportCookingNoWoodRes,
+	CommandReportCookingOverheatRes,
+	CommandReportCookingWoodConfirmRes,
+	CommandReportCookingWoodConfirmReq,
+	CommandReportCookingReviveReq,
+	CommandReportCookingReviveRes,
+	CommandReportCookingCraftReq,
+	CommandReportCookingCraftRes,
+	CookingCraftErrors,
+	CookingCraftError
+} from "../../../../Lib/src/packets/commands/CommandReportPacket";
+import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
+import { CookingService } from "../cooking/CookingService";
+import { recipeRegistry } from "../cooking/RecipeRegistry";
+import {
+	Players
+} from "../database/game/models/Player";
+import {
+	Homes
+} from "../database/game/models/Home";
+import { Materials } from "../database/game/models/Material";
+import { PotionDataController } from "../../data/Potion";
+import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
+import {
+	getCookingGrade, FURNACE_MAX_USES_PER_DAY, CookingOutputType, CookingOutputTypeValue
+} from "../../../../Lib/src/constants/CookingConstants";
+import { giveItemToPlayer } from "../utils/ItemUtils";
+
+/**
+ * Temporary in-memory store for pending wood confirmations.
+ * Maps keycloakId → { materialId, rarity } so that when a player
+ * confirms, we know which wood was originally selected.
+ */
+const pendingWoodConfirmations = new Map<string, {
+	materialId: number;
+	rarity: number;
+}>();
+
+async function getPlayerAndHome(keycloakId: string): Promise<{
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
+	home: NonNullable<Awaited<ReturnType<typeof Homes.getOfPlayer>>>;
+	cookingSlots: number;
+} | null> {
+	const player = await Players.getByKeycloakId(keycloakId);
+	if (!player) {
+		return null;
+	}
+	const home = await Homes.getOfPlayer(player.id);
+	if (!home) {
+		return null;
+	}
+	const homeLevel = home.getLevel();
+	if (!homeLevel || homeLevel.features.cookingSlots <= 0) {
+		return null;
+	}
+	return {
+		player,
+		home,
+		cookingSlots: homeLevel.features.cookingSlots
+	};
+}
+
+function buildIgniteOrReviveResponse(
+	PacketClass: typeof CommandReportCookingIgniteRes | typeof CommandReportCookingReviveRes,
+	slots: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>,
+	woodConsumed: boolean,
+	woodMaterialId: number,
+	furnaceUsesToday: number,
+	cookingLevel: number
+): CommandReportCookingIgniteRes | CommandReportCookingReviveRes {
+	return makePacket(PacketClass, {
+		slots,
+		woodConsumed,
+		woodMaterialId,
+		furnaceUsesRemaining: FURNACE_MAX_USES_PER_DAY - furnaceUsesToday,
+		cookingGrade: getCookingGrade(cookingLevel).name,
+		cookingLevel
+	});
+}
+
+async function buildBlockedCraftResponse(params: {
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
+	homeId: number;
+	cookingSlots: number;
+	error: CookingCraftError;
+	recipeId: string;
+	wasSecret: boolean;
+	outputType: CookingOutputTypeValue;
+}): Promise<CommandReportCookingCraftRes> {
+	const updatedSlots = await CookingService.getSlotRecipes(params.player, params.homeId, params.cookingSlots);
+
+	return makePacket(CommandReportCookingCraftRes, {
+		success: false,
+		recipeId: params.recipeId,
+		wasSecret: params.wasSecret,
+		outputType: params.outputType,
+		cookingXpGained: 0,
+		cookingLevelUp: false,
+		error: params.error,
+		updatedSlots
+	});
+}
+
+async function igniteOrReviveFurnace(
+	keycloakId: string,
+	response: CrowniclesPacket[],
+	PacketClass: typeof CommandReportCookingIgniteRes | typeof CommandReportCookingReviveRes
+): Promise<void> {
+	const data = await getPlayerAndHome(keycloakId);
+	if (!data) {
+		return;
+	}
+	const {
+		player, home, cookingSlots
+	} = data;
+
+	// Check overheat
+	if (CookingService.isFurnaceOverheated(player)) {
+		response.push(makePacket(CommandReportCookingOverheatRes, {
+			overheatUntil: new Date(player.furnaceOverheatUntil!).getTime()
+		}));
+		return;
+	}
+
+	// Get wood
+	const wood = await CookingService.getWoodToConsume(player.id);
+	if (!wood) {
+		response.push(makePacket(CommandReportCookingNoWoodRes, {}));
+		return;
+	}
+
+	// Non-common wood needs confirmation
+	if (wood.needsConfirmation) {
+		pendingWoodConfirmations.set(keycloakId, {
+			materialId: wood.materialId,
+			rarity: wood.rarity
+		});
+		response.push(makePacket(CommandReportCookingWoodConfirmReq, {
+			woodMaterialId: wood.materialId,
+			woodRarity: wood.rarity
+		}));
+		return;
+	}
+
+	// Check wood save buff (Chef de table grade)
+	const grade = getCookingGrade(player.cookingLevel);
+	const woodSaved = grade.woodSaveChance > 0 && RandomUtils.crowniclesRandom.realZeroToOneInclusive() < grade.woodSaveChance;
+
+	if (!woodSaved) {
+		await Materials.consumeMaterial(player.id, wood.materialId, 1);
+	}
+
+	// Advance furnace position and increment usage
+	player.furnacePosition++;
+	await CookingService.incrementFurnaceUsage(player);
+
+	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	response.push(buildIgniteOrReviveResponse(PacketClass, slots, !woodSaved, wood.materialId, player.furnaceUsesToday, player.cookingLevel));
+}
+
+export async function handleCookingIgnite(
+	keycloakId: string,
+	_packet: CommandReportCookingIgniteReq
+): Promise<CrowniclesPacket[]> {
+	const response: CrowniclesPacket[] = [];
+	await igniteOrReviveFurnace(keycloakId, response, CommandReportCookingIgniteRes);
+	return response;
+}
+
+export async function handleCookingWoodConfirm(
+	keycloakId: string,
+	packet: CommandReportCookingWoodConfirmRes
+): Promise<CrowniclesPacket[]> {
+	const response: CrowniclesPacket[] = [];
+	const pending = pendingWoodConfirmations.get(keycloakId);
+	pendingWoodConfirmations.delete(keycloakId);
+
+	if (!packet.accepted || !pending) {
+		// Cancelled — return empty so Discord goes back to cooking menu
+		return response;
+	}
+
+	const data = await getPlayerAndHome(keycloakId);
+	if (!data) {
+		return response;
+	}
+	const {
+		player, home, cookingSlots
+	} = data;
+
+	// Consume the confirmed wood (no save buff — player already confirmed rare wood)
+	await Materials.consumeMaterial(player.id, pending.materialId, 1);
+
+	// Advance furnace position and increment usage
+	player.furnacePosition++;
+	await CookingService.incrementFurnaceUsage(player);
+
+	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	response.push(buildIgniteOrReviveResponse(CommandReportCookingIgniteRes, slots, true, pending.materialId, player.furnaceUsesToday, player.cookingLevel));
+	return response;
+}
+
+export async function handleCookingRevive(
+	keycloakId: string,
+	_packet: CommandReportCookingReviveReq
+): Promise<CrowniclesPacket[]> {
+	const response: CrowniclesPacket[] = [];
+	await igniteOrReviveFurnace(keycloakId, response, CommandReportCookingReviveRes);
+	return response;
+}
+
+export async function handleCookingCraft(
+	context: PacketContext,
+	keycloakId: string,
+	packet: CommandReportCookingCraftReq
+): Promise<CrowniclesPacket[]> {
+	const response: CrowniclesPacket[] = [];
+	const data = await getPlayerAndHome(keycloakId);
+	if (!data) {
+		return response;
+	}
+	const {
+		player, home, cookingSlots
+	} = data;
+
+	// Get the current slots to find the recipe at the requested slot
+	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+	const slot = slots.find(s => s.slotIndex === packet.slotIndex);
+	if (!slot?.recipe) {
+		response.push(makePacket(CommandReportCookingCraftRes, {
+			success: false,
+			recipeId: "",
+			wasSecret: false,
+			outputType: CookingOutputType.POTION,
+			cookingXpGained: 0,
+			cookingLevelUp: false,
+			error: CookingCraftErrors.CRAFT_UNAVAILABLE,
+			updatedSlots: slots
+		}));
+		return response;
+	}
+
+	const recipe = recipeRegistry.getById(slot.recipe.id);
+	if (!recipe) {
+		return response;
+	}
+
+	const guild = await CookingService.getPlayerGuild(player);
+	if (recipe.outputType === CookingOutputType.PET_FOOD && !guild) {
+		response.push(await buildBlockedCraftResponse({
+			player,
+			homeId: home.id,
+			cookingSlots,
+			error: CookingCraftErrors.GUILD_REQUIRED,
+			recipeId: recipe.id,
+			wasSecret: slot.recipe.isSecret,
+			outputType: recipe.outputType
+		}));
+		return response;
+	}
+
+	// Verify ingredients are still available
+	if (!slot.recipe.canCraft) {
+		response.push(await buildBlockedCraftResponse({
+			player,
+			homeId: home.id,
+			cookingSlots,
+			error: CookingCraftErrors.CRAFT_UNAVAILABLE,
+			recipeId: recipe.id,
+			wasSecret: slot.recipe.isSecret,
+			outputType: recipe.outputType
+		}));
+		return response;
+	}
+
+	// Execute the craft
+	const result = await CookingService.executeCraft(player, recipe, home.id);
+
+	// Determine output
+	let potionId: number | undefined;
+	let petFoodType: string | undefined;
+	let petFoodQuantity: number | undefined;
+	let petFoodStoredQuantity: number | undefined;
+	let petFedFromSurplus: boolean | undefined;
+	let surplusMaterialId: number | undefined;
+	let surplusMaterialQuantity: number | undefined;
+	let craftedMaterialId: number | undefined;
+	let craftedMaterialQuantity: number | undefined;
+	let failedPotionId: number | undefined;
+	let inventorySwapPackets: CrowniclesPacket[] | undefined;
+
+	if (result.success && recipe.outputType === CookingOutputType.POTION && recipe.potionNature !== undefined && recipe.potionRarity !== undefined) {
+		const potion = PotionDataController.instance.randomItem(recipe.potionNature, recipe.potionRarity);
+		const itemReceived = await player.giveItem(potion);
+		if (!itemReceived) {
+			inventorySwapPackets = [];
+			await giveItemToPlayer(inventorySwapPackets, context, player, potion);
+		}
+		potionId = potion.id;
+	}
+	else if (result.success && recipe.outputType === CookingOutputType.PET_FOOD && recipe.petFoodType !== undefined && recipe.petFoodQuantity !== undefined && guild) {
+		petFoodType = recipe.petFoodType;
+		petFoodQuantity = recipe.petFoodQuantity;
+
+		// Calculate how much can actually be stored in guild
+		const availableSpace = CookingService.getAvailableFoodSpace(guild, recipe.petFoodType);
+		const storedQuantity = Math.min(recipe.petFoodQuantity, availableSpace);
+		petFoodStoredQuantity = storedQuantity;
+
+		if (storedQuantity > 0) {
+			guild.addFood(recipe.petFoodType, storedQuantity, NumberChangeReason.COOKING);
+			await guild.save();
+		}
+
+		// Handle surplus
+		let surplus = recipe.petFoodQuantity - storedQuantity;
+		if (surplus > 0) {
+			// Try to feed player's pet if hungry and compatible
+			const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFoodType);
+			if (hungryPet) {
+				await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFoodType);
+				petFedFromSurplus = true;
+				surplus--;
+			}
+
+			// Remaining surplus is recycled into materials
+			if (surplus > 0) {
+				const recycleMaterialId = CookingService.getSurplusRecycleMaterial(recipe);
+				if (recycleMaterialId !== undefined) {
+					await Materials.giveMaterial(player.id, recycleMaterialId, surplus);
+					surplusMaterialId = recycleMaterialId;
+					surplusMaterialQuantity = surplus;
+				}
+			}
+		}
+	}
+	else if (result.success && recipe.outputType === CookingOutputType.MATERIAL && recipe.outputMaterialId !== undefined && recipe.outputMaterialQuantity !== undefined) {
+		await Materials.giveMaterial(player.id, recipe.outputMaterialId, recipe.outputMaterialQuantity);
+		craftedMaterialId = recipe.outputMaterialId;
+		craftedMaterialQuantity = recipe.outputMaterialQuantity;
+	}
+	else if (!result.success && recipe.outputType === CookingOutputType.POTION) {
+		// Failed potion — give a no-effect potion (nature 0, rarity 0 = "potion sans effet")
+		const noEffectPotion = PotionDataController.instance.getById(0);
+		if (noEffectPotion) {
+			const itemReceived = await player.giveItem(noEffectPotion);
+			if (!itemReceived) {
+				inventorySwapPackets = [];
+				await giveItemToPlayer(inventorySwapPackets, context, player, noEffectPotion);
+			}
+			failedPotionId = 0;
+		}
+	}
+
+	const updatedSlots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
+
+	response.push(makePacket(CommandReportCookingCraftRes, {
+		success: result.success,
+		recipeId: recipe.id,
+		wasSecret: slot.recipe.isSecret,
+		outputType: recipe.outputType,
+		potionId,
+		petFoodType,
+		petFoodQuantity,
+		petFoodStoredQuantity,
+		petFedFromSurplus,
+		surplusMaterialId,
+		surplusMaterialQuantity,
+		craftedMaterialId,
+		craftedMaterialQuantity,
+		failedPotionId,
+		cookingXpGained: result.xpGained,
+		cookingLevelUp: result.levelUp,
+		newCookingLevel: result.newLevel,
+		newCookingGrade: result.newGrade,
+		materialSaved: result.materialSaved,
+		discoveredRecipeIds: result.discoveredRecipeIds,
+		updatedSlots
+	}));
+	if (inventorySwapPackets) {
+		response.push(...inventorySwapPackets);
+	}
+	return response;
+}

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -46,10 +46,11 @@ const WOOD_CONFIRMATION_TTL_MS = 5 * 60 * 1000;
 const pendingWoodConfirmations = new Map<string, {
 	materialId: number;
 	rarity: MaterialRarity;
+	isRevive: boolean;
 	timeout: ReturnType<typeof setTimeout>;
 }>();
 
-function setPendingWoodConfirmation(keycloakId: string, materialId: number, rarity: MaterialRarity): void {
+function setPendingWoodConfirmation(keycloakId: string, materialId: number, rarity: MaterialRarity, isRevive: boolean): void {
 	const existing = pendingWoodConfirmations.get(keycloakId);
 	if (existing) {
 		clearTimeout(existing.timeout);
@@ -58,6 +59,7 @@ function setPendingWoodConfirmation(keycloakId: string, materialId: number, rari
 	pendingWoodConfirmations.set(keycloakId, {
 		materialId,
 		rarity,
+		isRevive,
 		timeout
 	});
 }
@@ -65,6 +67,7 @@ function setPendingWoodConfirmation(keycloakId: string, materialId: number, rari
 function consumePendingWoodConfirmation(keycloakId: string): {
 	materialId: number;
 	rarity: MaterialRarity;
+	isRevive: boolean;
 } | undefined {
 	const pending = pendingWoodConfirmations.get(keycloakId);
 	if (!pending) {
@@ -74,7 +77,8 @@ function consumePendingWoodConfirmation(keycloakId: string): {
 	pendingWoodConfirmations.delete(keycloakId);
 	return {
 		materialId: pending.materialId,
-		rarity: pending.rarity
+		rarity: pending.rarity,
+		isRevive: pending.isRevive
 	};
 }
 
@@ -173,7 +177,8 @@ async function igniteOrReviveFurnace(
 
 	// Non-common wood needs confirmation
 	if (wood.needsConfirmation) {
-		setPendingWoodConfirmation(keycloakId, wood.materialId, wood.rarity);
+		const isRevive = PacketClass === CommandReportCookingReviveRes;
+		setPendingWoodConfirmation(keycloakId, wood.materialId, wood.rarity, isRevive);
 		response.push(makePacket(CommandReportCookingWoodConfirmReq, {
 			woodMaterialId: wood.materialId,
 			woodRarity: wood.rarity
@@ -234,7 +239,8 @@ export async function handleCookingWoodConfirm(
 	await CookingService.incrementFurnaceUsage(player);
 
 	const slots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
-	response.push(buildIgniteOrReviveResponse(CommandReportCookingIgniteRes, slots, true, pending.materialId, player.furnaceUsesToday, player.cookingLevel));
+	const ResponseClass = pending.isRevive ? CommandReportCookingReviveRes : CommandReportCookingIgniteRes;
+	response.push(buildIgniteOrReviveResponse(ResponseClass, slots, true, pending.materialId, player.furnaceUsesToday, player.cookingLevel));
 	return response;
 }
 
@@ -287,36 +293,49 @@ async function handlePetFoodOutput(
 	if (recipe.petFoodType === undefined || recipe.petFoodQuantity === undefined) {
 		return {};
 	}
-	const result: CraftOutputResult = {
-		petFoodType: recipe.petFoodType,
-		petFoodQuantity: recipe.petFoodQuantity
-	};
 
 	const availableSpace = CookingService.getAvailableFoodSpace(guild, recipe.petFoodType);
 	const storedQuantity = Math.min(recipe.petFoodQuantity, availableSpace);
-	result.petFoodStoredQuantity = storedQuantity;
 
 	if (storedQuantity > 0) {
 		guild.addFood(recipe.petFoodType, storedQuantity, NumberChangeReason.COOKING);
 		await guild.save();
 	}
 
-	let surplus = recipe.petFoodQuantity - storedQuantity;
-	if (surplus > 0) {
-		const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFoodType);
-		if (hungryPet) {
-			await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFoodType);
-			result.petFedFromSurplus = true;
-			surplus--;
-		}
+	const surplus = recipe.petFoodQuantity - storedQuantity;
+	const surplusResult = surplus > 0
+		? await handlePetFoodSurplus(player, recipe, surplus)
+		: {};
 
-		if (surplus > 0) {
-			const recycleMaterialId = CookingService.getSurplusRecycleMaterial(recipe);
-			if (recycleMaterialId !== undefined) {
-				await Materials.giveMaterial(player.id, recycleMaterialId, surplus);
-				result.surplusMaterialId = recycleMaterialId;
-				result.surplusMaterialQuantity = surplus;
-			}
+	return {
+		petFoodType: recipe.petFoodType,
+		petFoodQuantity: recipe.petFoodQuantity,
+		petFoodStoredQuantity: storedQuantity,
+		...surplusResult
+	};
+}
+
+async function handlePetFoodSurplus(
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	recipe: CookingRecipeData,
+	surplus: number
+): Promise<Partial<CraftOutputResult>> {
+	const result: Partial<CraftOutputResult> = {};
+	let remaining = surplus;
+
+	const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFoodType!);
+	if (hungryPet) {
+		await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFoodType!);
+		result.petFedFromSurplus = true;
+		remaining--;
+	}
+
+	if (remaining > 0) {
+		const recycleMaterialId = CookingService.getSurplusRecycleMaterial(recipe);
+		if (recycleMaterialId !== undefined) {
+			await Materials.giveMaterial(player.id, recycleMaterialId, remaining);
+			result.surplusMaterialId = recycleMaterialId;
+			result.surplusMaterialQuantity = remaining;
 		}
 	}
 
@@ -354,13 +373,21 @@ async function handleFailedPotionOutput(
 	return result;
 }
 
-function processCraftOutput(
-	context: PacketContext,
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
-	recipe: CookingRecipeData,
-	result: { success: boolean },
-	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>
-): Promise<CraftOutputResult> | CraftOutputResult {
+interface CraftOutputParams {
+	context: PacketContext;
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
+	recipe: CookingRecipeData;
+	result: { success: boolean };
+	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>;
+}
+
+function processCraftOutput({
+	context,
+	player,
+	recipe,
+	result,
+	guild
+}: CraftOutputParams): Promise<CraftOutputResult> | CraftOutputResult {
 	if (result.success && recipe.outputType === CookingOutputType.POTION) {
 		return handlePotionOutput(context, player, recipe);
 	}
@@ -446,7 +473,13 @@ export async function handleCookingCraft(
 	// Determine and apply output
 	const {
 		inventorySwapPackets, ...outputFields
-	} = await processCraftOutput(context, player, recipe, result, guild);
+	} = await processCraftOutput({
+		context,
+		player,
+		recipe,
+		result,
+		guild
+	});
 
 	const updatedSlots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
 

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -23,10 +23,10 @@ import {
 	CookingRecipeData, CookingRecipeDataController
 } from "../../data/CookingRecipeData";
 import {
-	Players
+	Player, Players
 } from "../database/game/models/Player";
 import {
-	Homes
+	Home, Homes
 } from "../database/game/models/Home";
 import { Materials } from "../database/game/models/Material";
 import { PotionDataController } from "../../data/Potion";
@@ -36,6 +36,15 @@ import {
 } from "../../../../Lib/src/constants/CookingConstants";
 import { giveItemToPlayer } from "../utils/ItemUtils";
 
+type CookingSlots = Awaited<ReturnType<typeof CookingService.getSlotRecipes>>;
+type PlayerGuild = NonNullable<Awaited<ReturnType<typeof CookingService.getPlayerGuild>>>;
+
+interface PlayerAndHome {
+	player: Player;
+	home: Home;
+	cookingSlots: number;
+}
+
 /**
  * Temporary in-memory store for pending wood confirmations.
  * Maps keycloakId → { materialId, rarity, timeout } so that when a player
@@ -43,10 +52,14 @@ import { giveItemToPlayer } from "../utils/ItemUtils";
  * Entries auto-expire after 5 minutes to prevent memory leaks.
  */
 const WOOD_CONFIRMATION_TTL_MS = 5 * 60 * 1000;
-const pendingWoodConfirmations = new Map<string, {
+
+interface PendingWoodConfirmation {
 	materialId: number;
 	rarity: MaterialRarity;
 	isRevive: boolean;
+}
+
+const pendingWoodConfirmations = new Map<string, PendingWoodConfirmation & {
 	timeout: ReturnType<typeof setTimeout>;
 }>();
 
@@ -64,11 +77,7 @@ function setPendingWoodConfirmation(keycloakId: string, materialId: number, rari
 	});
 }
 
-function consumePendingWoodConfirmation(keycloakId: string): {
-	materialId: number;
-	rarity: MaterialRarity;
-	isRevive: boolean;
-} | undefined {
+function consumePendingWoodConfirmation(keycloakId: string): PendingWoodConfirmation | undefined {
 	const pending = pendingWoodConfirmations.get(keycloakId);
 	if (!pending) {
 		return undefined;
@@ -82,71 +91,67 @@ function consumePendingWoodConfirmation(keycloakId: string): {
 	};
 }
 
-async function getPlayerAndHome(keycloakId: string): Promise<{
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
-	home: NonNullable<Awaited<ReturnType<typeof Homes.getOfPlayer>>>;
-	cookingSlots: number;
-} | null> {
+async function getPlayerAndHome(keycloakId: string): Promise<PlayerAndHome | null> {
 	const player = await Players.getByKeycloakId(keycloakId);
 	if (!player) {
 		return null;
 	}
 	const home = await Homes.getOfPlayer(player.id);
-	if (!home) {
-		return null;
-	}
-	const homeLevel = home.getLevel();
+	const homeLevel = home?.getLevel();
 	if (!homeLevel || homeLevel.features.cookingSlots <= 0) {
 		return null;
 	}
 	return {
 		player,
-		home,
+		home: home!,
 		cookingSlots: homeLevel.features.cookingSlots
 	};
 }
 
+interface IgniteOrReviveParams {
+	slots: CookingSlots;
+	woodConsumed: boolean;
+	woodMaterialId: number;
+	furnaceUsesToday: number;
+	cookingLevel: number;
+}
+
+function buildIgniteOrReviveResponse(PacketClass: typeof CommandReportCookingIgniteRes, params: IgniteOrReviveParams): CommandReportCookingIgniteRes;
+function buildIgniteOrReviveResponse(PacketClass: typeof CommandReportCookingReviveRes, params: IgniteOrReviveParams): CommandReportCookingReviveRes;
 function buildIgniteOrReviveResponse(
 	PacketClass: typeof CommandReportCookingIgniteRes | typeof CommandReportCookingReviveRes,
-	slots: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>,
-	woodConsumed: boolean,
-	woodMaterialId: number,
-	furnaceUsesToday: number,
-	cookingLevel: number
+	params: IgniteOrReviveParams
 ): CommandReportCookingIgniteRes | CommandReportCookingReviveRes {
 	return makePacket(PacketClass, {
-		slots,
-		woodConsumed,
-		woodMaterialId,
-		furnaceUsesRemaining: FURNACE_MAX_USES_PER_DAY - furnaceUsesToday,
-		cookingGrade: getCookingGrade(cookingLevel).id,
-		cookingLevel
+		...params,
+		furnaceUsesRemaining: FURNACE_MAX_USES_PER_DAY - params.furnaceUsesToday,
+		cookingGrade: getCookingGrade(params.cookingLevel).id
 	});
 }
 
-async function buildBlockedCraftResponse(params: {
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
+interface BlockedCraftParams {
+	player: Player;
 	homeId: number;
 	cookingSlots: number;
 	error: CookingCraftError;
 	recipeId: string;
 	wasSecret: boolean;
 	outputType: CookingOutputTypeValue;
-}): Promise<CommandReportCookingCraftRes> {
+}
+
+async function buildBlockedCraftResponse(params: BlockedCraftParams): Promise<CommandReportCookingCraftRes> {
+	const {
+		player, homeId, cookingSlots, ...craftInfo
+	} = params;
 	const updatedSlots = await CookingService.getSlotRecipes({
-		player: params.player,
-		homeId: params.homeId,
-		cookingSlots: params.cookingSlots
+		player, homeId, cookingSlots
 	});
 
 	return makePacket(CommandReportCookingCraftRes, {
 		success: false,
-		recipeId: params.recipeId,
-		wasSecret: params.wasSecret,
-		outputType: params.outputType,
+		...craftInfo,
 		cookingXpGained: 0,
 		cookingLevelUp: false,
-		error: params.error,
 		updatedSlots
 	});
 }
@@ -205,7 +210,9 @@ async function igniteOrReviveFurnace(
 	const slots = await CookingService.getSlotRecipes({
 		player, homeId: home.id, cookingSlots
 	});
-	response.push(buildIgniteOrReviveResponse(PacketClass, slots, !woodSaved, wood.materialId, player.furnaceUsesToday, player.cookingLevel));
+	response.push(buildIgniteOrReviveResponse(PacketClass, {
+		slots, woodConsumed: !woodSaved, woodMaterialId: wood.materialId, furnaceUsesToday: player.furnaceUsesToday, cookingLevel: player.cookingLevel
+	}));
 }
 
 export async function handleCookingIgnite(
@@ -248,7 +255,9 @@ export async function handleCookingWoodConfirm(
 		player, homeId: home.id, cookingSlots
 	});
 	const ResponseClass = pending.isRevive ? CommandReportCookingReviveRes : CommandReportCookingIgniteRes;
-	response.push(buildIgniteOrReviveResponse(ResponseClass, slots, true, pending.materialId, player.furnaceUsesToday, player.cookingLevel));
+	response.push(buildIgniteOrReviveResponse(ResponseClass, {
+		slots, woodConsumed: true, woodMaterialId: pending.materialId, furnaceUsesToday: player.furnaceUsesToday, cookingLevel: player.cookingLevel
+	}));
 	return response;
 }
 
@@ -261,23 +270,31 @@ export async function handleCookingRevive(
 	return response;
 }
 
-interface CraftOutputResult {
-	potionId?: number;
-	petFoodType?: PetFood;
-	petFoodQuantity?: number;
-	petFoodStoredQuantity?: number;
-	petFedFromSurplus?: boolean;
+interface PetFoodOutput {
+	type: PetFood;
+	quantity: number;
+	storedQuantity: number;
+	fedFromSurplus?: boolean;
 	surplusMaterialId?: number;
 	surplusMaterialQuantity?: number;
-	craftedMaterialId?: number;
-	craftedMaterialQuantity?: number;
+}
+
+interface MaterialOutput {
+	materialId: number;
+	quantity: number;
+}
+
+interface CraftOutputResult {
+	potionId?: number;
+	petFood?: PetFoodOutput;
+	material?: MaterialOutput;
 	failedPotionId?: number;
 	inventorySwapPackets?: CrowniclesPacket[];
 }
 
 async function handlePotionOutput(
 	context: PacketContext,
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	player: Player,
 	recipe: CookingRecipeData
 ): Promise<CraftOutputResult> {
 	if (recipe.potionNature === undefined || recipe.potionRarity === undefined) {
@@ -294,47 +311,49 @@ async function handlePotionOutput(
 }
 
 async function handlePetFoodOutput(
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	player: Player,
 	recipe: CookingRecipeData,
-	guild: NonNullable<Awaited<ReturnType<typeof CookingService.getPlayerGuild>>>
+	guild: PlayerGuild
 ): Promise<CraftOutputResult> {
-	if (recipe.petFoodType === undefined || recipe.petFoodQuantity === undefined) {
+	if (!recipe.petFood) {
 		return {};
 	}
 
-	const availableSpace = CookingService.getAvailableFoodSpace(guild, recipe.petFoodType);
-	const storedQuantity = Math.min(recipe.petFoodQuantity, availableSpace);
+	const availableSpace = CookingService.getAvailableFoodSpace(guild, recipe.petFood.type);
+	const storedQuantity = Math.min(recipe.petFood.quantity, availableSpace);
 
 	if (storedQuantity > 0) {
-		guild.addFood(recipe.petFoodType, storedQuantity, NumberChangeReason.COOKING);
+		guild.addFood(recipe.petFood.type, storedQuantity, NumberChangeReason.COOKING);
 		await guild.save();
 	}
 
-	const surplus = recipe.petFoodQuantity - storedQuantity;
+	const surplus = recipe.petFood.quantity - storedQuantity;
 	const surplusResult = surplus > 0
 		? await handlePetFoodSurplus(player, recipe, surplus)
 		: {};
 
 	return {
-		petFoodType: recipe.petFoodType,
-		petFoodQuantity: recipe.petFoodQuantity,
-		petFoodStoredQuantity: storedQuantity,
-		...surplusResult
+		petFood: {
+			type: recipe.petFood.type,
+			quantity: recipe.petFood.quantity,
+			storedQuantity,
+			...surplusResult
+		}
 	};
 }
 
 async function handlePetFoodSurplus(
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	player: Player,
 	recipe: CookingRecipeData,
 	surplus: number
-): Promise<Partial<CraftOutputResult>> {
-	const result: Partial<CraftOutputResult> = {};
+): Promise<Partial<PetFoodOutput>> {
+	const result: Partial<PetFoodOutput> = {};
 	let remaining = surplus;
 
-	const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFoodType!);
+	const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFood!.type);
 	if (hungryPet) {
-		await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFoodType!);
-		result.petFedFromSurplus = true;
+		await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFood!.type);
+		result.fedFromSurplus = true;
 		remaining--;
 	}
 
@@ -351,7 +370,7 @@ async function handlePetFoodSurplus(
 }
 
 async function handleMaterialOutput(
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	player: Player,
 	recipe: CookingRecipeData
 ): Promise<CraftOutputResult> {
 	if (recipe.outputMaterialId === undefined || recipe.outputMaterialQuantity === undefined) {
@@ -359,14 +378,16 @@ async function handleMaterialOutput(
 	}
 	await Materials.giveMaterial(player.id, recipe.outputMaterialId, recipe.outputMaterialQuantity);
 	return {
-		craftedMaterialId: recipe.outputMaterialId,
-		craftedMaterialQuantity: recipe.outputMaterialQuantity
+		material: {
+			materialId: recipe.outputMaterialId,
+			quantity: recipe.outputMaterialQuantity
+		}
 	};
 }
 
 async function handleFailedPotionOutput(
 	context: PacketContext,
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>
+	player: Player
 ): Promise<CraftOutputResult> {
 	const noEffectPotion = PotionDataController.instance.getById(0);
 	if (!noEffectPotion) {
@@ -383,7 +404,7 @@ async function handleFailedPotionOutput(
 
 interface CraftOutputParams {
 	context: PacketContext;
-	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>;
+	player: Player;
 	recipe: CookingRecipeData;
 	result: { success: boolean };
 	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>;
@@ -391,7 +412,7 @@ interface CraftOutputParams {
 
 function processSuccessfulCraftOutput(
 	context: PacketContext,
-	player: CraftOutputParams["player"],
+	player: Player,
 	recipe: CookingRecipeData,
 	guild: CraftOutputParams["guild"]
 ): Promise<CraftOutputResult> | CraftOutputResult {
@@ -409,7 +430,7 @@ function processSuccessfulCraftOutput(
 
 function processFailedCraftOutput(
 	context: PacketContext,
-	player: CraftOutputParams["player"],
+	player: Player,
 	recipe: CookingRecipeData
 ): Promise<CraftOutputResult> | CraftOutputResult {
 	if (recipe.outputType === CookingOutputType.POTION) {
@@ -431,14 +452,18 @@ function processCraftOutput({
 	return processSuccessfulCraftOutput(context, player, recipe, guild);
 }
 
-function getCraftErrorInfo(
-	slot: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>[number] | undefined,
-	recipe: CookingRecipeData | undefined
-): {
+type CookingSlotEntry = CookingSlots[number];
+
+interface CraftErrorInfo {
 	recipeId: string;
 	wasSecret: boolean;
 	outputType: CookingOutputTypeValue;
-} {
+}
+
+function getCraftErrorInfo(
+	slot: CookingSlotEntry | undefined,
+	recipe: CookingRecipeData | undefined
+): CraftErrorInfo {
 	return {
 		recipeId: recipe?.id ?? "",
 		wasSecret: slot?.recipe?.isSecret ?? false,
@@ -447,7 +472,7 @@ function getCraftErrorInfo(
 }
 
 function validateCraftRequest(
-	slot: Awaited<ReturnType<typeof CookingService.getSlotRecipes>>[number] | undefined,
+	slot: CookingSlotEntry | undefined,
 	recipe: CookingRecipeData | undefined,
 	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>
 ): CookingCraftError | null {
@@ -507,9 +532,7 @@ export async function handleCookingCraft(
 	});
 
 	// Determine and apply output
-	const {
-		inventorySwapPackets, ...outputFields
-	} = await processCraftOutput({
+	const outputResult = await processCraftOutput({
 		context,
 		player,
 		recipe: validatedRecipe,
@@ -526,7 +549,16 @@ export async function handleCookingCraft(
 		recipeId: validatedRecipe.id,
 		wasSecret: validatedSlotRecipe.isSecret,
 		outputType: validatedRecipe.outputType,
-		...outputFields,
+		potionId: outputResult.potionId,
+		failedPotionId: outputResult.failedPotionId,
+		petFoodType: outputResult.petFood?.type,
+		petFoodQuantity: outputResult.petFood?.quantity,
+		petFoodStoredQuantity: outputResult.petFood?.storedQuantity,
+		petFedFromSurplus: outputResult.petFood?.fedFromSurplus,
+		surplusMaterialId: outputResult.petFood?.surplusMaterialId,
+		surplusMaterialQuantity: outputResult.petFood?.surplusMaterialQuantity,
+		craftedMaterialId: outputResult.material?.materialId,
+		craftedMaterialQuantity: outputResult.material?.quantity,
 		cookingXpGained: result.xpGained,
 		cookingLevelUp: result.levelUp,
 		newCookingLevel: result.newLevel,
@@ -535,8 +567,8 @@ export async function handleCookingCraft(
 		discoveredRecipeIds: result.discoveredRecipeIds,
 		updatedSlots
 	}));
-	if (inventorySwapPackets) {
-		response.push(...inventorySwapPackets);
+	if (outputResult.inventorySwapPackets) {
+		response.push(...outputResult.inventorySwapPackets);
 	}
 	return response;
 }

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -19,7 +19,9 @@ import {
 } from "../../../../Lib/src/packets/commands/CommandReportPacket";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { CookingService } from "../cooking/CookingService";
-import { CookingRecipeDataController } from "../../data/CookingRecipeData";
+import {
+	CookingRecipeData, CookingRecipeDataController
+} from "../../data/CookingRecipeData";
 import {
 	Players
 } from "../database/game/models/Player";
@@ -245,6 +247,135 @@ export async function handleCookingRevive(
 	return response;
 }
 
+interface CraftOutputResult {
+	potionId?: number;
+	petFoodType?: PetFood;
+	petFoodQuantity?: number;
+	petFoodStoredQuantity?: number;
+	petFedFromSurplus?: boolean;
+	surplusMaterialId?: number;
+	surplusMaterialQuantity?: number;
+	craftedMaterialId?: number;
+	craftedMaterialQuantity?: number;
+	failedPotionId?: number;
+	inventorySwapPackets?: CrowniclesPacket[];
+}
+
+async function handlePotionOutput(
+	context: PacketContext,
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	recipe: CookingRecipeData
+): Promise<CraftOutputResult> {
+	if (recipe.potionNature === undefined || recipe.potionRarity === undefined) {
+		return {};
+	}
+	const potion = PotionDataController.instance.randomItem(recipe.potionNature, recipe.potionRarity);
+	const itemReceived = await player.giveItem(potion);
+	const result: CraftOutputResult = { potionId: potion.id };
+	if (!itemReceived) {
+		result.inventorySwapPackets = [];
+		await giveItemToPlayer(result.inventorySwapPackets, context, player, potion);
+	}
+	return result;
+}
+
+async function handlePetFoodOutput(
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	recipe: CookingRecipeData,
+	guild: NonNullable<Awaited<ReturnType<typeof CookingService.getPlayerGuild>>>
+): Promise<CraftOutputResult> {
+	if (recipe.petFoodType === undefined || recipe.petFoodQuantity === undefined) {
+		return {};
+	}
+	const result: CraftOutputResult = {
+		petFoodType: recipe.petFoodType,
+		petFoodQuantity: recipe.petFoodQuantity
+	};
+
+	const availableSpace = CookingService.getAvailableFoodSpace(guild, recipe.petFoodType);
+	const storedQuantity = Math.min(recipe.petFoodQuantity, availableSpace);
+	result.petFoodStoredQuantity = storedQuantity;
+
+	if (storedQuantity > 0) {
+		guild.addFood(recipe.petFoodType, storedQuantity, NumberChangeReason.COOKING);
+		await guild.save();
+	}
+
+	let surplus = recipe.petFoodQuantity - storedQuantity;
+	if (surplus > 0) {
+		const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFoodType);
+		if (hungryPet) {
+			await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFoodType);
+			result.petFedFromSurplus = true;
+			surplus--;
+		}
+
+		if (surplus > 0) {
+			const recycleMaterialId = CookingService.getSurplusRecycleMaterial(recipe);
+			if (recycleMaterialId !== undefined) {
+				await Materials.giveMaterial(player.id, recycleMaterialId, surplus);
+				result.surplusMaterialId = recycleMaterialId;
+				result.surplusMaterialQuantity = surplus;
+			}
+		}
+	}
+
+	return result;
+}
+
+async function handleMaterialOutput(
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	recipe: CookingRecipeData
+): Promise<CraftOutputResult> {
+	if (recipe.outputMaterialId === undefined || recipe.outputMaterialQuantity === undefined) {
+		return {};
+	}
+	await Materials.giveMaterial(player.id, recipe.outputMaterialId, recipe.outputMaterialQuantity);
+	return {
+		craftedMaterialId: recipe.outputMaterialId,
+		craftedMaterialQuantity: recipe.outputMaterialQuantity
+	};
+}
+
+async function handleFailedPotionOutput(
+	context: PacketContext,
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>
+): Promise<CraftOutputResult> {
+	const noEffectPotion = PotionDataController.instance.getById(0);
+	if (!noEffectPotion) {
+		return {};
+	}
+	const itemReceived = await player.giveItem(noEffectPotion);
+	const result: CraftOutputResult = { failedPotionId: 0 };
+	if (!itemReceived) {
+		result.inventorySwapPackets = [];
+		await giveItemToPlayer(result.inventorySwapPackets, context, player, noEffectPotion);
+	}
+	return result;
+}
+
+function processCraftOutput(
+	context: PacketContext,
+	player: NonNullable<Awaited<ReturnType<typeof Players.getByKeycloakId>>>,
+	recipe: CookingRecipeData,
+	result: { success: boolean },
+	guild: Awaited<ReturnType<typeof CookingService.getPlayerGuild>>
+): Promise<CraftOutputResult> | CraftOutputResult {
+	if (result.success && recipe.outputType === CookingOutputType.POTION) {
+		return handlePotionOutput(context, player, recipe);
+	}
+	if (result.success && recipe.outputType === CookingOutputType.PET_FOOD && guild) {
+		return handlePetFoodOutput(player, recipe, guild);
+	}
+	if (result.success && recipe.outputType === CookingOutputType.MATERIAL) {
+		return handleMaterialOutput(player, recipe);
+	}
+	if (!result.success && recipe.outputType === CookingOutputType.POTION) {
+		return handleFailedPotionOutput(context, player);
+	}
+	return {};
+}
+
 export async function handleCookingCraft(
 	context: PacketContext,
 	keycloakId: string,
@@ -312,81 +443,10 @@ export async function handleCookingCraft(
 	// Execute the craft
 	const result = await CookingService.executeCraft(player, recipe, home.id);
 
-	// Determine output
-	let potionId: number | undefined;
-	let petFoodType: PetFood | undefined;
-	let petFoodQuantity: number | undefined;
-	let petFoodStoredQuantity: number | undefined;
-	let petFedFromSurplus: boolean | undefined;
-	let surplusMaterialId: number | undefined;
-	let surplusMaterialQuantity: number | undefined;
-	let craftedMaterialId: number | undefined;
-	let craftedMaterialQuantity: number | undefined;
-	let failedPotionId: number | undefined;
-	let inventorySwapPackets: CrowniclesPacket[] | undefined;
-
-	if (result.success && recipe.outputType === CookingOutputType.POTION && recipe.potionNature !== undefined && recipe.potionRarity !== undefined) {
-		const potion = PotionDataController.instance.randomItem(recipe.potionNature, recipe.potionRarity);
-		const itemReceived = await player.giveItem(potion);
-		if (!itemReceived) {
-			inventorySwapPackets = [];
-			await giveItemToPlayer(inventorySwapPackets, context, player, potion);
-		}
-		potionId = potion.id;
-	}
-	else if (result.success && recipe.outputType === CookingOutputType.PET_FOOD && recipe.petFoodType !== undefined && recipe.petFoodQuantity !== undefined && guild) {
-		petFoodType = recipe.petFoodType;
-		petFoodQuantity = recipe.petFoodQuantity;
-
-		// Calculate how much can actually be stored in guild
-		const availableSpace = CookingService.getAvailableFoodSpace(guild, recipe.petFoodType);
-		const storedQuantity = Math.min(recipe.petFoodQuantity, availableSpace);
-		petFoodStoredQuantity = storedQuantity;
-
-		if (storedQuantity > 0) {
-			guild.addFood(recipe.petFoodType, storedQuantity, NumberChangeReason.COOKING);
-			await guild.save();
-		}
-
-		// Handle surplus
-		let surplus = recipe.petFoodQuantity - storedQuantity;
-		if (surplus > 0) {
-			// Try to feed player's pet if hungry and compatible
-			const hungryPet = await CookingService.getHungryCompatiblePet(player, recipe.petFoodType);
-			if (hungryPet) {
-				await CookingService.feedPetFromSurplus(player, hungryPet, recipe.petFoodType);
-				petFedFromSurplus = true;
-				surplus--;
-			}
-
-			// Remaining surplus is recycled into materials
-			if (surplus > 0) {
-				const recycleMaterialId = CookingService.getSurplusRecycleMaterial(recipe);
-				if (recycleMaterialId !== undefined) {
-					await Materials.giveMaterial(player.id, recycleMaterialId, surplus);
-					surplusMaterialId = recycleMaterialId;
-					surplusMaterialQuantity = surplus;
-				}
-			}
-		}
-	}
-	else if (result.success && recipe.outputType === CookingOutputType.MATERIAL && recipe.outputMaterialId !== undefined && recipe.outputMaterialQuantity !== undefined) {
-		await Materials.giveMaterial(player.id, recipe.outputMaterialId, recipe.outputMaterialQuantity);
-		craftedMaterialId = recipe.outputMaterialId;
-		craftedMaterialQuantity = recipe.outputMaterialQuantity;
-	}
-	else if (!result.success && recipe.outputType === CookingOutputType.POTION) {
-		// Failed potion — give a no-effect potion (nature 0, rarity 0 = "potion sans effet")
-		const noEffectPotion = PotionDataController.instance.getById(0);
-		if (noEffectPotion) {
-			const itemReceived = await player.giveItem(noEffectPotion);
-			if (!itemReceived) {
-				inventorySwapPackets = [];
-				await giveItemToPlayer(inventorySwapPackets, context, player, noEffectPotion);
-			}
-			failedPotionId = 0;
-		}
-	}
+	// Determine and apply output
+	const {
+		inventorySwapPackets, ...outputFields
+	} = await processCraftOutput(context, player, recipe, result, guild);
 
 	const updatedSlots = await CookingService.getSlotRecipes(player, home.id, cookingSlots);
 
@@ -395,16 +455,7 @@ export async function handleCookingCraft(
 		recipeId: recipe.id,
 		wasSecret: slot.recipe.isSecret,
 		outputType: recipe.outputType,
-		potionId,
-		petFoodType,
-		petFoodQuantity,
-		petFoodStoredQuantity,
-		petFedFromSurplus,
-		surplusMaterialId,
-		surplusMaterialQuantity,
-		craftedMaterialId,
-		craftedMaterialQuantity,
-		failedPotionId,
+		...outputFields,
 		cookingXpGained: result.xpGained,
 		cookingLevelUp: result.levelUp,
 		newCookingLevel: result.newLevel,

--- a/Core/src/core/report/ReportPveService.ts
+++ b/Core/src/core/report/ReportPveService.ts
@@ -34,6 +34,7 @@ import { crowniclesInstance } from "../../index";
 import { InventorySlots } from "../database/game/models/InventorySlot";
 import { PlayerActiveObjects } from "../database/game/models/PlayerActiveObjects";
 import { chooseDestination } from "./ReportDestinationService";
+import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
 
 /**
  * PVE fight rewards structure
@@ -223,6 +224,9 @@ export async function doPVEBoss(
 						missionId: "winBossWithDifferentClasses",
 						params: { classId: player.class }
 					});
+
+					// Discover an island boss cooking recipe
+					await RecipeDiscoveryService.discoverFromBoss(player, mapId);
 				}
 			}
 			else {

--- a/Core/src/core/smallEvents/farmer.ts
+++ b/Core/src/core/smallEvents/farmer.ts
@@ -21,6 +21,10 @@ import { PlayerSmallEvents } from "../database/game/models/PlayerSmallEvent";
 import { MapLocationConstants } from "../../../../Lib/src/constants/MapLocationConstants";
 import { PetConstants } from "../../../../Lib/src/constants/PetConstants";
 import { SmallEventConstants } from "../../../../Lib/src/constants/SmallEventConstants";
+import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
+import {
+	FARMER_RECIPE_COSTS, RecipeDiscoverySource
+} from "../../../../Lib/src/constants/CookingConstants";
 
 const FARMER_INTERACTIONS = {
 	SALAD: "salad",
@@ -79,6 +83,16 @@ export const smallEventFuncs: SmallEventFuncs = {
 			const maxGiveable = GuildConstants.MAX_HERBIVOROUS_PET_FOOD - guild.herbivorousFood;
 			packet.amount = Math.min(RandomUtils.randInt(SALAD_AMOUNT.MIN, SALAD_AMOUNT.MAX + 1), maxGiveable);
 			await giveFoodToGuild(response, player, PetConstants.PET_FOOD.HERBIVOROUS_FOOD, packet.amount, NumberChangeReason.SMALL_EVENT);
+
+			// Discover a farmer recipe (costs money)
+			const discovery = await RecipeDiscoveryService.tryDiscoverAndPay({
+				player,
+				source: RecipeDiscoverySource.FARMER,
+				costs: FARMER_RECIPE_COSTS,
+				response
+			});
+			packet.discoveredRecipeId = discovery.discoveredRecipeId;
+			packet.recipeCost = discovery.recipeCost;
 		}
 
 		response.push(makePacket(SmallEventFarmerPacket, packet));

--- a/Core/src/core/smallEvents/petFood.ts
+++ b/Core/src/core/smallEvents/petFood.ts
@@ -36,6 +36,10 @@ import { Maps } from "../maps/Maps";
 import { SmallEventConstants } from "../../../../Lib/src/constants/SmallEventConstants";
 import { Effect } from "../../../../Lib/src/types/Effect";
 import { PetUtils } from "../utils/PetUtils";
+import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
+import {
+	GASPARD_JO_RECIPE_COSTS, RecipeDiscoverySource
+} from "../../../../Lib/src/constants/CookingConstants";
 
 type ReactionHandler = (player: Player, properties: PetFoodProperties) => Promise<string>;
 
@@ -200,12 +204,32 @@ async function applyOutcome(
 		await petEntity.save();
 	}
 
+	// Discover a Gaspard Jo recipe when successfully finding soup (costs money)
+	let discoveredRecipeId: string | undefined;
+	let recipeCost: number | undefined;
+	if (foodType === SmallEventConstants.PET_FOOD.FOOD_TYPES.SOUP && [
+		SmallEventConstants.PET_FOOD.OUTCOMES.FOUND_BY_PLAYER,
+		SmallEventConstants.PET_FOOD.OUTCOMES.FOUND_BY_PET,
+		SmallEventConstants.PET_FOOD.OUTCOMES.FOUND_ANYWAY
+	].includes(outcome)) {
+		const discovery = await RecipeDiscoveryService.tryDiscoverAndPay({
+			player,
+			source: RecipeDiscoverySource.GASPARD_JO,
+			costs: GASPARD_JO_RECIPE_COSTS,
+			response
+		});
+		discoveredRecipeId = discovery.discoveredRecipeId;
+		recipeCost = discovery.recipeCost;
+	}
+
 	response.push(makePacket(SmallEventPetFoodPacket, {
 		outcome,
 		foodType,
 		loveChange,
 		timeLost: wasInvestigating ? SmallEventConstants.PET_FOOD.TRAVEL_TIME_PENALTY_MINUTES : undefined,
-		petSex: petEntity.sex
+		petSex: petEntity.sex,
+		discoveredRecipeId,
+		recipeCost
 	}));
 }
 

--- a/Core/src/core/smallEvents/witch.ts
+++ b/Core/src/core/smallEvents/witch.ts
@@ -30,6 +30,7 @@ import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants"
 import { WitchActionOutcomeType } from "../../../../Lib/src/types/WitchActionOutcomeType";
 import { Effect } from "../../../../Lib/src/types/Effect";
 import { ClassConstants } from "../../../../Lib/src/constants/ClassConstants";
+import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
 
 
 type WitchEventSelection = {
@@ -91,7 +92,7 @@ async function givePotion(context: PacketContext, player: Player, potionToGive: 
  * @param player
  * @param response
  */
-async function applyOutcome(outcome: WitchActionOutcomeType, selectedEvent: WitchAction, context: PacketContext, player: Player, response: CrowniclesPacket[]): Promise<void> {
+async function applyOutcome(outcome: WitchActionOutcomeType, selectedEvent: WitchAction, context: PacketContext, player: Player, response: CrowniclesPacket[]): Promise<string | undefined> {
 	if (selectedEvent.forceEffect || outcome === WitchActionOutcomeType.EFFECT) {
 		await selectedEvent.giveEffect(player);
 	}
@@ -111,8 +112,17 @@ async function applyOutcome(outcome: WitchActionOutcomeType, selectedEvent: Witc
 			generateRandomItem(potionToGive),
 			response
 		);
+
+		// Discover a cooking recipe matching the potion nature
+		const potionNature = potionToGive.subType ?? ItemNature.NONE;
+		const discovered = await RecipeDiscoveryService.discoverWitchRecipe(player, potionNature);
+		if (discovered) {
+			await player.save();
+			return discovered.id;
+		}
 	}
 	await player.save();
+	return undefined;
 }
 
 function getEndCallback(player: Player): EndCallback {
@@ -142,6 +152,7 @@ function getEndCallback(player: Player): EndCallback {
 				await selectedEvent.giveEffect(player);
 			}
 			resultPacket.outcome = WitchActionOutcomeType.POTION;
+
 			response.push(resultPacket);
 			const potionToGive = generateRandomItem({
 				itemCategory: ItemCategory.POTION,
@@ -151,9 +162,12 @@ function getEndCallback(player: Player): EndCallback {
 			return;
 		}
 
-		response.push(resultPacket);
+		const discoveredRecipeId = await applyOutcome(outcome, selectedEvent, collector.context, player, response);
+		if (discoveredRecipeId) {
+			resultPacket.discoveredRecipeId = discoveredRecipeId;
+		}
 
-		await applyOutcome(outcome, selectedEvent, collector.context, player, response);
+		response.push(resultPacket);
 
 		await selectedEvent.checkMissionsWitchAction(player, outcome, response);
 	};

--- a/Core/src/data/CookingRecipeData.ts
+++ b/Core/src/data/CookingRecipeData.ts
@@ -1,7 +1,7 @@
 import { DataControllerString } from "./DataController";
 import { Data } from "./Data";
 import {
-	CookingRecipeMaterial, CookingRecipePlant
+	CookingRecipeMaterial, CookingRecipePlant, PetFoodRecipe
 } from "../../../Lib/src/types/CookingRecipe";
 import {
 	CookingOutputTypeValue, RecipeDiscoverySource, RecipeType
@@ -9,7 +9,6 @@ import {
 import {
 	ItemNature, ItemRarity
 } from "../../../Lib/src/constants/ItemConstants";
-import { PetFood } from "../../../Lib/src/types/PetFood";
 
 export class CookingRecipeData extends Data<string> {
 	public readonly level!: number;
@@ -26,11 +25,7 @@ export class CookingRecipeData extends Data<string> {
 
 	public readonly potionRarity?: ItemRarity;
 
-	public readonly petFoodType?: PetFood;
-
-	public readonly petFoodQuantity?: number;
-
-	public readonly petFoodLovePoints?: number;
+	public readonly petFood!: PetFoodRecipe | null;
 
 	public readonly outputMaterialId?: number;
 

--- a/Core/src/data/Pet.ts
+++ b/Core/src/data/Pet.ts
@@ -28,6 +28,22 @@ export class Pet extends Data<number> {
 	public canEatVegetables(): boolean {
 		return this.diet === PetConstants.RESTRICTIVES_DIETS.HERBIVOROUS || !this.diet;
 	}
+
+	/**
+	 * Returns true if this pet can eat the given food type
+	 */
+	public canEatFood(foodType: string): boolean {
+		if (foodType === PetConstants.PET_FOOD.COMMON_FOOD || foodType === PetConstants.PET_FOOD.ULTIMATE_FOOD) {
+			return true;
+		}
+		if (foodType === PetConstants.PET_FOOD.HERBIVOROUS_FOOD) {
+			return this.canEatVegetables();
+		}
+		if (foodType === PetConstants.PET_FOOD.CARNIVOROUS_FOOD) {
+			return this.canEatMeat();
+		}
+		return false;
+	}
 }
 
 export class PetDataController extends DataControllerNumber<Pet> {

--- a/Discord/src/commands/player/ProfileCommand.ts
+++ b/Discord/src/commands/player/ProfileCommand.ts
@@ -109,7 +109,7 @@ function addField(fields: EmbedField[], fieldKey: string, shouldBeFielded: boole
  * Add information field (health, money, experience, tokens)
  */
 function addInformationField(fields: EmbedField[], packet: CommandProfilePacketRes, lng: Language): void {
-	const showTokens = packet.playerData.level >= TokensConstants.LEVEL_TO_UNLOCK;
+	const showTokens = packet.playerData.tokens !== undefined;
 	addField(fields, showTokens ? "information" : "informationNoTokens", true, {
 		lng,
 		health: packet.playerData.health.value,
@@ -117,8 +117,8 @@ function addInformationField(fields: EmbedField[], packet: CommandProfilePacketR
 		money: packet.playerData.money,
 		experience: packet.playerData.experience.value,
 		experienceNeededToLevelUp: packet.playerData.experience.max,
-		tokens: packet.playerData.tokens ?? 0,
-		tokensMax: packet.playerData.tokensMax ?? TokensConstants.MAX
+		tokens: packet.playerData.tokens?.value ?? 0,
+		tokensMax: packet.playerData.tokens?.max ?? TokensConstants.MAX
 	});
 }
 

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -1,6 +1,7 @@
 import { PlantId } from "./PlantConstants";
 import { CrowniclesIcons } from "../CrowniclesIcons";
 import { MaterialRarity } from "../types/MaterialRarity";
+import { hoursToMilliseconds } from "../utils/TimeUtils";
 
 /**
  * Cooking recipe types — each maps to a specific base plant
@@ -344,7 +345,7 @@ export const MIN_GUARANTEED_PLAYER_LEVEL_RECIPES = 2;
  */
 export const FURNACE_MAX_USES_PER_DAY = 10;
 export const FURNACE_MIN_OVERHEAT_HOURS = 6;
-export const FURNACE_MIN_OVERHEAT_MS = FURNACE_MIN_OVERHEAT_HOURS * 60 * 60 * 1000;
+export const FURNACE_MIN_OVERHEAT_MS = hoursToMilliseconds(FURNACE_MIN_OVERHEAT_HOURS);
 
 /**
  * Gaspard Jo recipe costs by grade index (0-9)

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -332,6 +332,11 @@ export const SLOT_SEED_OFFSETS = [
 ] as const;
 
 /**
+ * Minimum number of recipes at or below the player's grade level that should be guaranteed across all slots
+ */
+export const MIN_GUARANTEED_PLAYER_LEVEL_RECIPES = 2;
+
+/**
  * Furnace overheat constants
  */
 export const FURNACE_MAX_USES_PER_DAY = 10;

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -237,12 +237,6 @@ export const CookingXpConstants = {
 export const FAILURE_LEVEL_OFFSET = 18;
 
 /**
- * Alias to preserve naming compatibility while clarifying intent.
- * This constant is an offset applied to recipe level in failure penalty.
- */
-export const FAILURE_LEVEL_PENALTY_OFFSET = FAILURE_LEVEL_OFFSET;
-
-/**
  * If the recipe level exceeds the grade's max by this amount or more, no XP is gained
  */
 export const NO_XP_LEVEL_THRESHOLD = 3;
@@ -350,6 +344,7 @@ export const MIN_GUARANTEED_PLAYER_LEVEL_RECIPES = 2;
  */
 export const FURNACE_MAX_USES_PER_DAY = 10;
 export const FURNACE_MIN_OVERHEAT_HOURS = 6;
+export const FURNACE_MIN_OVERHEAT_MS = FURNACE_MIN_OVERHEAT_HOURS * 60 * 60 * 1000;
 
 /**
  * Gaspard Jo recipe costs by grade index (0-9)

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -1,5 +1,6 @@
 import { PlantId } from "./PlantConstants";
 import { CrowniclesIcons } from "../CrowniclesIcons";
+import { MaterialRarity } from "../types/MaterialRarity";
 
 /**
  * Cooking recipe types — each maps to a specific base plant
@@ -216,10 +217,10 @@ export const PLANT_COOKING_XP: Record<PlantId, number> = {
 /**
  * XP per material rarity (MaterialRarity enum: COMMON=1, UNCOMMON=2, RARE=3)
  */
-export const MATERIAL_RARITY_COOKING_XP: Record<number, number> = {
-	1: 15,
-	2: 40,
-	3: 80
+export const MATERIAL_RARITY_COOKING_XP: Record<MaterialRarity, number> = {
+	[MaterialRarity.COMMON]: 15,
+	[MaterialRarity.UNCOMMON]: 40,
+	[MaterialRarity.RARE]: 80
 };
 
 export const CookingXpConstants = {
@@ -229,9 +230,11 @@ export const CookingXpConstants = {
 } as const;
 
 /**
- * Failure rate penalty multiplier when recipe is above grade limit
+ * Level offset added to recipe level when calculating the failure rate penalty
+ * for recipes above the grade's max level without penalty.
+ * Formula: failureRate * (FAILURE_LEVEL_OFFSET + recipeLevel)
  */
-export const FAILURE_PENALTY_BASE = 18;
+export const FAILURE_LEVEL_OFFSET = 18;
 
 /**
  * If the recipe level exceeds the grade's max by this amount or more, no XP is gained

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -237,6 +237,12 @@ export const CookingXpConstants = {
 export const FAILURE_LEVEL_OFFSET = 18;
 
 /**
+ * Alias to preserve naming compatibility while clarifying intent.
+ * This constant is an offset applied to recipe level in failure penalty.
+ */
+export const FAILURE_LEVEL_PENALTY_OFFSET = FAILURE_LEVEL_OFFSET;
+
+/**
  * If the recipe level exceeds the grade's max by this amount or more, no XP is gained
  */
 export const NO_XP_LEVEL_THRESHOLD = 3;

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -344,8 +344,7 @@ export const MIN_GUARANTEED_PLAYER_LEVEL_RECIPES = 2;
  * Furnace overheat constants
  */
 export const FURNACE_MAX_USES_PER_DAY = 10;
-export const FURNACE_MIN_OVERHEAT_HOURS = 6;
-export const FURNACE_MIN_OVERHEAT_MS = hoursToMilliseconds(FURNACE_MIN_OVERHEAT_HOURS);
+export const FURNACE_MIN_OVERHEAT_MS = hoursToMilliseconds(6);
 
 /**
  * Gaspard Jo recipe costs by grade index (0-9)

--- a/Lib/src/constants/ShopConstants.ts
+++ b/Lib/src/constants/ShopConstants.ts
@@ -30,6 +30,20 @@ export abstract class ShopConstants {
 		5,
 		10
 	];
+
+	static readonly LUMBERJACK_PRICES = {
+		COMMON: 10,
+		UNCOMMON: 35,
+		RARE: 100
+	};
+
+	static readonly LUMBERJACK_AMOUNTS = [
+		5,
+		10,
+		15,
+		25,
+		50
+	];
 }
 
 export enum ShopCurrency {

--- a/Lib/src/packets/commands/CommandProfilePacket.ts
+++ b/Lib/src/packets/commands/CommandProfilePacket.ts
@@ -79,9 +79,13 @@ export class CommandProfilePacketRes extends CrowniclesPacket {
 			max: number;
 		};
 		money: number;
-		tokens?: number;
-		tokensMax?: number;
-		cookingLevel?: number;
-		cookingGrade?: string;
+		tokens?: {
+			value: number;
+			max: number;
+		};
+		cooking?: {
+			level: number;
+			grade: string;
+		};
 	};
 }

--- a/Lib/src/packets/commands/CommandReportPacket.ts
+++ b/Lib/src/packets/commands/CommandReportPacket.ts
@@ -476,6 +476,20 @@ export class CommandReportCookingCraftReq extends CrowniclesPacket {
 	slotIndex!: number;
 }
 
+export interface CraftPetFoodResult {
+	type: PetFood;
+	quantity: number;
+	storedQuantity: number;
+	fedFromSurplus?: boolean;
+	surplusMaterialId?: number;
+	surplusMaterialQuantity?: number;
+}
+
+export interface CraftMaterialResult {
+	materialId: number;
+	quantity: number;
+}
+
 @sendablePacket(PacketDirection.NONE)
 export class CommandReportCookingCraftRes extends CrowniclesPacket {
 	success!: boolean;
@@ -488,27 +502,9 @@ export class CommandReportCookingCraftRes extends CrowniclesPacket {
 
 	potionId?: number;
 
-	petFoodType?: PetFood;
+	petFood?: CraftPetFoodResult;
 
-	petFoodQuantity?: number;
-
-	/** How much food was actually stored in guild (may be less than recipe output) */
-	petFoodStoredQuantity?: number;
-
-	/** Whether the player's pet was fed from surplus food */
-	petFedFromSurplus?: boolean;
-
-	/** Material ID returned from surplus food recycling */
-	surplusMaterialId?: number;
-
-	/** Quantity of materials returned from surplus food recycling */
-	surplusMaterialQuantity?: number;
-
-	/** Material ID crafted from a material recipe */
-	craftedMaterialId?: number;
-
-	/** Quantity of materials crafted from a material recipe */
-	craftedMaterialQuantity?: number;
+	material?: CraftMaterialResult;
 
 	failedPotionId?: number;
 

--- a/Lib/src/packets/interaction/ReactionCollectorShop.ts
+++ b/Lib/src/packets/interaction/ReactionCollectorShop.ts
@@ -19,7 +19,7 @@ export interface ShopItem {
 
 	price: number;
 
-	amounts: number[];
+	amounts: readonly number[];
 
 	buyCallback: (response: CrowniclesPacket[], player: number, context: PacketContext, amount: number) => boolean | Promise<boolean>;
 }

--- a/Lib/src/types/CookingRecipe.ts
+++ b/Lib/src/types/CookingRecipe.ts
@@ -17,6 +17,12 @@ export interface CookingRecipePlant {
 	quantity: number;
 }
 
+export interface PetFoodRecipe {
+	type: PetFood;
+	quantity: number;
+	lovePoints: number;
+}
+
 export interface CookingRecipe {
 	id: string;
 	level: number;
@@ -26,9 +32,7 @@ export interface CookingRecipe {
 	outputType: CookingOutputTypeValue;
 	potionNature?: ItemNature;
 	potionRarity?: ItemRarity;
-	petFoodType?: PetFood;
-	petFoodQuantity?: number;
-	petFoodLovePoints?: number;
+	petFood: PetFoodRecipe | null;
 	outputMaterialId?: number;
 	outputMaterialQuantity?: number;
 	discoveredByDefault: boolean;

--- a/Lib/src/types/CookingTypes.ts
+++ b/Lib/src/types/CookingTypes.ts
@@ -26,6 +26,8 @@ export interface CookingSlotData {
 	} | null;
 }
 
+export type RecipeSlotData = NonNullable<CookingSlotData["recipe"]>;
+
 export const CookingCraftErrors = {
 	CRAFT_UNAVAILABLE: "craftUnavailable",
 	INVENTORY_FULL: "inventoryFull",

--- a/Lib/src/utils/RandomUtils.ts
+++ b/Lib/src/utils/RandomUtils.ts
@@ -54,10 +54,10 @@ export abstract class RandomUtils {
 	 */
 	static deterministicShuffle<T>(array: T[], seed: number): T[] {
 		const result = [...array];
-		let s = Math.abs(seed) | 1;
+		let lcgState = Math.abs(seed) | 1;
 		for (let i = result.length - 1; i > 0; i--) {
-			s = (s * 1103515245 + 12345) & 0x7fffffff;
-			const j = s % (i + 1);
+			lcgState = (lcgState * 1103515245 + 12345) & 0x7fffffff;
+			const j = lcgState % (i + 1);
 			[result[i], result[j]] = [result[j], result[i]];
 		}
 		return result;

--- a/Lib/src/utils/RandomUtils.ts
+++ b/Lib/src/utils/RandomUtils.ts
@@ -47,4 +47,19 @@ export abstract class RandomUtils {
 		const randomIndex = RandomUtils.randInt(0, enumValues.length);
 		return enumValues[randomIndex];
 	};
+
+	/**
+	 * Deterministic Fisher-Yates shuffle using a simple LCG seeded PRNG.
+	 * Always produces the same output for the same input array and seed.
+	 */
+	static deterministicShuffle<T>(array: T[], seed: number): T[] {
+		const result = [...array];
+		let s = Math.abs(seed) | 1;
+		for (let i = result.length - 1; i > 0; i--) {
+			s = (s * 1103515245 + 12345) & 0x7fffffff;
+			const j = s % (i + 1);
+			[result[i], result[j]] = [result[j], result[i]];
+		}
+		return result;
+	}
 }

--- a/Lib/src/utils/RandomUtils.ts
+++ b/Lib/src/utils/RandomUtils.ts
@@ -54,9 +54,12 @@ export abstract class RandomUtils {
 	 */
 	static deterministicShuffle<T>(array: T[], seed: number): T[] {
 		const result = [...array];
-		let lcgState = Math.abs(seed) | 1;
+		let lcgState = seed >>> 0;
+		if (lcgState === 0) {
+			lcgState = 1;
+		}
 		for (let i = result.length - 1; i > 0; i--) {
-			lcgState = (lcgState * 1103515245 + 12345) & 0x7fffffff;
+			lcgState = (lcgState * 1103515245 + 12345) >>> 0;
 			const j = lcgState % (i + 1);
 			[result[i], result[j]] = [result[j], result[i]];
 		}


### PR DESCRIPTION
## PR 3/4 — Cooking Core Backend

Backend du système de cuisson : services de jeu, handlers MQTT, intégration small events.

### Contenu
- **Core Cooking** : `CookingService`, `CookingSlotRotation` (rotation hebdomadaire des recettes)
- **Core Report** : `ReportCookingService` (ignite, craft, revive), `ReportCityShopService` (shop bois), `ReportCityService` (notary amélioré)
- **Core Handlers** : enregistrement packets cooking dans `CoreHandlers`
- **Small Events** : intégration cooking dans `farmer`, `petFood` (surplus → matériaux), `witch` (découverte recettes)
- **Missions** : découverte recettes via campagne (`Campaign.ts`) et boss PvE
- **Tests** : 4 suites de tests (CookingConstants, CookingService, CookingSlotRotation, CookingRecipeData)
- **Test Commands** : `GiveMaterialTestCommand`, `ResetFurnaceTestCommand`

### Dépendances
- Base : `cooking-1-foundation` (PR #4087)
- Indépendant de PR 3 (Discord UI)

Relates to #3592