### PR TITLE
K-factor attacker boost based on attack count in logs

### DIFF
--- a/Core/__tests__/core/utils/EloUtils.test.ts
+++ b/Core/__tests__/core/utils/EloUtils.test.ts
@@ -23,44 +23,45 @@ describe('EloUtils', () => {
     describe('getAttackerKFactor', () => {
         const nonRoyalLeague = { id: 5 };
         const royalLeague = { id: LeagueInfoConstants.ROYAL_LEAGUE_ID };
+        const threshold = FightConstants.ELO.INACTIVE_ATTACKER_ATTACK_COUNT_THRESHOLD;
 
-        it('should return base k-factor when attacker is active (attackCount >= REGEN_LIMIT)', () => {
+        it('should return base k-factor when attacker is active (attackCount >= threshold)', () => {
             const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // 7+ attacks in window → attackBasedCountdown = 0 → no boost
-            expect(EloUtils.getAttackerKFactor(attacker, 7)).toBe(32);
-            expect(EloUtils.getAttackerKFactor(attacker, 10)).toBe(32);
+            // threshold+ attacks in window → attackBasedCountdown = 0 → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, threshold)).toBe(32);
+            expect(EloUtils.getAttackerKFactor(attacker, threshold + 3)).toBe(32);
         });
 
         it('should return base k-factor when attacker has recent activity (attackBasedCountdown <= 2)', () => {
             const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // 5 attacks → attackBasedCountdown = max(0, 7-5) = 2 → no boost
-            expect(EloUtils.getAttackerKFactor(attacker, 5)).toBe(32);
-            // 6 attacks → attackBasedCountdown = 1 → no boost
-            expect(EloUtils.getAttackerKFactor(attacker, 6)).toBe(32);
+            // threshold-2 attacks → attackBasedCountdown = 2 → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, threshold - 2)).toBe(32);
+            // threshold-1 attacks → attackBasedCountdown = 1 → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, threshold - 1)).toBe(32);
         });
 
         it('should return boosted k-factor when attacker is returning from inactivity (attackBasedCountdown >= 3)', () => {
             const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // 4 attacks → attackBasedCountdown = max(0, 7-4) = 3 → multiplier = min(3-1, 4) = 2
-            expect(EloUtils.getAttackerKFactor(attacker, 4)).toBe(32 * 2);
+            // threshold-3 attacks → attackBasedCountdown = 3 → multiplier = min(3-1, 4) = 2
+            expect(EloUtils.getAttackerKFactor(attacker, threshold - 3)).toBe(32 * 2);
         });
 
         it('should increase multiplier with higher inactivity', () => {
             const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // 3 attacks → attackBasedCountdown = 4 → multiplier = min(4-1, 4) = 3
-            expect(EloUtils.getAttackerKFactor(attacker, 3)).toBe(32 * 3);
+            // threshold-4 attacks → attackBasedCountdown = 4 → multiplier = min(4-1, 4) = 3
+            expect(EloUtils.getAttackerKFactor(attacker, threshold - 4)).toBe(32 * 3);
         });
 
         it('should cap the multiplier at INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER', () => {
             const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // 2 attacks → attackBasedCountdown = 5 → multiplier = min(5-1, 4) = 4 (capped)
-            expect(EloUtils.getAttackerKFactor(attacker, 2)).toBe(32 * 4);
-            // 0 attacks → attackBasedCountdown = 7 → multiplier = min(7-1, 4) = 4 (still capped)
+            // threshold-5 attacks → attackBasedCountdown = 5 → multiplier = min(5-1, 4) = 4 (capped)
+            expect(EloUtils.getAttackerKFactor(attacker, threshold - 5)).toBe(32 * 4);
+            // 0 attacks → attackBasedCountdown = threshold → multiplier capped at max
             expect(EloUtils.getAttackerKFactor(attacker, 0)).toBe(32 * FightConstants.ELO.INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER);
         });
 
@@ -75,15 +76,15 @@ describe('EloUtils', () => {
             // Player with 2200 glory → K = 24 (LOW_K_FACTOR)
             const highGloryAttacker = { getGloryPoints: () => 2200, getLeague: () => nonRoyalLeague } as any;
 
-            // 0 attacks → attackBasedCountdown = 7 → multiplier = 4 (capped)
+            // 0 attacks → attackBasedCountdown = threshold → multiplier = 4 (capped)
             expect(EloUtils.getAttackerKFactor(highGloryAttacker, 0)).toBe(24 * 4);
         });
 
-        it('should handle exact boundary at REGEN_LIMIT (7 attacks → no boost)', () => {
+        it('should handle exact boundary at threshold (threshold attacks → no boost)', () => {
             const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // 7 attacks → attackBasedCountdown = max(0, 7-7) = 0 → below threshold → no boost
-            expect(EloUtils.getAttackerKFactor(attacker, 7)).toBe(32);
+            // threshold attacks → attackBasedCountdown = 0 → below FIGHT_COUNTDOWN_THRESHOLD → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, threshold)).toBe(32);
         });
     });
 

--- a/Core/__tests__/core/utils/EloUtils.test.ts
+++ b/Core/__tests__/core/utils/EloUtils.test.ts
@@ -70,6 +70,21 @@ describe('EloUtils', () => {
             // Royal league → no boost, just base k-factor (12 for 3500 glory)
             expect(EloUtils.getAttackerKFactor(attacker, 0)).toBe(12);
         });
+
+        it('should apply lower base k-factor for high-glory players even with boost', () => {
+            // Player with 2200 glory → K = 24 (LOW_K_FACTOR)
+            const highGloryAttacker = { getGloryPoints: () => 2200, getLeague: () => nonRoyalLeague } as any;
+
+            // 0 attacks → attackBasedCountdown = 7 → multiplier = 4 (capped)
+            expect(EloUtils.getAttackerKFactor(highGloryAttacker, 0)).toBe(24 * 4);
+        });
+
+        it('should handle exact boundary at REGEN_LIMIT (7 attacks → no boost)', () => {
+            const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
+
+            // 7 attacks → attackBasedCountdown = max(0, 7-7) = 0 → below threshold → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, 7)).toBe(32);
+        });
     });
 
     describe('calculateNewRating', () => {

--- a/Core/__tests__/core/utils/EloUtils.test.ts
+++ b/Core/__tests__/core/utils/EloUtils.test.ts
@@ -24,43 +24,51 @@ describe('EloUtils', () => {
         const nonRoyalLeague = { id: 5 };
         const royalLeague = { id: LeagueInfoConstants.ROYAL_LEAGUE_ID };
 
-        it('should return base k-factor when attacker is active (fightCountdown <= 2)', () => {
-            const attacker0 = { getGloryPoints: () => 1500, fightCountdown: 0, getLeague: () => nonRoyalLeague } as any;
-            const attacker2 = { getGloryPoints: () => 1500, fightCountdown: 2, getLeague: () => nonRoyalLeague } as any;
+        it('should return base k-factor when attacker is active (attackCount >= REGEN_LIMIT)', () => {
+            const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            expect(EloUtils.getAttackerKFactor(attacker0)).toBe(32);
-            expect(EloUtils.getAttackerKFactor(attacker2)).toBe(32);
+            // 7+ attacks in window → attackBasedCountdown = 0 → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, 7)).toBe(32);
+            expect(EloUtils.getAttackerKFactor(attacker, 10)).toBe(32);
         });
 
-        it('should return boosted k-factor when attacker is returning from inactivity (fightCountdown >= 3)', () => {
-            const attacker = { getGloryPoints: () => 1500, fightCountdown: 3, getLeague: () => nonRoyalLeague } as any;
+        it('should return base k-factor when attacker has recent activity (attackBasedCountdown <= 2)', () => {
+            const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // fightCountdown=3 → multiplier = min(3-1, 4) = 2
-            expect(EloUtils.getAttackerKFactor(attacker)).toBe(32 * 2);
+            // 5 attacks → attackBasedCountdown = max(0, 7-5) = 2 → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, 5)).toBe(32);
+            // 6 attacks → attackBasedCountdown = 1 → no boost
+            expect(EloUtils.getAttackerKFactor(attacker, 6)).toBe(32);
         });
 
-        it('should increase multiplier with higher fightCountdown', () => {
-            const attacker = { getGloryPoints: () => 1500, fightCountdown: 4, getLeague: () => nonRoyalLeague } as any;
+        it('should return boosted k-factor when attacker is returning from inactivity (attackBasedCountdown >= 3)', () => {
+            const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // fightCountdown=4 → multiplier = min(4-1, 4) = 3
-            expect(EloUtils.getAttackerKFactor(attacker)).toBe(32 * 3);
+            // 4 attacks → attackBasedCountdown = max(0, 7-4) = 3 → multiplier = min(3-1, 4) = 2
+            expect(EloUtils.getAttackerKFactor(attacker, 4)).toBe(32 * 2);
+        });
+
+        it('should increase multiplier with higher inactivity', () => {
+            const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
+
+            // 3 attacks → attackBasedCountdown = 4 → multiplier = min(4-1, 4) = 3
+            expect(EloUtils.getAttackerKFactor(attacker, 3)).toBe(32 * 3);
         });
 
         it('should cap the multiplier at INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER', () => {
-            const attacker5 = { getGloryPoints: () => 1500, fightCountdown: 5, getLeague: () => nonRoyalLeague } as any;
-            const attacker7 = { getGloryPoints: () => 1500, fightCountdown: 7, getLeague: () => nonRoyalLeague } as any;
+            const attacker = { getGloryPoints: () => 1500, getLeague: () => nonRoyalLeague } as any;
 
-            // fightCountdown=5 → multiplier = min(5-1, 4) = 4 (capped)
-            expect(EloUtils.getAttackerKFactor(attacker5)).toBe(32 * 4);
-            // fightCountdown=7 → multiplier = min(7-1, 4) = 4 (still capped)
-            expect(EloUtils.getAttackerKFactor(attacker7)).toBe(32 * FightConstants.ELO.INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER);
+            // 2 attacks → attackBasedCountdown = 5 → multiplier = min(5-1, 4) = 4 (capped)
+            expect(EloUtils.getAttackerKFactor(attacker, 2)).toBe(32 * 4);
+            // 0 attacks → attackBasedCountdown = 7 → multiplier = min(7-1, 4) = 4 (still capped)
+            expect(EloUtils.getAttackerKFactor(attacker, 0)).toBe(32 * FightConstants.ELO.INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER);
         });
 
         it('should NOT boost k-factor for Royal league players even when inactive', () => {
-            const attacker = { getGloryPoints: () => 3500, fightCountdown: 5, getLeague: () => royalLeague } as any;
+            const attacker = { getGloryPoints: () => 3500, getLeague: () => royalLeague } as any;
 
             // Royal league → no boost, just base k-factor (12 for 3500 glory)
-            expect(EloUtils.getAttackerKFactor(attacker)).toBe(12);
+            expect(EloUtils.getAttackerKFactor(attacker, 0)).toBe(12);
         });
     });
 

--- a/Core/src/commands/player/FightCommand.ts
+++ b/Core/src/commands/player/FightCommand.ts
@@ -24,6 +24,7 @@ import {
 	PersonalFightDailySummary,
 	RankedFightResult
 } from "../../core/database/logs/LogsReadRequests";
+import { LogsFightHistoryRequests } from "../../core/database/logs/requests/LogsFightHistoryRequests";
 import {
 	FightController
 } from "../../core/fights/FightController";
@@ -207,7 +208,11 @@ async function updatePlayersEloAndCooldowns(
 	fightLogId: number | null
 ): Promise<void> {
 	// Calculate elo
-	const player1KFactor = EloUtils.getAttackerKFactor(attacker);
+	const attackCountInWindow = await LogsFightHistoryRequests.getAttackCountInLastNWeeks(
+		attacker.keycloakId,
+		FightConstants.ELO.ATTACK_COUNT_WINDOW_WEEKS
+	);
+	const player1KFactor = EloUtils.getAttackerKFactor(attacker, attackCountInWindow);
 	const player2KFactor = EloUtils.getKFactor(defender);
 	const player1NewRating = EloUtils.calculateNewRating(attacker.attackGloryPoints, defender.defenseGloryPoints, attackerGameResult, player1KFactor);
 	const player2NewRating = EloUtils.calculateNewRating(defender.defenseGloryPoints, attacker.attackGloryPoints, defenderGameResult, player2KFactor);

--- a/Core/src/commands/player/FightCommand.ts
+++ b/Core/src/commands/player/FightCommand.ts
@@ -208,10 +208,13 @@ async function updatePlayersEloAndCooldowns(
 	fightLogId: number | null
 ): Promise<void> {
 	// Calculate elo
-	const attackCountInWindow = await LogsFightHistoryRequests.getAttackCountInLastNWeeks(
+	const rawAttackCountInWindow = await LogsFightHistoryRequests.getAttackCountInLastNWeeks(
 		attacker.keycloakId,
 		FightConstants.ELO.ATTACK_COUNT_WINDOW_WEEKS
 	);
+
+	// The current fight is already logged at this point, subtract 1 to count only previous attacks
+	const attackCountInWindow = Math.max(0, rawAttackCountInWindow - (fightLogId !== null ? 1 : 0));
 	const player1KFactor = EloUtils.getAttackerKFactor(attacker, attackCountInWindow);
 	const player2KFactor = EloUtils.getKFactor(defender);
 	const player1NewRating = EloUtils.calculateNewRating(attacker.attackGloryPoints, defender.defenseGloryPoints, attackerGameResult, player1KFactor);

--- a/Core/src/core/database/logs/migrations/020-fights-results-attack-count-index.ts
+++ b/Core/src/core/database/logs/migrations/020-fights-results-attack-count-index.ts
@@ -1,0 +1,58 @@
+import { QueryInterface } from "sequelize";
+
+/**
+ * Safely add an index, ignoring duplicate key errors (ER_DUP_KEYNAME - 1061).
+ */
+async function safeAddIndex(context: QueryInterface, tableName: string, columns: string[], indexName: string): Promise<void> {
+	try {
+		await context.addIndex(tableName, columns, { name: indexName });
+	}
+	catch (error) {
+		if (error instanceof Error && "original" in error) {
+			const dbError = error as Error & { original?: { errno?: number } };
+			if (dbError.original?.errno === 1061) {
+				return;
+			}
+		}
+		throw error;
+	}
+}
+
+/**
+ * Safely remove an index, ignoring "can't drop" errors.
+ */
+async function safeRemoveIndex(context: QueryInterface, tableName: string, indexName: string): Promise<void> {
+	try {
+		await context.removeIndex(tableName, indexName);
+	}
+	catch (error) {
+		if (error instanceof Error && "original" in error) {
+			const dbError = error as Error & { original?: { errno?: number } };
+			if (dbError.original?.errno === 1091) {
+				return;
+			}
+		}
+		throw error;
+	}
+}
+
+export async function up({ context }: { context: QueryInterface }): Promise<void> {
+	/*
+	 * Composite index to optimize the attacker K-factor inactivity query:
+	 * SELECT COUNT(*) FROM fights_results WHERE fightInitiatorId = ? AND friendly = false AND date >= ?
+	 */
+	await safeAddIndex(
+		context,
+		"fights_results",
+		[
+			"fightInitiatorId",
+			"friendly",
+			"date"
+		],
+		"idx_fightInitiator_friendly_date"
+	);
+}
+
+export async function down({ context }: { context: QueryInterface }): Promise<void> {
+	await safeRemoveIndex(context, "fights_results", "idx_fightInitiator_friendly_date");
+}

--- a/Core/src/core/database/logs/requests/LogsFightHistoryRequests.ts
+++ b/Core/src/core/database/logs/requests/LogsFightHistoryRequests.ts
@@ -7,7 +7,9 @@ import { LogsDatabase } from "../LogsDatabase";
 import { LogsPlayersGloryPoints } from "../models/LogsPlayersGloryPoints";
 import { LeagueDataController } from "../../../../data/League";
 import { FightHistoryItem } from "../../../../../../Lib/src/packets/commands/CommandFightHistoryPacket";
-import { secondsToMilliseconds } from "../../../../../../Lib/src/utils/TimeUtils";
+import {
+	getDateLogs, secondsToMilliseconds, weeksToSeconds
+} from "../../../../../../Lib/src/utils/TimeUtils";
 import { EloGameResult } from "../../../../../../Lib/src/types/EloGameResult";
 
 type HistoryCombinedLogsFightsResults = LogsFightsResults & {
@@ -160,5 +162,25 @@ export abstract class LogsFightHistoryRequests {
 			],
 			limit: count
 		}) as unknown as HistoryCombinedLogsFightsResults[];
+	}
+
+	/**
+	 * Count the number of ranked fights a player has initiated in the last N weeks
+	 * @param keycloakId
+	 * @param weeks
+	 */
+	static async getAttackCountInLastNWeeks(keycloakId: string, weeks: number): Promise<number> {
+		const logPlayer = await LogsDatabase.findOrCreatePlayer(keycloakId);
+		if (!logPlayer) {
+			return 0;
+		}
+		const since = getDateLogs() - weeksToSeconds(weeks);
+		return await LogsFightsResults.count({
+			where: {
+				fightInitiatorId: logPlayer.id,
+				friendly: false,
+				date: { [Op.gte]: since }
+			}
+		});
 	}
 }

--- a/Core/src/core/utils/EloUtils.ts
+++ b/Core/src/core/utils/EloUtils.ts
@@ -33,15 +33,18 @@ export abstract class EloUtils {
 	/**
 	 * Get the k-factor for an attacker, boosted when the attacker is returning from inactivity.
 	 * This is a custom Crownicles balancing rule to help stale attacker ratings converge faster.
-	 * The boost gradually decreases as fightCountdown goes down with each fight.
+	 * The boost is based on how many ranked fights the player has initiated in the last
+	 * ATTACK_COUNT_WINDOW_WEEKS weeks: fewer attacks means a higher multiplier.
 	 * @param attacker
+	 * @param attackCountInWindow - Number of ranked fights initiated in the last ATTACK_COUNT_WINDOW_WEEKS weeks
 	 */
-	static getAttackerKFactor(attacker: Player): number {
+	static getAttackerKFactor(attacker: Player, attackCountInWindow: number): number {
 		const baseFactor = EloUtils.getKFactor(attacker);
-		if (attacker.fightCountdown >= FightConstants.ELO.INACTIVE_ATTACKER_FIGHT_COUNTDOWN_THRESHOLD
+		const attackBasedCountdown = Math.max(0, FightConstants.FIGHT_COUNTDOWN_REGEN_LIMIT - attackCountInWindow);
+		if (attackBasedCountdown >= FightConstants.ELO.INACTIVE_ATTACKER_FIGHT_COUNTDOWN_THRESHOLD
 			&& attacker.getLeague().id < LeagueInfoConstants.ROYAL_LEAGUE_ID) {
 			const multiplier = Math.min(
-				attacker.fightCountdown - 1,
+				attackBasedCountdown - 1,
 				FightConstants.ELO.INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER
 			);
 			return baseFactor * multiplier;

--- a/Core/src/core/utils/EloUtils.ts
+++ b/Core/src/core/utils/EloUtils.ts
@@ -40,7 +40,7 @@ export abstract class EloUtils {
 	 */
 	static getAttackerKFactor(attacker: Player, attackCountInWindow: number): number {
 		const baseFactor = EloUtils.getKFactor(attacker);
-		const attackBasedCountdown = Math.max(0, FightConstants.FIGHT_COUNTDOWN_REGEN_LIMIT - attackCountInWindow);
+		const attackBasedCountdown = Math.max(0, FightConstants.ELO.INACTIVE_ATTACKER_ATTACK_COUNT_THRESHOLD - attackCountInWindow);
 		if (attackBasedCountdown >= FightConstants.ELO.INACTIVE_ATTACKER_FIGHT_COUNTDOWN_THRESHOLD
 			&& attacker.getLeague().id < LeagueInfoConstants.ROYAL_LEAGUE_ID) {
 			const multiplier = Math.min(

--- a/Lib/src/constants/FightConstants.ts
+++ b/Lib/src/constants/FightConstants.ts
@@ -299,7 +299,8 @@ export abstract class FightConstants {
 		MAX_RANK_FOR_LEAGUE_POINTS_REWARD: 200,
 		ELO_DIFFERENCE_FOR_SAME_ELO: 30,
 		INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER: 4,
-		INACTIVE_ATTACKER_FIGHT_COUNTDOWN_THRESHOLD: 3
+		INACTIVE_ATTACKER_FIGHT_COUNTDOWN_THRESHOLD: 3,
+		ATTACK_COUNT_WINDOW_WEEKS: 10
 	};
 
 	// If a player has a fight countdown higher than this value, he will not appear in the glory top

--- a/Lib/src/constants/FightConstants.ts
+++ b/Lib/src/constants/FightConstants.ts
@@ -300,7 +300,13 @@ export abstract class FightConstants {
 		ELO_DIFFERENCE_FOR_SAME_ELO: 30,
 		INACTIVE_ATTACKER_K_FACTOR_MAX_MULTIPLIER: 4,
 		INACTIVE_ATTACKER_FIGHT_COUNTDOWN_THRESHOLD: 3,
-		ATTACK_COUNT_WINDOW_WEEKS: 10
+		ATTACK_COUNT_WINDOW_WEEKS: 10,
+
+		/*
+		 * Number of attacks below which a player is considered inactive and gets a K-factor boost.
+		 * Must be independent from FIGHT_COUNTDOWN_REGEN_LIMIT to avoid accidental balance coupling.
+		 */
+		INACTIVE_ATTACKER_ATTACK_COUNT_THRESHOLD: 7
 	};
 
 	// If a player has a fight countdown higher than this value, he will not appear in the glory top

--- a/Lib/src/utils/TimeUtils.ts
+++ b/Lib/src/utils/TimeUtils.ts
@@ -149,6 +149,14 @@ export function daysToSeconds(days: number): number {
 }
 
 /**
+ * Convert weeks to seconds
+ * @param weeks
+ */
+export function weeksToSeconds(weeks: number): number {
+	return weeks * TimeConstants.S_TIME.WEEK;
+}
+
+/**
  * Check if two dates are the same day
  * @param first - first date
  * @param second - second date

--- a/Lib/tests/utils/TimeUtils.test.ts
+++ b/Lib/tests/utils/TimeUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {getWeekNumber, minutesDisplayIntl} from "../../src/utils/TimeUtils";
+import { getWeekNumber, minutesDisplayIntl, weeksToSeconds } from "../../src/utils/TimeUtils";
 import {LANGUAGE} from "../../src/Language";
 
 
@@ -131,5 +131,19 @@ describe("minutesDisplayIntl", () => {
 		expect(minutesDisplayIntl(125, "es")).toBe("2 horas y 5 minutos");
 		// Italian
 		expect(minutesDisplayIntl(125, "it")).toBe("2 ore e 5 minuti");
+	});
+});
+
+describe("weeksToSeconds", () => {
+	it("should return 604800 seconds for 1 week", () => {
+		expect(weeksToSeconds(1)).toBe(604800);
+	});
+
+	it("should return 0 for 0 weeks", () => {
+		expect(weeksToSeconds(0)).toBe(0);
+	});
+
+	it("should scale linearly", () => {
+		expect(weeksToSeconds(10)).toBe(10 * 604800);
 	});
 });


### PR DESCRIPTION
Fixes #4158

The previous implementation used `fightCountdown` to measure attacker inactivity, but this counter also decreases when a player is a defender. This meant players who got attacked frequently would also trigger the K-factor boost, even though they were actively participating in the ranking.

This PR replaces the `fightCountdown`-based boost with a logs DB query that counts how many ranked fights the player has **initiated** (as attacker) in the last 10 weeks. The same constants and multiplier formula are preserved.

**Mapping:**
- 7+ attacks in 10 weeks → no boost
- 4 attacks → 2x
- 3 attacks → 3x
- ≤2 attacks → 4x (max)