### PR TITLE
fix(logger): remove redundant format.simple() from Loki transport

### DIFF
--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "5.3.1",
+  "version": "5.3.1.a",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "5.3.1",
+  "version": "5.3.1.a",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "5.3.1",
+  "version": "5.3.1.a",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/Lib/src/logs/CrowniclesLogger.ts
+++ b/Lib/src/logs/CrowniclesLogger.ts
@@ -116,7 +116,6 @@ export abstract class CrowniclesLogger {
 							&& lokiSettings.password !== ""
 							? `${lokiSettings.username}:${lokiSettings.password}`
 							: undefined,
-						format: format.simple(),
 						json: true,
 						onConnectionError: console.error,
 						interval: 5,

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "5.3.1",
+  "version": "5.3.1.a",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
## Contexte

Depuis le **27 avril 2026 15:51:47 UTC** (deploy de `5.3.0.a`), Loki ne reçoit plus aucun log des 4 services. Les logs fichier (`winston-daily-rotate-file`) continuent de fonctionner et sont accessibles sur le NAS, mais Grafana est aveugle.

`winston-loki` swallow silencieusement les HTTP 400 retournés par Loki, donc le bug n'a pas été visible côté app.

## Symptôme

Loki répond `HTTP 400` à chaque push avec :

```
couldn't parse push request:
loghttp.PushRequest.Streams: []loghttp.LogProtoStream: unmarshalerDecoder:
Value is string, but can't find closing '"' symbol
```

Le payload envoyé est de la forme :

```json
"values": [["<msg_avec_JSON_inline>", {"level":"warn","metadata":{}}]]
```

Au lieu du standard Loki `[ts_ns_str, line_str]`.

## Root cause

Le combo `format: format.simple()` + `json: true` a été introduit par Feiryn dans la PR #2895 ("Add loki logger") le 6 avril 2025, dans le fichier `Lib/src/logs/Logger.ts` (renommé plus tard en `CrowniclesLogger.ts`).

C'était copié du README officiel de `winston-loki` de l'époque, qui montrait cet exemple type. La combinaison était redondante mais tolérée par `winston-loki` 6.0.x → 6.1.3.

Pas de raison fonctionnelle dans le code. Pas de tests dessus. Aucun comportement intentionnel à préserver.

`winston-loki@6.1.4` (deps bump dans PR #4138 par toi-même, 23 avril 2026) a refait le sérialiseur interne pour supporter le structured metadata de Loki 3.0+. Ce changement de sérialiseur est ce qui a cassé la combo.

## Fix

Suppression d'une ligne : `format: format.simple(),` dans la config `LokiTransport` de `Lib/src/logs/CrowniclesLogger.ts`.

Le `formatToUse` global (timestamp + label + `myFormatWithLabel`) continue d'être appliqué par winston, et `LokiTransport` avec `json: true` produit alors des `values` au format standard `[ts_ns, line]` que Loki accepte sans broncher.

## Tests

- Loki 3.7.1 sur la prod (upgrade depuis 3.4.3 le 4 mai, n'a pas suffi seul à résoudre — c'était bien un bug client)
- Tests existants Lib intacts
- À tester en local avant merge si tu veux : container `grafana/loki:3.7.1` + petit script Node

## Version

Bump à `5.3.1.a` sur les 4 packages.

## Recommandations follow-up (hors scope de cette PR)

- Volume persistant pour `/tmp/loki/chunks` sur le VPS (actuellement perdu à chaque restart container)
- Persistance `BlockingUtils` + `ReactionCollectorInstance` (Redis ou DB) pour éviter les players bloqués lors des deploys (cf. cas FoxB612)
