### PR TITLE
Refactor Discord i18n typing

### DIFF
--- a/Discord/__tests__/utils/StringUtils.test.ts
+++ b/Discord/__tests__/utils/StringUtils.test.ts
@@ -66,7 +66,7 @@ describe('StringUtils', () => {
 			randomSpy.mockRestore();
 		});
 
-		it('should pass replacements to i18n.t', () => {
+		it('should pass replacements to i18n.tArray', () => {
 			// Setup
 			const mockTranslations = ['Hello {{name}}', 'Hi {{name}}'];
 			(i18n.tArray as any).mockReturnValue(mockTranslations);

--- a/Discord/__tests__/utils/StringUtils.test.ts
+++ b/Discord/__tests__/utils/StringUtils.test.ts
@@ -5,7 +5,8 @@ import i18n from "../../src/translations/i18n";
 vi.mock('../../src/translations/i18n', () => {
 	return {
 		default: {
-			t: vi.fn()
+			t: vi.fn(),
+			tArray: vi.fn()
 		}
 	};
 });
@@ -46,7 +47,7 @@ describe('StringUtils', () => {
 		it('should return a random item from the translation array', () => {
 			// Setup
 			const mockTranslations = ['Hello', 'Hi', 'Hey'];
-			(i18n.t as any).mockReturnValue(mockTranslations);
+			(i18n.tArray as any).mockReturnValue(mockTranslations);
 
 			// Mock Math.random to return a predictable value
 			const randomSpy = vi.spyOn(Math, 'floor');
@@ -56,7 +57,7 @@ describe('StringUtils', () => {
 			const result = StringUtils.getRandomTranslation('greeting', "en");
 
 			// Assert
-			expect(i18n.t).toHaveBeenCalledWith('greeting', {
+			expect(i18n.tArray).toHaveBeenCalledWith('greeting', {
 				returnObjects: true,
 				lng: "en"
 			});
@@ -69,14 +70,14 @@ describe('StringUtils', () => {
 		it('should pass replacements to i18n.t', () => {
 			// Setup
 			const mockTranslations = ['Hello {{name}}', 'Hi {{name}}'];
-			(i18n.t as any).mockReturnValue(mockTranslations);
+			(i18n.tArray as any).mockReturnValue(mockTranslations);
 			const randomSpy = vi.spyOn(Math, 'floor').mockReturnValue(0);
 
 			// Execute
 			const result = StringUtils.getRandomTranslation('greeting', "fr", {name: 'John'});
 
 			// Assert
-			expect(i18n.t).toHaveBeenCalledWith('greeting', {
+			expect(i18n.tArray).toHaveBeenCalledWith('greeting', {
 				returnObjects: true,
 				lng: "fr",
 				name: 'John'

--- a/Discord/__tests__/utils/StringUtils.test.ts
+++ b/Discord/__tests__/utils/StringUtils.test.ts
@@ -58,7 +58,6 @@ describe('StringUtils', () => {
 
 			// Assert
 			expect(i18n.tArray).toHaveBeenCalledWith('greeting', {
-				returnObjects: true,
 				lng: "en"
 			});
 			expect(result).toBe('Hi');
@@ -78,7 +77,6 @@ describe('StringUtils', () => {
 
 			// Assert
 			expect(i18n.tArray).toHaveBeenCalledWith('greeting', {
-				returnObjects: true,
 				lng: "fr",
 				name: 'John'
 			});

--- a/Discord/src/commands/player/ProfileCommand.ts
+++ b/Discord/src/commands/player/ProfileCommand.ts
@@ -3,7 +3,7 @@ import {
 	makePacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { CrowniclesInteraction } from "../../messages/CrowniclesInteraction";
-import i18n, { TranslationOption } from "../../translations/i18n";
+import i18n, { I18nCrowniclesOptions } from "../../translations/i18n";
 import { SlashCommandBuilderGenerator } from "../SlashCommandBuilderGenerator";
 import {
 	CommandProfilePacketReq,
@@ -93,9 +93,7 @@ async function displayBadges(badges: Badge[], msg: Message): Promise<void> {
  * @param shouldBeFielded
  * @param replacements
  */
-function addField(fields: EmbedField[], fieldKey: string, shouldBeFielded: boolean, replacements: TranslationOption & {
-	returnObjects?: false;
-}): void {
+function addField(fields: EmbedField[], fieldKey: string, shouldBeFielded: boolean, replacements: I18nCrowniclesOptions): void {
 	if (shouldBeFielded) {
 		fields.push({
 			name: i18n.t(`commands:profile.${fieldKey}.fieldName`, replacements),

--- a/Discord/src/commands/player/ProfileCommand.ts
+++ b/Discord/src/commands/player/ProfileCommand.ts
@@ -91,7 +91,7 @@ async function displayBadges(badges: Badge[], msg: Message): Promise<void> {
  * @param fields
  * @param fieldKey
  * @param shouldBeFielded
- * @param replacements
+ * @param replacements interpolation values reused for both translated field keys
  */
 function addField(fields: EmbedField[], fieldKey: string, shouldBeFielded: boolean, replacements: I18nCrowniclesOptions): void {
 	if (shouldBeFielded) {

--- a/Discord/src/commands/player/ReportCommand.ts
+++ b/Discord/src/commands/player/ReportCommand.ts
@@ -735,7 +735,6 @@ function addEnergyAndPointsFields(
  */
 function addAdviceField(travelEmbed: CrowniclesEmbed, lng: Language): void {
 	const advices = i18n.tArray("advices:advices", {
-		returnObjects: true,
 		lng
 	});
 	travelEmbed.addFields({

--- a/Discord/src/commands/player/ReportCommand.ts
+++ b/Discord/src/commands/player/ReportCommand.ts
@@ -18,7 +18,7 @@ import {
 import {
 	ReactionCollectorBigEventPacket
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorBigEvent";
-import i18n, { TranslationOption } from "../../translations/i18n";
+import i18n, { I18nCrowniclesOptions } from "../../translations/i18n";
 import {
 	ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, parseEmoji
 } from "discord.js";
@@ -150,7 +150,7 @@ export async function createBigEventCollector(context: PacketContext, packet: Re
 }
 
 type Condition = boolean | number | undefined;
-type ConditionTriplet = [Condition, string, Omit<TranslationOption, "lng">];
+type ConditionTriplet = [Condition, string, Omit<I18nCrowniclesOptions, "lng">];
 
 function getReportResultConditionTriplets(packet: CommandReportBigEventResultRes, lng: Language): ConditionTriplet[] {
 	return [
@@ -734,7 +734,7 @@ function addEnergyAndPointsFields(
  * Add a random advice field to the travel embed
  */
 function addAdviceField(travelEmbed: CrowniclesEmbed, lng: Language): void {
-	const advices = i18n.t("advices:advices", {
+	const advices = i18n.tArray("advices:advices", {
 		returnObjects: true,
 		lng
 	});

--- a/Discord/src/packetHandlers/handlers/SmallEventsHandler.ts
+++ b/Discord/src/packetHandlers/handlers/SmallEventsHandler.ts
@@ -461,7 +461,6 @@ export default class SmallEventsHandler {
 		}
 		const lng = interaction.userLanguage;
 		const staffMember = RandomUtils.crowniclesRandom.pick(Object.keys(i18n.tRecord("smallEvents:staffMember.members", {
-			returnObjects: true,
 			lng
 		})));
 		await interaction.editReply({
@@ -646,7 +645,6 @@ export default class SmallEventsHandler {
 						specific: StringUtils.getRandomTranslation(`smallEvents:space.specific.${packet.chosenEvent}`, lng, {
 							mainValue: packet.chosenEvent === "moonPhase"
 								? i18n.tArray("smallEvents:space.moonPhases", {
-									returnObjects: true,
 									lng
 								})[packet.values.mainValue]
 								: packet.values.mainValue,
@@ -1096,7 +1094,6 @@ export default class SmallEventsHandler {
 			case ExpeditionAdviceInteractionType.TALISMAN_INTRO: {
 				// Talisman introduction (first 2 encounters, displayed in order)
 				const introTexts = i18n.tArray("smallEvents:expeditionAdvice.talismanIntro", {
-					returnObjects: true,
 					lng
 				});
 				story = introTexts[packet.encounterCount! - 1] ?? introTexts[0];

--- a/Discord/src/packetHandlers/handlers/SmallEventsHandler.ts
+++ b/Discord/src/packetHandlers/handlers/SmallEventsHandler.ts
@@ -460,7 +460,7 @@ export default class SmallEventsHandler {
 			return;
 		}
 		const lng = interaction.userLanguage;
-		const staffMember = RandomUtils.crowniclesRandom.pick(Object.keys(i18n.t("smallEvents:staffMember.members", {
+		const staffMember = RandomUtils.crowniclesRandom.pick(Object.keys(i18n.tRecord("smallEvents:staffMember.members", {
 			returnObjects: true,
 			lng
 		})));
@@ -645,7 +645,7 @@ export default class SmallEventsHandler {
 						action: StringUtils.getRandomTranslation("smallEvents:space.action", lng),
 						specific: StringUtils.getRandomTranslation(`smallEvents:space.specific.${packet.chosenEvent}`, lng, {
 							mainValue: packet.chosenEvent === "moonPhase"
-								? i18n.t("smallEvents:space.moonPhases", {
+								? i18n.tArray("smallEvents:space.moonPhases", {
 									returnObjects: true,
 									lng
 								})[packet.values.mainValue]
@@ -1095,7 +1095,7 @@ export default class SmallEventsHandler {
 		switch (packet.interactionType) {
 			case ExpeditionAdviceInteractionType.TALISMAN_INTRO: {
 				// Talisman introduction (first 2 encounters, displayed in order)
-				const introTexts: string[] = i18n.t("smallEvents:expeditionAdvice.talismanIntro", {
+				const introTexts = i18n.tArray("smallEvents:expeditionAdvice.talismanIntro", {
 					returnObjects: true,
 					lng
 				});

--- a/Discord/src/smallEvents/epicItemShop.ts
+++ b/Discord/src/smallEvents/epicItemShop.ts
@@ -30,7 +30,7 @@ export async function epicItemShopCollector(context: PacketContext, packet: Reac
 		+ StringUtils.getRandomTranslation("smallEvents:shop.end", lng, {
 			item: DisplayUtils.getItemDisplayWithStats(data.item, lng),
 			price: data.price,
-			type: `${CrowniclesIcons.itemCategories[data.item.category]}${i18n.t("smallEvents:shop.types", {
+			type: `${CrowniclesIcons.itemCategories[data.item.category]}${i18n.tArray("smallEvents:shop.types", {
 				returnObjects: true,
 				lng
 			})[data.item.category]}`

--- a/Discord/src/smallEvents/epicItemShop.ts
+++ b/Discord/src/smallEvents/epicItemShop.ts
@@ -31,7 +31,6 @@ export async function epicItemShopCollector(context: PacketContext, packet: Reac
 			item: DisplayUtils.getItemDisplayWithStats(data.item, lng),
 			price: data.price,
 			type: `${CrowniclesIcons.itemCategories[data.item.category]}${i18n.tArray("smallEvents:shop.types", {
-				returnObjects: true,
 				lng
 			})[data.item.category]}`
 		}),

--- a/Discord/src/smallEvents/petFood.ts
+++ b/Discord/src/smallEvents/petFood.ts
@@ -153,8 +153,7 @@ export function getPetFoodDescription(packet: SmallEventPetFoodPacket, lng: Lang
 	const foodName = outcomeIsFound
 		? RandomUtils.crowniclesRandom.pick(
 			i18n.tArray(`smallEvents:petFood.foodNames.${packet.foodType}`, {
-				lng,
-				returnObjects: true
+				lng
 			})
 		)
 		: "";

--- a/Discord/src/smallEvents/petFood.ts
+++ b/Discord/src/smallEvents/petFood.ts
@@ -152,7 +152,7 @@ export function getPetFoodDescription(packet: SmallEventPetFoodPacket, lng: Lang
 	// If the food was actually found, pick a readable display name for it from translations
 	const foodName = outcomeIsFound
 		? RandomUtils.crowniclesRandom.pick(
-			i18n.t(`smallEvents:petFood.foodNames.${packet.foodType}`, {
+			i18n.tArray(`smallEvents:petFood.foodNames.${packet.foodType}`, {
 				lng,
 				returnObjects: true
 			})

--- a/Discord/src/smallEvents/shop.ts
+++ b/Discord/src/smallEvents/shop.ts
@@ -32,7 +32,7 @@ export async function smallShopCollector(context: PacketContext, packet: Reactio
 		+ StringUtils.getRandomTranslation("smallEvents:shop.end", lng, {
 			item: DisplayUtils.getItemDisplayWithStats(data.item, lng),
 			price: data.price,
-			type: `${CrowniclesIcons.itemCategories[data.item.category]}${i18n.t("smallEvents:shop.types", {
+			type: `${CrowniclesIcons.itemCategories[data.item.category]}${i18n.tArray("smallEvents:shop.types", {
 				returnObjects: true,
 				lng
 			})[data.item.category]}`

--- a/Discord/src/smallEvents/shop.ts
+++ b/Discord/src/smallEvents/shop.ts
@@ -33,7 +33,6 @@ export async function smallShopCollector(context: PacketContext, packet: Reactio
 			item: DisplayUtils.getItemDisplayWithStats(data.item, lng),
 			price: data.price,
 			type: `${CrowniclesIcons.itemCategories[data.item.category]}${i18n.tArray("smallEvents:shop.types", {
-				returnObjects: true,
 				lng
 			})[data.item.category]}`
 		}),

--- a/Discord/src/translations/i18n.ts
+++ b/Discord/src/translations/i18n.ts
@@ -107,6 +107,10 @@ function getReturnObjectsTranslation(key: string | string[], options: I18nCrowni
 	}) as string[] | Record<string, string>;
 }
 
+function isTranslationRecord(value: string[] | Record<string, string>): value is Record<string, string> {
+	return !Array.isArray(value) && typeof value === "object" && value !== null;
+}
+
 i18next.init(getI18nOptions())
 	.then();
 
@@ -148,7 +152,7 @@ export class I18nCrownicles {
 	static tRecord(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): Record<string, string> {
 		// Even with typed call-sites, missing keys or resource drift can still return the wrong shape at runtime.
 		const value = getReturnObjectsTranslation(key, options);
-		if (Array.isArray(value) || typeof value !== "object" || value === null) {
+		if (!isTranslationRecord(value)) {
 			throw new TypeError(`Expected translation record for key \"${getTranslationKeyForError(key)}\" in language \"${options.lng}\"`);
 		}
 		return Object.entries(value)

--- a/Discord/src/translations/i18n.ts
+++ b/Discord/src/translations/i18n.ts
@@ -132,9 +132,10 @@ export class I18nCrownicles {
 	 * @param options
 	 */
 	static tArray(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): string[] {
+		// Even with typed call-sites, missing keys or resource drift can still return the wrong shape at runtime.
 		const value = getReturnObjectsTranslation(key, options);
 		if (!Array.isArray(value)) {
-			throw new TypeError(`Expected translation array for key \"${getTranslationKeyForError(key)}\"`);
+			throw new TypeError(`Expected translation array for key \"${getTranslationKeyForError(key)}\" in language \"${options.lng}\"`);
 		}
 		return value.map(crowniclesFormat);
 	}
@@ -145,9 +146,10 @@ export class I18nCrownicles {
 	 * @param options
 	 */
 	static tRecord(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): Record<string, string> {
+		// Even with typed call-sites, missing keys or resource drift can still return the wrong shape at runtime.
 		const value = getReturnObjectsTranslation(key, options);
 		if (Array.isArray(value) || typeof value !== "object" || value === null) {
-			throw new TypeError(`Expected translation record for key \"${getTranslationKeyForError(key)}\"`);
+			throw new TypeError(`Expected translation record for key \"${getTranslationKeyForError(key)}\" in language \"${options.lng}\"`);
 		}
 		return Object.entries(value)
 			.reduce((acc, [recordKey, value]) => {

--- a/Discord/src/translations/i18n.ts
+++ b/Discord/src/translations/i18n.ts
@@ -59,9 +59,13 @@ function convertEmoteFormat(str: string): string {
 type EmotePathFolder = Record<string, unknown> | string[];
 type EmotePath = EmotePathFolder | string;
 
-export type TranslationOption = Omit<i18next.TOptions, "context"> & {
+export type I18nCrowniclesOptions = Omit<i18next.TOptions, "context" | "returnObjects"> & {
 	lng: Language;
 	context?: string;
+};
+
+export type I18nCrowniclesReturnObjectsOptions = I18nCrowniclesOptions & {
+	returnObjects: true;
 };
 
 /**
@@ -99,57 +103,39 @@ i18next.init(getI18nOptions())
 
 export class I18nCrownicles {
 	/**
-	 * Translate the given key with the given options and returns all the objects found
-	 * @param key
-	 * @param options
-	 */
-	static t(key: string | string[], options: {
-		lng: Language;
-		returnObjects: true;
-	} & Omit<i18next.TOptions, "context"> & { context?: string }): string[];
-
-	/**
-	 * Translate the given key with the given options
-	 * @param key
-	 * @param options
-	 */
-	static t(key: string | string[], options: {
-		lng: Language;
-		returnObjects?: false;
-	} & Omit<i18next.TOptions, "context"> & { context?: string }): string;
-
-	/**
-	 * Translate the given key with the given options
-	 * @param key
-	 * @param options
-	 */
-	static t(key: string | string[], options: {
-		lng: Language;
-		returnObjects: true;
-	} & Omit<i18next.TOptions, "context"> & { context?: string }): Record<string, string>;
-
-	/**
-	 * Translate the given key with the given options
-	 * Override of the i18next.t function to allow the following :
+	 * Translate the given key with the given options.
+	 * Use tArray or tRecord for returnObjects translations.
+	 * Override of the i18next.t function to allow the following:
 	 * - replace the "{command:...}" format by the corresponding discord command
 	 * - force lng to be a Language value and being required
-	 * - force the return type to be a string (and not a never)
+	 * - force the return type to be a string
 	 * @param key
 	 * @param options
 	 */
-	static t(key: string | string[], options: TranslationOption): string | string[] | Record<string, string> {
-		const value: string | string[] | object = i18next.t(key, options);
-		if (options.returnObjects && !Array.isArray(value)) {
-			return Object.entries(value)
-				.reduce((acc, [k, v]) => {
-					acc[k] = crowniclesFormat(v as string);
-					return acc;
-				}, {} as Record<string, string>);
-		}
-		if (Array.isArray(value)) {
-			return (value as string[]).map(crowniclesFormat);
-		}
-		return crowniclesFormat(value);
+	static t(key: string | string[], options: I18nCrowniclesOptions): string {
+		return crowniclesFormat(i18next.t(key, options) as string);
+	}
+
+	/**
+	 * Translate the given key with returnObjects=true and return a string array.
+	 * @param key
+	 * @param options
+	 */
+	static tArray(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): string[] {
+		return (i18next.t(key, options) as string[]).map(crowniclesFormat);
+	}
+
+	/**
+	 * Translate the given key with returnObjects=true and return a string record.
+	 * @param key
+	 * @param options
+	 */
+	static tRecord(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): Record<string, string> {
+		return Object.entries(i18next.t(key, options) as Record<string, string>)
+			.reduce((acc, [recordKey, value]) => {
+				acc[recordKey] = crowniclesFormat(value);
+				return acc;
+			}, {} as Record<string, string>);
 	}
 
 	/**

--- a/Discord/src/translations/i18n.ts
+++ b/Discord/src/translations/i18n.ts
@@ -139,7 +139,7 @@ export class I18nCrownicles {
 		// Even with typed call-sites, missing keys or resource drift can still return the wrong shape at runtime.
 		const value = getReturnObjectsTranslation(key, options);
 		if (!Array.isArray(value)) {
-			throw new TypeError(`Expected translation array for key \"${getTranslationKeyForError(key)}\" in language \"${options.lng}\"`);
+			throw new TypeError(`Expected translation array for key "${getTranslationKeyForError(key)}" in language "${options.lng}"`);
 		}
 		return value.map(crowniclesFormat);
 	}
@@ -153,7 +153,7 @@ export class I18nCrownicles {
 		// Even with typed call-sites, missing keys or resource drift can still return the wrong shape at runtime.
 		const value = getReturnObjectsTranslation(key, options);
 		if (!isTranslationRecord(value)) {
-			throw new TypeError(`Expected translation record for key \"${getTranslationKeyForError(key)}\" in language \"${options.lng}\"`);
+			throw new TypeError(`Expected translation record for key "${getTranslationKeyForError(key)}" in language "${options.lng}"`);
 		}
 		return Object.entries(value)
 			.reduce((acc, [recordKey, value]) => {

--- a/Discord/src/translations/i18n.ts
+++ b/Discord/src/translations/i18n.ts
@@ -64,9 +64,7 @@ export type I18nCrowniclesOptions = Omit<i18next.TOptions, "context" | "returnOb
 	context?: string;
 };
 
-export type I18nCrowniclesReturnObjectsOptions = I18nCrowniclesOptions & {
-	returnObjects: true;
-};
+export type I18nCrowniclesReturnObjectsOptions = I18nCrowniclesOptions;
 
 /**
  * Get the corresponding to emote for the given emote name
@@ -98,6 +96,17 @@ function crowniclesFormat(str: string): string {
 	return convertCommandFormat(convertEmoteFormat(str));
 }
 
+function getTranslationKeyForError(key: string | string[]): string {
+	return Array.isArray(key) ? key.join(", ") : key;
+}
+
+function getReturnObjectsTranslation(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): string[] | Record<string, string> {
+	return i18next.t(key, {
+		...options,
+		returnObjects: true
+	}) as string[] | Record<string, string>;
+}
+
 i18next.init(getI18nOptions())
 	.then();
 
@@ -109,6 +118,7 @@ export class I18nCrownicles {
 	 * - replace the "{command:...}" format by the corresponding discord command
 	 * - force lng to be a Language value and being required
 	 * - force the return type to be a string
+	 * - apply crowniclesFormat per value in tArray and tRecord variants
 	 * @param key
 	 * @param options
 	 */
@@ -122,7 +132,11 @@ export class I18nCrownicles {
 	 * @param options
 	 */
 	static tArray(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): string[] {
-		return (i18next.t(key, options) as string[]).map(crowniclesFormat);
+		const value = getReturnObjectsTranslation(key, options);
+		if (!Array.isArray(value)) {
+			throw new TypeError(`Expected translation array for key \"${getTranslationKeyForError(key)}\"`);
+		}
+		return value.map(crowniclesFormat);
 	}
 
 	/**
@@ -131,7 +145,11 @@ export class I18nCrownicles {
 	 * @param options
 	 */
 	static tRecord(key: string | string[], options: I18nCrowniclesReturnObjectsOptions): Record<string, string> {
-		return Object.entries(i18next.t(key, options) as Record<string, string>)
+		const value = getReturnObjectsTranslation(key, options);
+		if (Array.isArray(value) || typeof value !== "object" || value === null) {
+			throw new TypeError(`Expected translation record for key \"${getTranslationKeyForError(key)}\"`);
+		}
+		return Object.entries(value)
 			.reduce((acc, [recordKey, value]) => {
 				acc[recordKey] = crowniclesFormat(value);
 				return acc;

--- a/Discord/src/utils/StringUtils.ts
+++ b/Discord/src/utils/StringUtils.ts
@@ -22,7 +22,7 @@ export abstract class StringUtils {
 		const {
 			context: _, ...remainingReplacements
 		} = replacements;
-		const intros: string[] = i18n.t(translationKey, {
+		const intros = i18n.tArray(translationKey, {
 			returnObjects: true,
 			lng,
 			...remainingReplacements

--- a/Discord/src/utils/StringUtils.ts
+++ b/Discord/src/utils/StringUtils.ts
@@ -23,7 +23,6 @@ export abstract class StringUtils {
 			context: _, ...remainingReplacements
 		} = replacements;
 		const intros = i18n.tArray(translationKey, {
-			returnObjects: true,
 			lng,
 			...remainingReplacements
 		});


### PR DESCRIPTION
Refactor the Discord i18n wrapper to make return types explicit.

Summary:
- factorize common i18n options typing
- add explicit tArray and tRecord helpers for returnObjects translations
- update existing Discord call-sites and StringUtils test

Why:
- the wrapper mixed string, array and record returns behind the same helper, which made typing noisy and easy to misuse

Closes #4143

Validation:
- pnpm exec tsc --noEmit --pretty false --incremental false
- pnpm exec eslint src/translations/i18n.ts src/utils/StringUtils.ts src/packetHandlers/handlers/SmallEventsHandler.ts src/commands/player/ProfileCommand.ts src/commands/player/ReportCommand.ts src/smallEvents/shop.ts src/smallEvents/epicItemShop.ts src/smallEvents/petFood.ts
- pnpm test