### PR TITLE
fix #4164 show confirmation after badge selection

### DIFF
--- a/Discord/src/commands/admin/GiveBadgeCommand.ts
+++ b/Discord/src/commands/admin/GiveBadgeCommand.ts
@@ -26,6 +26,7 @@ import {
 	ButtonBuilder,
 	ButtonInteraction,
 	ButtonStyle,
+	ComponentType,
 	parseEmoji,
 	StringSelectMenuBuilder,
 	StringSelectMenuInteraction,
@@ -111,7 +112,7 @@ async function handleGetPlayerInfoResponse(
 				return;
 			}
 
-			selectCollector.stop();
+			selectCollector.stop("badgeSelected");
 
 			const selectedOption = selectMenuInteraction.values[0] as Badge;
 			const badgeName = i18n.t(`commands:profile.badges.${selectedOption}`, { lng: interaction.userLanguage });
@@ -145,7 +146,9 @@ async function handleGetPlayerInfoResponse(
 			});
 
 			const confirmCollector = msg.createMessageComponentCollector({
-				time: Constants.MESSAGES.COLLECTOR_TIME
+				componentType: ComponentType.Button,
+				time: Constants.MESSAGES.COLLECTOR_TIME,
+				max: 1
 			});
 
 			confirmCollector.on("collect", async (buttonInteraction: ButtonInteraction) => {
@@ -174,7 +177,10 @@ async function handleGetPlayerInfoResponse(
 			});
 		});
 
-		selectCollector.on("end", async () => {
+		selectCollector.on("end", async (_, reason) => {
+			if (reason === "badgeSelected") {
+				return;
+			}
 			disableRows(rows);
 
 			await msg.edit({ components: rows }).catch(() => null);


### PR DESCRIPTION
## Description\n\nFixes #4164\n\nThe `/donnerbadge` command confirmation embed was being overwritten by the `selectCollector` end handler.\n\n**Root cause:** When the admin selects a badge, `selectCollector.stop()` is called immediately. This triggers the `"end"` event synchronously, which edits the message back to show the disabled select menu rows — overwriting the confirmation buttons that were just displayed via `selectMenuInteraction.update()`.\n\n**Fix:** Pass a reason `"badgeSelected"` to `stop()` and bail out of the `end"` handler early when that reason is received, so the confirmation embed is not overwritten.