### PR TITLE
Concurrency lock infra (foundation, no call sites migrated yet)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           npm install --global corepack@latest
           corepack enable
-          corepack use pnpm@latest-10
+          corepack prepare pnpm@10.26.0 --activate
 
       - name: Cache PNPM dependencies
         uses: actions/cache@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,103 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [ '**' ]
+    paths: [ Lib/**, Core/**, .github/workflows/integration-tests.yml ]
+  push:
+    branches: [ develop, master ]
+    paths: [ Lib/**, Core/**, .github/workflows/integration-tests.yml ]
+  workflow_dispatch:
+
+jobs:
+  core-integration:
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: super_secret_password
+          MARIADB_DATABASE: crownicles_bootstrap
+          MARIADB_USER: draftbot
+          MARIADB_PASSWORD: secret_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      TEST_DB_HOST: 127.0.0.1
+      TEST_DB_PORT: 3306
+      TEST_DB_ROOT_USER: root
+      TEST_DB_ROOT_PASSWORD: super_secret_password
+      TEST_DB_USER: draftbot
+      TEST_DB_PASSWORD: secret_password
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup PNPM
+        run: |
+          npm install --global corepack@latest
+          corepack enable
+          corepack use pnpm@latest-10
+
+      - name: Cache PNPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-integration-deps-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-integration-deps-
+
+      - name: Install dependencies
+        run: |
+          pnpm --dir ./Lib install
+          pnpm --dir ./Core install
+
+      - name: Wait for MariaDB to be ready
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -psuper_secret_password --silent; then
+              echo "MariaDB is up"
+              exit 0
+            fi
+            echo "Waiting for MariaDB ($i/30)…"
+            sleep 2
+          done
+          echo "MariaDB never became ready"
+          exit 1
+
+      - name: Grant test user privileges
+        # The integration test setup also issues GRANTs per generated schema,
+        # but we make sure the user can be discovered with `%` host first.
+        run: |
+          mysql -h 127.0.0.1 -P 3306 -uroot -psuper_secret_password -e "
+            CREATE USER IF NOT EXISTS 'draftbot'@'%' IDENTIFIED BY 'secret_password';
+            GRANT ALL PRIVILEGES ON *.* TO 'draftbot'@'%' WITH GRANT OPTION;
+            FLUSH PRIVILEGES;
+          "
+
+      - name: Create config file for Core
+        run: cp config/config.default.toml config/config.toml
+        working-directory: ./Core
+
+      - name: Run Core integration tests
+        run: pnpm --dir ./Core test:integration
+
+      - name: Upload integration test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: core-integration-results
+          path: Core/test-integration-results.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           npm install --global corepack@latest
           corepack enable
-          corepack use pnpm@latest-10
+          corepack prepare pnpm@10.26.0 --activate
 
       - name: Cache PNPM dependencies
         uses: actions/cache@v4

--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           npm install --global corepack@latest
           corepack enable
-          corepack use pnpm@latest-10
+          corepack prepare pnpm@10.26.0 --activate
 
       - name: Cache PNPM dependencies
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/coverage
 **/config/config.toml
 **/test-results.xml
+**/test-integration-results.xml
 .run
 mqtt5
 bdd

--- a/Core/README.md
+++ b/Core/README.md
@@ -1,3 +1,42 @@
 # Core
 
 Repository for the core of Crownicles
+
+## Tests
+
+### Unit tests
+
+```bash
+pnpm test
+```
+
+### Integration tests
+
+Integration tests live under `__tests__-integration/` and exercise the
+real MariaDB-backed locking primitives end-to-end (transactions, row
+locks, CLS propagation). They require a reachable MariaDB instance.
+
+By default the helpers in `__tests__-integration/_setup.ts` connect to
+`127.0.0.1:3306` with the credentials from `config/config.default.toml`.
+Override via env vars when needed:
+
+| Variable | Default |
+|---|---|
+| `TEST_DB_HOST` | `127.0.0.1` |
+| `TEST_DB_PORT` | `3306` |
+| `TEST_DB_ROOT_USER` | `root` |
+| `TEST_DB_ROOT_PASSWORD` | `super_secret_password` |
+| `TEST_DB_USER` | `draftbot` |
+| `TEST_DB_PASSWORD` | `secret_password` |
+
+Each test suite provisions a unique throw-away schema
+(`crownicles_test_<suite>_<pid>_<rand>`) and drops it on teardown, so
+runs are isolated and safe to interleave with the dev database.
+
+```bash
+pnpm test:integration
+```
+
+In CI the `Integration Tests` workflow boots a `mariadb:11` service
+container with the same defaults — see
+[`.github/workflows/integration-tests.yml`](../.github/workflows/integration-tests.yml).

--- a/Core/__tests__-integration/_setup.ts
+++ b/Core/__tests__-integration/_setup.ts
@@ -1,0 +1,146 @@
+import { createConnection } from "mariadb";
+import { Sequelize } from "sequelize";
+import { useCLSOnSequelize } from "../../Lib/src/locks/CLSNamespace";
+
+/**
+ * Configuration for the MariaDB instance backing the integration tests.
+ *
+ * Defaults match the dev `Core/config/config.default.toml`, so a fresh
+ * checkout that has run `launchScripts/firstConfig.sh` can run the suite
+ * without any extra setup. CI overrides these via `TEST_DB_*` env vars.
+ */
+export interface IntegrationDbConfig {
+	host: string;
+	port: number;
+	rootUser: string;
+	rootPassword: string;
+	user: string;
+	password: string;
+}
+
+export function getIntegrationDbConfig(): IntegrationDbConfig {
+	return {
+		host: process.env.TEST_DB_HOST ?? "127.0.0.1",
+		port: Number(process.env.TEST_DB_PORT ?? 3306),
+		rootUser: process.env.TEST_DB_ROOT_USER ?? "root",
+		rootPassword: process.env.TEST_DB_ROOT_PASSWORD ?? "super_secret_password",
+		user: process.env.TEST_DB_USER ?? "draftbot",
+		password: process.env.TEST_DB_PASSWORD ?? "secret_password"
+	};
+}
+
+/**
+ * A live test environment: a freshly-created MariaDB schema bound to a
+ * Sequelize instance, plus a `teardown()` that drops the schema.
+ *
+ * The instance is wired into the shared CLS namespace so tests exercise
+ * the same transaction-propagation path as production code.
+ */
+export interface IntegrationTestEnvironment {
+	sequelize: Sequelize;
+	dbName: string;
+	teardown: () => Promise<void>;
+}
+
+/**
+ * Spin up a one-shot MariaDB schema for an integration test suite.
+ *
+ * The schema name embeds `pid` and a 32-bit random suffix so two
+ * concurrent test runs (e.g. `vitest --watch` + a CI rerun) never share
+ * state. `teardown()` is idempotent and safe to call from `afterAll`.
+ */
+export async function setupIntegrationDb(suiteName: string): Promise<IntegrationTestEnvironment> {
+	const config = getIntegrationDbConfig();
+
+	// Sanitize the suite name down to a safe MariaDB identifier fragment.
+	const safeSuite = suiteName.toLowerCase().replace(/[^a-z0-9]+/g, "_").slice(0, 24);
+	const dbName = `crownicles_test_${safeSuite}_${process.pid}_${Math.floor(Math.random() * 0xFFFFFFFF).toString(16)}`;
+
+	// Provision the schema with root credentials.
+	const adminConn = await createConnection({
+		host: config.host,
+		port: config.port,
+		user: config.rootUser,
+		password: config.rootPassword
+	});
+	try {
+		await adminConn.query(`CREATE DATABASE IF NOT EXISTS \`${dbName}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;`);
+
+		// The game user can be registered under any host pattern (`%`,
+		// `localhost`, the dev host…). Look it up so the GRANT lands on
+		// the real account instead of guessing.
+		const rows = await adminConn.query(
+			"SELECT Host FROM mysql.user WHERE User = ?",
+			[config.user]
+		) as Array<{ Host: string }>;
+		if (rows.length === 0) {
+			throw new Error(`Test DB user '${config.user}' does not exist on ${config.host}:${config.port}. Set TEST_DB_USER or create the user first.`);
+		}
+		for (const { Host } of rows) {
+			await adminConn.query(`GRANT ALL PRIVILEGES ON \`${dbName}\`.* TO '${config.user}'@'${Host}';`);
+		}
+		await adminConn.query("FLUSH PRIVILEGES;");
+	}
+	finally {
+		await adminConn.end();
+	}
+
+	// Wire CLS *before* instantiating Sequelize, otherwise the connection
+	// captures the namespace-less default and transactions stop propagating.
+	// We pass the Sequelize ctor we are about to instantiate from — pnpm
+	// can resolve several physical copies of `sequelize` and useCLS only
+	// affects the constructor it is called on.
+	useCLSOnSequelize(Sequelize);
+
+	const sequelize = new Sequelize(dbName, config.user, config.password, {
+		dialect: "mariadb",
+		host: config.host,
+		port: config.port,
+		logging: false
+	});
+
+	await sequelize.authenticate();
+
+	return {
+		sequelize,
+		dbName,
+		async teardown() {
+			try {
+				await sequelize.close();
+			}
+			catch {
+				// Already closed — fine.
+			}
+			const cleanupConn = await createConnection({
+				host: config.host,
+				port: config.port,
+				user: config.rootUser,
+				password: config.rootPassword
+			});
+			try {
+				await cleanupConn.query(`DROP DATABASE IF EXISTS \`${dbName}\`;`);
+			}
+			finally {
+				await cleanupConn.end();
+			}
+		}
+	};
+}
+
+/**
+ * Resolve when `predicate()` returns true, polling at `intervalMs`. Used by
+ * race tests that need to assert "transaction B is still pending" without
+ * sleeping for an arbitrary duration.
+ */
+export async function waitFor(
+	predicate: () => boolean,
+	{ timeoutMs = 2000, intervalMs = 5 } = {}
+): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("waitFor: timeout");
+		}
+		await new Promise(resolve => setTimeout(resolve, intervalMs));
+	}
+}

--- a/Core/__tests__-integration/locks/withLockedEntities.integration.test.ts
+++ b/Core/__tests__-integration/locks/withLockedEntities.integration.test.ts
@@ -83,7 +83,7 @@ beforeEach(async () => {
 describe("withLockedEntities (integration)", () => {
 	it("commits the callback's mutations to the locked row", async () => {
 		const result = await withLockedEntities(
-			[AccountModel.lockKey ? AccountModel.lockKey(1) : { model: AccountModel, id: 1 }],
+			[{ model: AccountModel, id: 1 }],
 			async ([account]) => {
 				account.balance += 25;
 				await account.save();
@@ -122,7 +122,7 @@ describe("withLockedEntities (integration)", () => {
 
 		const events: string[] = [];
 
-		const a = withLockedEntities(
+		const txA = withLockedEntities(
 			[{ model: AccountModel, id: 1 }],
 			async ([account]) => {
 				events.push("A:locked");
@@ -137,7 +137,7 @@ describe("withLockedEntities (integration)", () => {
 		// Make sure A enters first.
 		await waitFor(() => events.includes("A:locked"));
 
-		const b = withLockedEntities(
+		const txB = withLockedEntities(
 			[{ model: AccountModel, id: 1 }],
 			async ([account]) => {
 				events.push("B:locked");
@@ -147,7 +147,7 @@ describe("withLockedEntities (integration)", () => {
 			}
 		);
 
-		await Promise.all([a, b]);
+		await Promise.all([txA, txB]);
 
 		// A must have fully committed before B even sees the lock.
 		expect(events).toEqual(["A:locked", "A:committed", "B:locked", "B:committed"]);
@@ -232,7 +232,7 @@ describe("withLockedEntities (integration)", () => {
 	it("throws and rolls back when a locked row does not exist", async () => {
 		await expect(withLockedEntities(
 			[{ model: AccountModel, id: 9999 }],
-			async () => "never reached"
+			() => Promise.resolve("never reached")
 		)).rejects.toThrow(/row not found/);
 
 		// Sanity: existing rows untouched.

--- a/Core/__tests__-integration/locks/withLockedEntities.integration.test.ts
+++ b/Core/__tests__-integration/locks/withLockedEntities.integration.test.ts
@@ -1,0 +1,242 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import {
+	DataTypes, Model, ModelStatic
+} from "sequelize";
+import {
+	setupIntegrationDb, IntegrationTestEnvironment, waitFor
+} from "../_setup";
+import { withLockedEntities } from "../../../Lib/src/locks/withLockedEntities";
+
+/**
+ * Integration tests for `withLockedEntities` against a real MariaDB.
+ *
+ * These tests are the only ones that can prove the safety guarantees we
+ * actually rely on at runtime: `SELECT … FOR UPDATE` row-locking, CLS
+ * propagation of the transaction handle to nested `model.save()`, and
+ * automatic rollback on throw. Unit tests in `Lib/tests/locks/` cover
+ * the deterministic logic (sort, dedup, error paths) without a DB.
+ */
+
+// Two ad-hoc models so we can test single-row locks AND composite locks
+// without dragging the entire game schema into PR-AB. Real handlers
+// (Player / Guild / Pet / Home) are exercised in PR-C onwards.
+class Account extends Model {
+	declare id: number;
+
+	declare balance: number;
+}
+class Inventory extends Model {
+	declare id: number;
+
+	declare stock: number;
+}
+
+let env: IntegrationTestEnvironment;
+let AccountModel: ModelStatic<Account>;
+let InventoryModel: ModelStatic<Inventory>;
+
+beforeAll(async () => {
+	env = await setupIntegrationDb("withlockedentities");
+
+	AccountModel = Account.init({
+		id: {
+			type: DataTypes.INTEGER, primaryKey: true
+		},
+		balance: {
+			type: DataTypes.INTEGER, allowNull: false
+		}
+	}, {
+		sequelize: env.sequelize, tableName: "account", timestamps: false
+	});
+	InventoryModel = Inventory.init({
+		id: {
+			type: DataTypes.INTEGER, primaryKey: true
+		},
+		stock: {
+			type: DataTypes.INTEGER, allowNull: false
+		}
+	}, {
+		sequelize: env.sequelize, tableName: "inventory", timestamps: false
+	});
+
+	await env.sequelize.sync();
+}, 60_000);
+
+afterAll(async () => {
+	await env?.teardown();
+}, 60_000);
+
+beforeEach(async () => {
+	await AccountModel.destroy({ where: {}, truncate: true });
+	await InventoryModel.destroy({ where: {}, truncate: true });
+	await AccountModel.bulkCreate([
+		{ id: 1, balance: 100 },
+		{ id: 2, balance: 50 }
+	]);
+	await InventoryModel.bulkCreate([
+		{ id: 1, stock: 10 }
+	]);
+});
+
+describe("withLockedEntities (integration)", () => {
+	it("commits the callback's mutations to the locked row", async () => {
+		const result = await withLockedEntities(
+			[AccountModel.lockKey ? AccountModel.lockKey(1) : { model: AccountModel, id: 1 }],
+			async ([account]) => {
+				account.balance += 25;
+				await account.save();
+				return account.balance;
+			}
+		);
+		expect(result).toBe(125);
+
+		const fresh = await AccountModel.findByPk(1);
+		expect(fresh?.balance).toBe(125);
+	});
+
+	it("rolls back every mutation when the callback throws", async () => {
+		await expect(withLockedEntities(
+			[{ model: AccountModel, id: 1 }],
+			async ([account]) => {
+				account.balance = 9999;
+				await account.save();
+				throw new Error("kaboom");
+			}
+		)).rejects.toThrow("kaboom");
+
+		const fresh = await AccountModel.findByPk(1);
+		expect(fresh?.balance).toBe(100);
+	});
+
+	it("serialises two callers racing for the same row (FOR UPDATE blocks)", async () => {
+		// The flow we want to observe:
+		//   t=0  A enters and locks account#1
+		//   t≈0  B tries to enter the same lock — must block
+		//   t=…  A increments and commits
+		//   t=…  B unblocks, sees the *committed* value, increments, commits
+		// If FOR UPDATE doesn't actually block B, both callers read 100,
+		// both write 110, and the final balance is 110 (lost update).
+		// Under proper locking the final balance is 120.
+
+		const events: string[] = [];
+
+		const a = withLockedEntities(
+			[{ model: AccountModel, id: 1 }],
+			async ([account]) => {
+				events.push("A:locked");
+				// Hold the lock long enough for B to attempt acquisition.
+				await new Promise(resolve => setTimeout(resolve, 200));
+				account.balance += 10;
+				await account.save();
+				events.push("A:committed");
+			}
+		);
+
+		// Make sure A enters first.
+		await waitFor(() => events.includes("A:locked"));
+
+		const b = withLockedEntities(
+			[{ model: AccountModel, id: 1 }],
+			async ([account]) => {
+				events.push("B:locked");
+				account.balance += 10;
+				await account.save();
+				events.push("B:committed");
+			}
+		);
+
+		await Promise.all([a, b]);
+
+		// A must have fully committed before B even sees the lock.
+		expect(events).toEqual(["A:locked", "A:committed", "B:locked", "B:committed"]);
+
+		const fresh = await AccountModel.findByPk(1);
+		expect(fresh?.balance).toBe(120);
+	}, 15_000);
+
+	it("propagates the transaction via CLS to nested save() calls", async () => {
+		// Inside `withLockedEntities` we touch a model the helper did NOT
+		// lock (Inventory). If CLS works, the rollback below also reverts
+		// the inventory mutation; if it doesn't, the inventory save commits
+		// independently and survives the throw.
+		await expect(withLockedEntities(
+			[{ model: AccountModel, id: 1 }],
+			async () => {
+				const inv = await InventoryModel.findByPk(1);
+				inv!.stock = 0;
+				await inv!.save();
+				throw new Error("rollback please");
+			}
+		)).rejects.toThrow("rollback please");
+
+		const inventoryAfter = await InventoryModel.findByPk(1);
+		expect(inventoryAfter?.stock).toBe(10);
+	});
+
+	it("locks several rows, in canonical order, and surfaces them to the callback in caller order", async () => {
+		// Composite lock — order at the call site (Account#2, Inventory#1, Account#1)
+		// must be preserved in the tuple, while internal acquisition is sorted.
+		const result = await withLockedEntities(
+			[
+				{ model: AccountModel, id: 2 },
+				{ model: InventoryModel, id: 1 },
+				{ model: AccountModel, id: 1 }
+			],
+			async ([account2, inventory, account1]) => {
+				expect(account2.id).toBe(2);
+				expect(inventory.id).toBe(1);
+				expect(account1.id).toBe(1);
+
+				account1.balance -= 30;
+				account2.balance += 30;
+				inventory.stock -= 1;
+				await account1.save();
+				await account2.save();
+				await inventory.save();
+				return "done";
+			}
+		);
+		expect(result).toBe("done");
+
+		const [a1, a2, inv] = await Promise.all([
+			AccountModel.findByPk(1),
+			AccountModel.findByPk(2),
+			InventoryModel.findByPk(1)
+		]);
+		expect(a1?.balance).toBe(70);
+		expect(a2?.balance).toBe(80);
+		expect(inv?.stock).toBe(9);
+	});
+
+	it("dedupes identical keys at the DB level (single FOR UPDATE round-trip)", async () => {
+		const result = await withLockedEntities(
+			[
+				{ model: AccountModel, id: 1 },
+				{ model: AccountModel, id: 1 }
+			],
+			async ([first, second]) => {
+				expect(first).toBe(second); // same instance, no duplicate fetch
+				first.balance += 5;
+				await first.save();
+				return first.balance;
+			}
+		);
+		expect(result).toBe(105);
+
+		const fresh = await AccountModel.findByPk(1);
+		expect(fresh?.balance).toBe(105);
+	});
+
+	it("throws and rolls back when a locked row does not exist", async () => {
+		await expect(withLockedEntities(
+			[{ model: AccountModel, id: 9999 }],
+			async () => "never reached"
+		)).rejects.toThrow(/row not found/);
+
+		// Sanity: existing rows untouched.
+		const fresh = await AccountModel.findByPk(1);
+		expect(fresh?.balance).toBe(100);
+	});
+});

--- a/Core/package.json
+++ b/Core/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.mts",
     "cd": "cd",
     "eslint": "eslint src",
     "eslintFix": "eslint src --fix",

--- a/Core/src/core/database/game/models/Guild.ts
+++ b/Core/src/core/database/game/models/Guild.ts
@@ -19,11 +19,32 @@ import { Constants } from "../../../../../../Lib/src/constants/Constants";
 import { NumberChangeReason } from "../../../../../../Lib/src/constants/LogsConstants";
 import { GuildConstants } from "../../../../../../Lib/src/constants/GuildConstants";
 import { GuildDomainConstants } from "../../../../../../Lib/src/constants/GuildDomainConstants";
+import {
+	LockKey, withLockedEntities
+} from "../../../../../../Lib/src/locks/withLockedEntities";
 
 // skipcq: JS-C1003 - moment does not expose itself as an ES Module.
 import * as moment from "moment";
 
 export class Guild extends Model {
+	/**
+	 * Build a {@link LockKey} for this guild so it can participate in a
+	 * `withLockedEntities([...])` composite critical section.
+	 */
+	static lockKey(id: number): LockKey<Guild> {
+		return {
+			model: Guild, id
+		};
+	}
+
+	/**
+	 * Convenience helper for the common case of locking a single guild.
+	 * See {@link withLockedEntities} for full semantics.
+	 */
+	static withLocked<R>(id: number, fn: (guild: Guild) => Promise<R>): Promise<R> {
+		return withLockedEntities([Guild.lockKey(id)], ([guild]) => fn(guild));
+	}
+
 	declare readonly id: number;
 
 	declare name: string;

--- a/Core/src/core/database/game/models/Home.ts
+++ b/Core/src/core/database/game/models/Home.ts
@@ -6,8 +6,29 @@ import * as moment from "moment";
 import { HomeChestSlots } from "./HomeChestSlot";
 import { HomeGardenSlots } from "./HomeGardenSlot";
 import { HomePlantStorages } from "./HomePlantStorage";
+import {
+	LockKey, withLockedEntities
+} from "../../../../../../Lib/src/locks/withLockedEntities";
 
 export class Home extends Model {
+	/**
+	 * Build a {@link LockKey} for this home so it can participate in a
+	 * `withLockedEntities([...])` composite critical section.
+	 */
+	static lockKey(id: number): LockKey<Home> {
+		return {
+			model: Home, id
+		};
+	}
+
+	/**
+	 * Convenience helper for the common case of locking a single home.
+	 * See {@link withLockedEntities} for full semantics.
+	 */
+	static withLocked<R>(id: number, fn: (home: Home) => Promise<R>): Promise<R> {
+		return withLockedEntities([Home.lockKey(id)], ([home]) => fn(home));
+	}
+
 	declare readonly id: number;
 
 	declare readonly ownerId: number;

--- a/Core/src/core/database/game/models/PetEntity.ts
+++ b/Core/src/core/database/game/models/PetEntity.ts
@@ -29,11 +29,32 @@ import {
 import { OwnedPet } from "../../../../../../Lib/src/types/OwnedPet";
 import { PetBasicInfo } from "../../../../../../Lib/src/types/PetBasicInfo";
 import { CrowniclesLogger } from "../../../../../../Lib/src/logs/CrowniclesLogger";
+import {
+	LockKey, withLockedEntities
+} from "../../../../../../Lib/src/locks/withLockedEntities";
 
 // skipcq: JS-C1003 - moment does not expose itself as an ES Module.
 import * as moment from "moment";
 
 export class PetEntity extends Model {
+	/**
+	 * Build a {@link LockKey} for this pet so it can participate in a
+	 * `withLockedEntities([...])` composite critical section (e.g. pet trade).
+	 */
+	static lockKey(id: number): LockKey<PetEntity> {
+		return {
+			model: PetEntity, id
+		};
+	}
+
+	/**
+	 * Convenience helper for the common case of locking a single pet.
+	 * See {@link withLockedEntities} for full semantics.
+	 */
+	static withLocked<R>(id: number, fn: (pet: PetEntity) => Promise<R>): Promise<R> {
+		return withLockedEntities([PetEntity.lockKey(id)], ([pet]) => fn(pet));
+	}
+
 	declare readonly id: number;
 
 	declare typeId: number;

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -39,6 +39,9 @@ import {
 	Class, ClassDataController
 } from "../../../../data/Class";
 import {
+	LockKey, withLockedEntities
+} from "../../../../../../Lib/src/locks/withLockedEntities";
+import {
 	League, LeagueDataController
 } from "../../../../data/League";
 import { TopConstants } from "../../../../../../Lib/src/constants/TopConstants";
@@ -91,6 +94,29 @@ type ressourcesLostOnPveFaint = {
 };
 
 export class Player extends Model {
+	/**
+	 * Build a {@link LockKey} for this player so it can participate in a
+	 * `withLockedEntities([...])` composite critical section.
+	 *
+	 * @param id Primary key of the player to lock.
+	 */
+	static lockKey(id: number): LockKey<Player> {
+		return {
+			model: Player, id
+		};
+	}
+
+	/**
+	 * Convenience helper for the common case of locking a single player.
+	 * Opens a Sequelize transaction, acquires `SELECT … FOR UPDATE` on the
+	 * row, re-fetches it, and passes the fresh instance to `fn`. Any
+	 * `player.save()` inside `fn` (directly or transitively) inherits the
+	 * transaction through the shared CLS namespace.
+	 */
+	static withLocked<R>(id: number, fn: (player: Player) => Promise<R>): Promise<R> {
+		return withLockedEntities([Player.lockKey(id)], ([player]) => fn(player));
+	}
+
 	declare readonly id: number;
 
 	declare keycloakId: string;

--- a/Core/vitest.config.mts
+++ b/Core/vitest.config.mts
@@ -11,6 +11,9 @@ export default defineConfig({
 		globals: true,
 		setupFiles: ['./vitest.setup.ts'],
 		include: ['**/*.{test,spec}.{js,ts}'],
+		// Integration tests run via `pnpm test:integration` against a real
+		// MariaDB and must not be picked up by the default unit-test run.
+		exclude: ['node_modules/**', 'dist/**', '__tests__-integration/**'],
 		reporters: [
 			'default',
 			['junit', { outputFile: 'test-results.xml' }]

--- a/Core/vitest.integration.config.mts
+++ b/Core/vitest.integration.config.mts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Dedicated Vitest configuration for integration tests.
+ *
+ * - Picks up only files under `__tests__-integration/`.
+ * - Generous timeouts because each suite spins up a fresh MariaDB schema
+ *   (CREATE DATABASE + sync) and tears it down at the end.
+ * - Runs suites sequentially (`fileParallelism: false`) so two tests
+ *   never compete for the same connection pool when MariaDB has a low
+ *   `max_connections` ceiling on a developer's local instance.
+ */
+export default defineConfig({
+	test: {
+		environment: "node",
+		globals: true,
+		include: ["__tests__-integration/**/*.test.ts"],
+		exclude: ["node_modules/**", "dist/**"],
+		testTimeout: 30_000,
+		hookTimeout: 60_000,
+		fileParallelism: false,
+		reporters: [
+			"default",
+			["junit", { outputFile: "test-integration-results.xml" }]
+		]
+	}
+});

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@types/node": "25.6.0",
+    "cls-hooked": "4.2.2",
     "mariadb": "3.4.5",
     "random-js": "2.1.0",
     "sequelize": "6.37.7",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "5.10.0",
+    "@types/cls-hooked": "4.3.9",
     "@types/triple-beam": "^1.3.5",
     "@typescript-eslint/eslint-plugin": "8.59.0",
     "@typescript-eslint/parser": "8.59.0",

--- a/Lib/pnpm-lock.yaml
+++ b/Lib/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
+      cls-hooked:
+        specifier: 4.2.2
+        version: 4.2.2
       mariadb:
         specifier: 3.4.5
         version: 3.4.5
@@ -39,6 +42,9 @@ importers:
       '@stylistic/eslint-plugin':
         specifier: 5.10.0
         version: 5.10.0(eslint@9.39.4)
+      '@types/cls-hooked':
+        specifier: 4.3.9
+        version: 4.3.9
       '@types/triple-beam':
         specifier: ^1.3.5
         version: 1.3.5
@@ -602,6 +608,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/cls-hooked@4.3.9':
+    resolution: {integrity: sha512-CMtHMz6Q/dkfcHarq9nioXH8BDPP+v5xvd+N90lBQ2bdmu06UvnLDqxTKoOJzz4SzIwb/x9i4UXGAAcnUDuIvg==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -791,6 +800,10 @@ packages:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
 
+  async-hook-jl@1.7.6:
+    resolution: {integrity: sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==}
+    engines: {node: ^4.7 || >=6.9 || >=7.3}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -828,6 +841,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  cls-hooked@4.2.2:
+    resolution: {integrity: sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==}
+    engines: {node: ^4.7 || >=6.9 || >=7.3 || >=8.2.1}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -894,6 +911,9 @@ packages:
   dottie@2.0.6:
     resolution: {integrity: sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  emitter-listener@1.1.2:
+    resolution: {integrity: sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1385,6 +1405,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -1450,6 +1474,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1472,6 +1499,9 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stack-chain@1.3.7:
+    resolution: {integrity: sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==}
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -2096,6 +2126,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cls-hooked@4.3.9':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -2324,6 +2358,10 @@ snapshots:
 
   async-exit-hook@2.0.1: {}
 
+  async-hook-jl@1.7.6:
+    dependencies:
+      stack-chain: 1.3.7
+
   async@3.2.6: {}
 
   balanced-match@1.0.2: {}
@@ -2353,6 +2391,12 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  cls-hooked@4.2.2:
+    dependencies:
+      async-hook-jl: 1.7.6
+      emitter-listener: 1.1.2
+      semver: 5.7.2
 
   color-convert@2.0.1:
     dependencies:
@@ -2400,6 +2444,10 @@ snapshots:
   denque@2.1.0: {}
 
   dottie@2.0.6: {}
+
+  emitter-listener@1.1.2:
+    dependencies:
+      shimmer: 1.2.1
 
   emittery@0.13.1: {}
 
@@ -2928,6 +2976,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  semver@5.7.2: {}
+
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
@@ -2969,6 +3019,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shimmer@1.2.1: {}
+
   siginfo@2.0.0: {}
 
   snappy@7.2.2:
@@ -3000,6 +3052,8 @@ snapshots:
   spdx-license-ids@3.0.22: {}
 
   sprintf-js@1.0.3: {}
+
+  stack-chain@1.3.7: {}
 
   stack-trace@0.0.10: {}
 

--- a/Lib/src/database/Database.ts
+++ b/Lib/src/database/Database.ts
@@ -8,6 +8,7 @@ import { promises } from "fs";
 import { createConnection } from "mariadb";
 import { DatabaseConfiguration } from "./DatabaseConfiguration";
 import { CrowniclesLogger } from "../logs/CrowniclesLogger";
+import { useCLSOnSequelize } from "../locks/CLSNamespace";
 import TYPES = Transaction.TYPES;
 
 const DB_RETRY_MAX_ATTEMPTS = 10;
@@ -67,6 +68,15 @@ export abstract class Database {
 		if (this.sequelize) {
 			return;
 		}
+
+		/*
+		 * Wire the shared CLS namespace into Sequelize so transactions opened
+		 * by `withLockedEntities` automatically propagate to nested
+		 * `model.save()` calls. Must run before any `new Sequelize(...)`.
+		 * The ctor is passed explicitly: pnpm may resolve several physical
+		 * copies of `sequelize` and `useCLS` only affects the one we hand it.
+		 */
+		useCLSOnSequelize(Sequelize);
 
 		const dbName = `${this.databaseConfiguration.prefix}_${this.databaseConfiguration.databaseName}`;
 

--- a/Lib/src/locks/CLSNamespace.ts
+++ b/Lib/src/locks/CLSNamespace.ts
@@ -1,7 +1,6 @@
 import {
 	createNamespace, getNamespace, Namespace
 } from "cls-hooked";
-import type { Sequelize } from "sequelize";
 
 /**
  * Minimal shape of `Sequelize` we depend on here. Typed as a structural
@@ -9,9 +8,13 @@ import type { Sequelize } from "sequelize";
  * resolve several physical instances of `sequelize` across packages
  * (different `mariadb` peer-dep selectors), and the CLS namespace must
  * be registered on each one that actually instantiates connections.
+ *
+ * The return value of `useCLS` is unused and intentionally typed as
+ * `unknown`; this keeps us free of any value-position reference to the
+ * `Sequelize` constructor (which would force a runtime import).
  */
 type SequelizeCtor = {
-	useCLS(ns: Namespace): typeof Sequelize;
+	useCLS(ns: Namespace): unknown;
 };
 
 /**

--- a/Lib/src/locks/CLSNamespace.ts
+++ b/Lib/src/locks/CLSNamespace.ts
@@ -1,0 +1,91 @@
+import {
+	createNamespace, getNamespace, Namespace
+} from "cls-hooked";
+import type { Sequelize } from "sequelize";
+
+/**
+ * Minimal shape of `Sequelize` we depend on here. Typed as a structural
+ * interface so callers can pass any copy of the constructor — pnpm may
+ * resolve several physical instances of `sequelize` across packages
+ * (different `mariadb` peer-dep selectors), and the CLS namespace must
+ * be registered on each one that actually instantiates connections.
+ */
+type SequelizeCtor = {
+	useCLS(ns: Namespace): typeof Sequelize;
+};
+
+/**
+ * Name of the shared CLS (Continuation-Local Storage) namespace used by
+ * {@link withLockedEntities} to thread the current Sequelize transaction
+ * through nested asynchronous calls.
+ *
+ * Any `model.save()`, `model.update()`, etc. executed inside a
+ * `withLockedEntities` callback automatically picks up the active
+ * transaction from this namespace — there is no need to plumb a
+ * `transaction` option through every call site.
+ *
+ * The string is exported as a constant so tests can resolve the same
+ * namespace in setup helpers.
+ */
+export const CROWNICLES_CLS_NAMESPACE = "crownicles-tx";
+
+let namespaceSingleton: Namespace | null = null;
+let wiredCtors = new WeakSet<SequelizeCtor>();
+
+/**
+ * Returns (creating it on first call) the shared `cls-hooked` namespace.
+ *
+ * Safe to call multiple times from anywhere — the underlying namespace is
+ * registered globally inside `cls-hooked`, so callers that import this
+ * module from different bundles still share the same context store.
+ */
+export function getCrowniclesNamespace(): Namespace {
+	if (namespaceSingleton) {
+		return namespaceSingleton;
+	}
+	namespaceSingleton = getNamespace(CROWNICLES_CLS_NAMESPACE)
+		?? createNamespace(CROWNICLES_CLS_NAMESPACE);
+	return namespaceSingleton;
+}
+
+/**
+ * Wires the shared namespace into the supplied Sequelize constructor so
+ * that every model operation (save / update / destroy / find / …)
+ * executed inside `namespace.run(...)` (or any `withLockedEntities`
+ * callback) uses the current transaction by default.
+ *
+ * Must be called **once per Sequelize constructor copy, before any
+ * `new Sequelize(...)` instantiation against that copy** (Sequelize v6
+ * freezes the CLS namespace at construction time of each connection).
+ * Calling it more than once with the same constructor is a no-op, so
+ * wiring this from the shared `Database` bootstrap is safe even when
+ * several services boot in the same process during integration tests.
+ *
+ * @param sequelizeCtor The `Sequelize` class. Pass it explicitly from the
+ * call site so the wiring lands on the same physical module the caller
+ * uses to create connections — pnpm may resolve more than one copy.
+ */
+export function useCLSOnSequelize(sequelizeCtor: SequelizeCtor): void {
+	if (wiredCtors.has(sequelizeCtor)) {
+		return;
+	}
+
+	// Force-register the namespace before Sequelize captures it.
+	getCrowniclesNamespace();
+
+	/*
+	 * Sequelize.useCLS is a static method on the constructor — see
+	 * https://sequelize.org/docs/v6/other-topics/transactions/#automatically-pass-transactions-to-all-queries
+	 */
+	sequelizeCtor.useCLS(getCrowniclesNamespace());
+	wiredCtors.add(sequelizeCtor);
+}
+
+/**
+ * Test-only escape hatch. Resets the internal "already wired" tracker so
+ * a test can re-arm CLS against a fresh Sequelize import. **Never call
+ * this from production code.**
+ */
+export function _resetUseCLSForTests(): void {
+	wiredCtors = new WeakSet<SequelizeCtor>();
+}

--- a/Lib/src/locks/withLockedEntities.ts
+++ b/Lib/src/locks/withLockedEntities.ts
@@ -25,14 +25,14 @@ export type ResolveEntities<K extends readonly LockKey<Model>[]> = {
 	[I in keyof K]: K[I] extends LockKey<infer M> ? M : never;
 };
 
-const lockCacheKey = (k: LockKey<Model>): string => `${k.model.tableName}#${k.id}`;
+const lockCacheKey = (key: LockKey<Model>): string => `${key.model.tableName}#${key.id}`;
 
-const compareKeys = (a: LockKey<Model>, b: LockKey<Model>): number => {
-	const tableCmp = a.model.tableName.localeCompare(b.model.tableName);
+const compareKeys = (left: LockKey<Model>, right: LockKey<Model>): number => {
+	const tableCmp = left.model.tableName.localeCompare(right.model.tableName);
 	if (tableCmp !== 0) {
 		return tableCmp;
 	}
-	return a.id - b.id;
+	return left.id - right.id;
 };
 
 /**
@@ -91,35 +91,35 @@ export async function withLockedEntities<
 	 * Sanity check: all keys must share the same Sequelize instance, otherwise
 	 * we cannot lock them in a single transaction.
 	 */
-	for (const k of keys) {
-		if (k.model.sequelize !== sequelize) {
+	for (const key of keys) {
+		if (key.model.sequelize !== sequelize) {
 			throw new Error(
-				`withLockedEntities: model ${k.model.name} is bound to a different Sequelize instance than ${keys[0].model.name}`
+				`withLockedEntities: model ${key.model.name} is bound to a different Sequelize instance than ${keys[0].model.name}`
 			);
 		}
 	}
 
 	const sorted = [...keys].sort(compareKeys);
 
-	return await sequelize.transaction(async (t: Transaction) => {
+	return await sequelize.transaction(async (transaction: Transaction) => {
 		const lockedByKey = new Map<string, Model>();
 
 		for (const key of sorted) {
-			const ck = lockCacheKey(key);
-			if (lockedByKey.has(ck)) {
+			const cacheKey = lockCacheKey(key);
+			if (lockedByKey.has(cacheKey)) {
 				continue;
 			}
 			const instance = await key.model.findByPk(key.id, {
-				lock: t.LOCK.UPDATE,
-				transaction: t
+				lock: transaction.LOCK.UPDATE,
+				transaction
 			});
 			if (!instance) {
-				throw new Error(`withLockedEntities: row not found for ${ck}`);
+				throw new Error(`withLockedEntities: row not found for ${cacheKey}`);
 			}
-			lockedByKey.set(ck, instance);
+			lockedByKey.set(cacheKey, instance);
 		}
 
-		const entities = keys.map(k => lockedByKey.get(lockCacheKey(k))!);
+		const entities = keys.map(key => lockedByKey.get(lockCacheKey(key))!);
 		return fn(entities as unknown as ResolveEntities<K>);
 	});
 }

--- a/Lib/src/locks/withLockedEntities.ts
+++ b/Lib/src/locks/withLockedEntities.ts
@@ -1,0 +1,125 @@
+import {
+	Model, ModelStatic, Transaction
+} from "sequelize";
+
+/**
+ * A handle on a row that the caller wants to lock with
+ * `SELECT … FOR UPDATE` for the duration of a {@link withLockedEntities}
+ * critical section.
+ *
+ * Build instances of this through the `lockKey()` static of any model
+ * that participates in the lock protocol — never construct them by hand
+ * at call sites, so the type parameter is always inferred correctly.
+ */
+export interface LockKey<M extends Model = Model> {
+	readonly model: ModelStatic<M>;
+	readonly id: number;
+}
+
+/**
+ * Maps a tuple of `LockKey` to the matching tuple of model instances.
+ * `withLockedEntities` returns instances in the caller's *original*
+ * order, regardless of the canonical lock-acquisition order.
+ */
+export type ResolveEntities<K extends readonly LockKey<Model>[]> = {
+	[I in keyof K]: K[I] extends LockKey<infer M> ? M : never;
+};
+
+const lockCacheKey = (k: LockKey<Model>): string => `${k.model.tableName}#${k.id}`;
+
+const compareKeys = (a: LockKey<Model>, b: LockKey<Model>): number => {
+	const tableCmp = a.model.tableName.localeCompare(b.model.tableName);
+	if (tableCmp !== 0) {
+		return tableCmp;
+	}
+	return a.id - b.id;
+};
+
+/**
+ * Opens a Sequelize transaction, acquires `SELECT … FOR UPDATE` row locks
+ * on every requested entity in canonical order — `(tableName, id)` —
+ * then re-fetches each row inside the transaction and passes the fresh
+ * instances to `fn`.
+ *
+ * **Why canonical order?** Sequential acquisition under a stable global
+ * order is the textbook deadlock-prevention strategy for fixed-size lock
+ * sets: two transactions racing for the same set of rows will always
+ * acquire the first contended row in the same direction, so one will
+ * simply wait for the other instead of forming a cycle.
+ *
+ * **Why a re-fetch?** Any value that the caller read *before*
+ * `withLockedEntities` might be stale by the time the lock is taken.
+ * Re-fetching inside the critical section is the only way to guarantee
+ * that subsequent writes are based on the committed state.
+ *
+ * **CLS propagation.** The transaction is registered in the shared
+ * `crownicles-tx` namespace (see `CLSNamespace.ts`), so any
+ * `model.save()` / `model.update()` / `findByPk(...)` executed inside
+ * `fn` (directly or transitively) automatically uses this transaction
+ * without the caller having to thread it manually.
+ *
+ * **Lifecycle.** If `fn` resolves, the transaction is committed and its
+ * resolved value is returned. If `fn` throws (or any locked row is not
+ * found), the transaction is rolled back and the error propagates.
+ *
+ * **Duplicates.** The same `(model, id)` may appear several times in
+ * `keys`; the row is locked exactly once and the same instance is
+ * surfaced at every matching position of the returned tuple.
+ *
+ * @param keys Lock keys describing the rows to lock. Must be non-empty
+ * and all attached to the same Sequelize instance.
+ * @param fn Critical section. Receives a tuple of fresh, locked model
+ * instances in the same order as `keys`.
+ */
+export async function withLockedEntities<
+	K extends readonly LockKey<Model>[],
+	R
+>(
+	keys: K,
+	fn: (entities: ResolveEntities<K>) => Promise<R>
+): Promise<R> {
+	if (keys.length === 0) {
+		throw new Error("withLockedEntities: keys must be non-empty");
+	}
+
+	const sequelize = keys[0].model.sequelize;
+	if (!sequelize) {
+		throw new Error(`withLockedEntities: model ${keys[0].model.name} is not bound to a Sequelize instance`);
+	}
+
+	/*
+	 * Sanity check: all keys must share the same Sequelize instance, otherwise
+	 * we cannot lock them in a single transaction.
+	 */
+	for (const k of keys) {
+		if (k.model.sequelize !== sequelize) {
+			throw new Error(
+				`withLockedEntities: model ${k.model.name} is bound to a different Sequelize instance than ${keys[0].model.name}`
+			);
+		}
+	}
+
+	const sorted = [...keys].sort(compareKeys);
+
+	return await sequelize.transaction(async (t: Transaction) => {
+		const lockedByKey = new Map<string, Model>();
+
+		for (const key of sorted) {
+			const ck = lockCacheKey(key);
+			if (lockedByKey.has(ck)) {
+				continue;
+			}
+			const instance = await key.model.findByPk(key.id, {
+				lock: t.LOCK.UPDATE,
+				transaction: t
+			});
+			if (!instance) {
+				throw new Error(`withLockedEntities: row not found for ${ck}`);
+			}
+			lockedByKey.set(ck, instance);
+		}
+
+		const entities = keys.map(k => lockedByKey.get(lockCacheKey(k))!);
+		return fn(entities as unknown as ResolveEntities<K>);
+	});
+}

--- a/Lib/tests/locks/AsyncLock.test.ts
+++ b/Lib/tests/locks/AsyncLock.test.ts
@@ -1,0 +1,87 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { AsyncLock } from "../../src/locks/AsyncLock";
+
+describe("AsyncLock", () => {
+	it("acquires immediately when free", async () => {
+		const lock = new AsyncLock();
+		const release = await lock.acquire();
+		release();
+	});
+
+	it("serialises concurrent acquirers in FIFO order", async () => {
+		const lock = new AsyncLock();
+		const order: number[] = [];
+
+		const release1 = await lock.acquire();
+		const p2 = lock.acquire().then(release => {
+			order.push(2);
+			return release;
+		});
+		const p3 = lock.acquire().then(release => {
+			order.push(3);
+			return release;
+		});
+		const p4 = lock.acquire().then(release => {
+			order.push(4);
+			return release;
+		});
+
+		// None of the followers should have entered yet.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(order).toEqual([]);
+
+		release1();
+		(await p2)();
+		(await p3)();
+		(await p4)();
+
+		expect(order).toEqual([2, 3, 4]);
+	});
+
+	it("releases the lock so subsequent acquirers run sequentially", async () => {
+		const lock = new AsyncLock();
+		const log: string[] = [];
+
+		async function critical(label: string): Promise<void> {
+			const release = await lock.acquire();
+			log.push(`enter ${label}`);
+			await Promise.resolve();
+			log.push(`exit ${label}`);
+			release();
+		}
+
+		await Promise.all([critical("A"), critical("B"), critical("C")]);
+
+		// No interleaving: every "exit X" must come before the next "enter Y".
+		expect(log).toEqual([
+			"enter A", "exit A",
+			"enter B", "exit B",
+			"enter C", "exit C"
+		]);
+	});
+
+	it("does not leak the lock when the holder forgets to release (regression guard)", async () => {
+		// This test documents that the lock is *not* automatically released —
+		// callers must always call the release function (typically inside a
+		// `finally`). If somebody forgets, subsequent acquirers wait forever.
+		const lock = new AsyncLock();
+		await lock.acquire(); // never released
+
+		let entered = false;
+		const racing = lock.acquire().then(() => {
+			entered = true;
+		});
+
+		// Yield several times — the second acquirer must still be pending.
+		for (let i = 0; i < 5; i++) {
+			await Promise.resolve();
+		}
+		expect(entered).toBe(false);
+
+		// Avoid an unhandled rejection warning on test teardown.
+		racing.catch(() => undefined);
+	});
+});

--- a/Lib/tests/locks/LockManager.test.ts
+++ b/Lib/tests/locks/LockManager.test.ts
@@ -1,0 +1,47 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { LockManager } from "../../src/locks/LockManager";
+
+describe("LockManager", () => {
+	it("returns the same lock instance for the same id", () => {
+		const manager = new LockManager();
+		const lock1 = manager.getLock(42);
+		const lock2 = manager.getLock(42);
+		expect(lock1).toBe(lock2);
+	});
+
+	it("returns distinct locks for distinct ids", () => {
+		const manager = new LockManager();
+		const lockA = manager.getLock(1);
+		const lockB = manager.getLock(2);
+		expect(lockA).not.toBe(lockB);
+	});
+
+	it("isolates concurrent critical sections per id", async () => {
+		const manager = new LockManager();
+		const log: string[] = [];
+
+		async function inSection(id: number, label: string): Promise<void> {
+			const release = await manager.getLock(id).acquire();
+			log.push(`enter ${label}`);
+			await Promise.resolve();
+			log.push(`exit ${label}`);
+			release();
+		}
+
+		// Two pairs racing on disjoint ids: they should interleave freely.
+		await Promise.all([
+			inSection(1, "A1"),
+			inSection(2, "A2"),
+			inSection(1, "B1"),
+			inSection(2, "B2")
+		]);
+
+		// For each id, "exit X" precedes "enter Y" of the same id (serialised).
+		const onlyId1 = log.filter(s => s.endsWith("A1") || s.endsWith("B1"));
+		const onlyId2 = log.filter(s => s.endsWith("A2") || s.endsWith("B2"));
+		expect(onlyId1).toEqual(["enter A1", "exit A1", "enter B1", "exit B1"]);
+		expect(onlyId2).toEqual(["enter A2", "exit A2", "enter B2", "exit B2"]);
+	});
+});

--- a/Lib/tests/locks/withLockedEntities.test.ts
+++ b/Lib/tests/locks/withLockedEntities.test.ts
@@ -21,7 +21,7 @@ interface FakeSequelize {
 
 function makeFakeSequelize(): FakeSequelize {
 	return {
-		transaction: async fn => fn({ LOCK: { UPDATE: "FOR UPDATE" } })
+		transaction: fn => fn({ LOCK: { UPDATE: "FOR UPDATE" } })
 	};
 }
 

--- a/Lib/tests/locks/withLockedEntities.test.ts
+++ b/Lib/tests/locks/withLockedEntities.test.ts
@@ -39,7 +39,7 @@ function makeFakeModel(
 		tableName,
 		name: tableName,
 		sequelize,
-		findByPk: vi.fn(async (id: number) => rows[id] ?? null)
+		findByPk: vi.fn((id: number): Promise<FakeRow | null> => Promise.resolve(rows[id] ?? null))
 	};
 }
 
@@ -68,13 +68,13 @@ describe("withLockedEntities (unit)", () => {
 	it("rejects when keys come from different Sequelize instances", async () => {
 		const seqA = makeFakeSequelize();
 		const seqB = makeFakeSequelize();
-		const a = makeFakeModel("a", { 1: { id: 1, tag: "a1" } }, seqA);
-		const b = makeFakeModel("b", { 1: { id: 1, tag: "b1" } }, seqB);
+		const modelA = makeFakeModel("a", { 1: { id: 1, tag: "a1" } }, seqA);
+		const modelB = makeFakeModel("b", { 1: { id: 1, tag: "b1" } }, seqB);
 
 		await expect(withLockedEntities(
 			[
-				{ model: a as never, id: 1 },
-				{ model: b as never, id: 1 }
+				{ model: modelA as never, id: 1 },
+				{ model: modelB as never, id: 1 }
 			],
 			async () => "never"
 		)).rejects.toThrow(/different Sequelize instance/);
@@ -147,7 +147,7 @@ describe("withLockedEntities (unit)", () => {
 			}
 		);
 
-		expect(received.map(r => r.tag)).toEqual(["p7", "g5", "p2"]);
+		expect(received.map(row => row.tag)).toEqual(["p7", "g5", "p2"]);
 	});
 
 	it("dedupes identical keys but still surfaces them at every position", async () => {

--- a/Lib/tests/locks/withLockedEntities.test.ts
+++ b/Lib/tests/locks/withLockedEntities.test.ts
@@ -1,0 +1,209 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import {
+	withLockedEntities, LockKey
+} from "../../src/locks/withLockedEntities";
+
+/**
+ * Minimal "model double" mimicking the slice of Sequelize's `ModelStatic`
+ * that {@link withLockedEntities} touches: `tableName`, `name`,
+ * `sequelize`, and `findByPk(id, options)`. This keeps the unit tests
+ * fully synchronous and DB-free; the real serialisation guarantees of
+ * `SELECT … FOR UPDATE` are exercised separately by the integration
+ * suite in `Core/__tests__-integration/`.
+ */
+type FakeRow = { id: number; tag: string };
+
+interface FakeSequelize {
+	transaction: (fn: (t: { LOCK: { UPDATE: string } }) => Promise<unknown>) => Promise<unknown>;
+}
+
+function makeFakeSequelize(): FakeSequelize {
+	return {
+		transaction: async fn => fn({ LOCK: { UPDATE: "FOR UPDATE" } })
+	};
+}
+
+function makeFakeModel(
+	tableName: string,
+	rows: Record<number, FakeRow>,
+	sequelize: FakeSequelize
+): {
+		tableName: string;
+		name: string;
+		sequelize: FakeSequelize;
+		findByPk: ReturnType<typeof vi.fn>;
+	} {
+	return {
+		tableName,
+		name: tableName,
+		sequelize,
+		findByPk: vi.fn(async (id: number) => rows[id] ?? null)
+	};
+}
+
+// All the unit tests cast the fake model to `any` only at the call site
+// where it crosses into `withLockedEntities` — `LockKey<...>`'s structural
+// shape matches the fake exactly, so this is a localised cheat.
+
+describe("withLockedEntities (unit)", () => {
+	it("rejects an empty key list", async () => {
+		await expect(withLockedEntities([], async () => "never")).rejects.toThrow(/non-empty/);
+	});
+
+	it("rejects when the target model is not bound to a Sequelize instance", async () => {
+		const orphan = {
+			tableName: "ghost",
+			name: "Ghost",
+			sequelize: null,
+			findByPk: vi.fn()
+		};
+		const key: LockKey = {
+			model: orphan as never, id: 1
+		};
+		await expect(withLockedEntities([key], async () => 1)).rejects.toThrow(/not bound/);
+	});
+
+	it("rejects when keys come from different Sequelize instances", async () => {
+		const seqA = makeFakeSequelize();
+		const seqB = makeFakeSequelize();
+		const a = makeFakeModel("a", { 1: { id: 1, tag: "a1" } }, seqA);
+		const b = makeFakeModel("b", { 1: { id: 1, tag: "b1" } }, seqB);
+
+		await expect(withLockedEntities(
+			[
+				{ model: a as never, id: 1 },
+				{ model: b as never, id: 1 }
+			],
+			async () => "never"
+		)).rejects.toThrow(/different Sequelize instance/);
+	});
+
+	it("acquires locks in canonical (tableName, id) order", async () => {
+		const seq = makeFakeSequelize();
+		const guild = makeFakeModel("guild", { 5: { id: 5, tag: "g5" } }, seq);
+		const player = makeFakeModel("player", {
+			2: { id: 2, tag: "p2" },
+			7: { id: 7, tag: "p7" }
+		}, seq);
+
+		const callOrder: string[] = [];
+		guild.findByPk.mockImplementation(async (id: number) => {
+			callOrder.push(`guild#${id}`);
+			return { id, tag: `g${id}` };
+		});
+		player.findByPk.mockImplementation(async (id: number) => {
+			callOrder.push(`player#${id}`);
+			return { id, tag: `p${id}` };
+		});
+
+		// Caller passes them in arbitrary order; the helper must sort internally.
+		await withLockedEntities(
+			[
+				{ model: player as never, id: 7 },
+				{ model: guild as never, id: 5 },
+				{ model: player as never, id: 2 }
+			],
+			async () => "ok"
+		);
+
+		expect(callOrder).toEqual(["guild#5", "player#2", "player#7"]);
+	});
+
+	it("passes findByPk a transaction with FOR UPDATE row-lock", async () => {
+		const seq = makeFakeSequelize();
+		const player = makeFakeModel("player", { 1: { id: 1, tag: "p1" } }, seq);
+
+		await withLockedEntities([{ model: player as never, id: 1 }], async () => "ok");
+
+		expect(player.findByPk).toHaveBeenCalledTimes(1);
+		const [id, options] = player.findByPk.mock.calls[0];
+		expect(id).toBe(1);
+		expect(options).toMatchObject({
+			lock: "FOR UPDATE"
+		});
+		expect(options.transaction).toBeDefined();
+	});
+
+	it("returns entities to the callback in the caller's original order", async () => {
+		const seq = makeFakeSequelize();
+		const guild = makeFakeModel("guild", { 5: { id: 5, tag: "g5" } }, seq);
+		const player = makeFakeModel("player", {
+			2: { id: 2, tag: "p2" },
+			7: { id: 7, tag: "p7" }
+		}, seq);
+
+		let received: { tag: string }[] = [];
+		await withLockedEntities(
+			[
+				{ model: player as never, id: 7 },
+				{ model: guild as never, id: 5 },
+				{ model: player as never, id: 2 }
+			],
+			async entities => {
+				received = entities as { tag: string }[];
+				return "ok";
+			}
+		);
+
+		expect(received.map(r => r.tag)).toEqual(["p7", "g5", "p2"]);
+	});
+
+	it("dedupes identical keys but still surfaces them at every position", async () => {
+		const seq = makeFakeSequelize();
+		const player = makeFakeModel("player", { 3: { id: 3, tag: "p3" } }, seq);
+
+		let received: { tag: string }[] = [];
+		await withLockedEntities(
+			[
+				{ model: player as never, id: 3 },
+				{ model: player as never, id: 3 }
+			],
+			async entities => {
+				received = entities as { tag: string }[];
+				return "ok";
+			}
+		);
+
+		// findByPk should have been called only once for the deduped key…
+		expect(player.findByPk).toHaveBeenCalledTimes(1);
+		// …and both tuple positions point to the same locked instance.
+		expect(received).toHaveLength(2);
+		expect(received[0]).toBe(received[1]);
+	});
+
+	it("throws when a locked row cannot be found", async () => {
+		const seq = makeFakeSequelize();
+		const player = makeFakeModel("player", {}, seq); // empty rows
+
+		await expect(withLockedEntities(
+			[{ model: player as never, id: 99 }],
+			async () => "never"
+		)).rejects.toThrow(/row not found/);
+	});
+
+	it("propagates and surfaces errors thrown inside the callback", async () => {
+		const seq = makeFakeSequelize();
+		const player = makeFakeModel("player", { 1: { id: 1, tag: "p1" } }, seq);
+
+		const boom = new Error("kaboom");
+		await expect(withLockedEntities(
+			[{ model: player as never, id: 1 }],
+			async () => {
+				throw boom;
+			}
+		)).rejects.toBe(boom);
+	});
+
+	it("returns the callback's resolved value on success", async () => {
+		const seq = makeFakeSequelize();
+		const player = makeFakeModel("player", { 1: { id: 1, tag: "p1" } }, seq);
+
+		const result = await withLockedEntities(
+			[{ model: player as never, id: 1 }],
+			async () => 1234
+		);
+		expect(result).toBe(1234);
+	});
+});

--- a/docs/CONCURRENCY_PLAN.md
+++ b/docs/CONCURRENCY_PLAN.md
@@ -43,11 +43,11 @@
 |---|---|---|
 | Locking mechanism | **Sequelize transaction + `SELECT … FOR UPDATE`** via `findByPk(..., { lock: true, transaction: t })` | Native Sequelize/MariaDB. Works mono- and multi-instance. Zero custom logic. |
 | Transaction threading to existing `xxx.save()` calls | **`Sequelize.useCLS(namespace)`** with **`cls-hooked`** dep | Documented Sequelize v6 path. Reviewer accepts the dep for the zero-maintenance / battle-tested upside. ~175 call sites are not touched. |
-| Composite locks | Deterministic ordering: `(scope, id)` lexicographic, applied **inside** `withEntityLock` | Prevents deadlocks; callers can pass keys in any order. |
-| Re-fetch inside critical section | **Mandatory** — `withEntityLock` does the re-fetch and passes fresh entities to the callback | Closes the bug pattern: any value read before the lock is discarded. |
+| Composite locks | Deterministic ordering: `(tableName, id)` lexicographic, applied **inside** `withLockedEntities` | Prevents deadlocks; callers can pass keys in any order. |
+| Re-fetch inside critical section | **Mandatory** — `withLockedEntities` does the re-fetch and passes fresh entities to the callback | Closes the bug pattern: any value read before the lock is discarded. |
 | In-process `AsyncLock` | Kept as an **opt-in coalescing optimisation** layered above DB locks | Cheap insurance; not on the critical correctness path. |
 | Integration tests | New `pnpm test:integration` against a real **MariaDB** (local: reuse dev DB with a randomised `prefix`; CI: a `mariadb` service in GitHub Actions) | No `testcontainers` dep. Must run on every PR. |
-| ESLint guard rail | Custom rule forbidding `xxx.save()` outside `withEntityLock`, with allow-list (cron / admin / GDPR / read-only) | Prevents regression after the migration. |
+| ESLint guard rail | Custom rule forbidding `xxx.save()` outside `withLockedEntities`, with allow-list (cron / admin / GDPR / read-only) | Prevents regression after the migration. |
 | Delivery | **Merge train of PRs**, not one mega-PR. This MD ships with every PR. | Faster review, easier revert. Reviewer confirmed: "fais bien toutes les PRs". |
 
 ## 2. Public API of the new module
@@ -110,7 +110,7 @@ return withLockedEntities(
 | Layer | Tool | Goal |
 |---|---|---|
 | `AsyncLock`, `LockManager`, key-ordering | Unit (Vitest, no DB) | Behavioural contract |
-| `withEntityLock` end-to-end | **Integration** (Vitest + real MariaDB) | Two parallel callers serialise; rollback on throw; CLS propagation to nested `save()` |
+| `withLockedEntities` end-to-end | **Integration** (Vitest + real MariaDB) | Two parallel callers serialise; rollback on throw; CLS propagation to nested `save()` |
 | Per-handler race tests | **Integration** | For each migrated handler: two concurrent calls + assert at most one passes when only one fits the budget / capacity |
 | Existing unit tests | Vitest | Stay green |
 
@@ -222,7 +222,7 @@ Each PR must keep the project green: `pnpm eslint` + `pnpm test` + `pnpm test:in
 - [ ] `pnpm test` green in every modified service
 - [ ] `pnpm test:integration` green (from PR-B onwards)
 - [ ] Race integration test added for any handler newly migrated
-- [ ] No new `xxx.save()` outside a `withEntityLock` (or allow-listed)
+- [ ] No new `xxx.save()` outside a `withLockedEntities` (or allow-listed)
 - [ ] **This document** updated in the same commit
 
 ## 7. Open questions

--- a/docs/CONCURRENCY_PLAN.md
+++ b/docs/CONCURRENCY_PLAN.md
@@ -1,0 +1,240 @@
+# Concurrency Hardening Plan — `tx-isolation` branch
+
+> **Goal**: eliminate the class of bugs where two concurrent MQTT packet handlers
+> read-modify-write the same DB row (player money, guild treasury / storage,
+> pet, mission progress, …) and one of the writes is silently lost or a
+> validation is bypassed (double-spend, treasury overdraft, storage cap
+> exceeded, item duplication on pet trade, …).
+>
+> The bug raised on `handleFoodShopBuy` is the visible tip of a codebase-wide
+> pattern: ~175 `xxx.save()` call sites across Core and only **2** are
+> currently guarded (`GuildDailyCommand`, `handleGuildDomainDepositTreasury`).
+>
+> **Additional goal (confirmed by reviewer)**: the solution must keep working
+> if Core is later deployed as **multiple instances**. ⇒ in-process locks are
+> not enough; we need DB-backed locking.
+>
+> This document is the **single source of truth** for the work. It is updated
+> as work progresses — checkboxes reflect real status. Work is split across
+> a **merge train of PRs** (see §5).
+
+---
+
+## 0. Architectural facts (verified)
+
+- **Today**: Core is a single Node.js process (no shard config).
+- **Tomorrow**: Core may be deployed multi-instance. The plan must support that
+  without rewriting call sites.
+- **Concurrency source**: MQTT messages are dispatched concurrently — every
+  `await` between `Players.getByKeycloakId(...)` and `player.save()` yields
+  the event loop, so a second packet for the same player can interleave.
+- **Sequelize version**: `6.37.7` (verified in all 4 service `package.json`).
+- **Existing primitive**: `Lib/src/locks/AsyncLock.ts` + `LockManager.ts`
+  (in-process FIFO). Used in 2 places. Will be **kept** as an optional
+  same-process coalescing optimisation but is no longer the correctness
+  mechanism.
+- **No existing `sequelize.transaction()` calls** in `Core/src` (`grep` returns 0).
+- **Test infra**: Vitest is wired for unit tests. **No integration test
+  framework exists** — this PR train introduces one.
+
+## 1. Strategy — confirmed decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Locking mechanism | **Sequelize transaction + `SELECT … FOR UPDATE`** via `findByPk(..., { lock: true, transaction: t })` | Native Sequelize/MariaDB. Works mono- and multi-instance. Zero custom logic. |
+| Transaction threading to existing `xxx.save()` calls | **`Sequelize.useCLS(namespace)`** with **`cls-hooked`** dep | Documented Sequelize v6 path. Reviewer accepts the dep for the zero-maintenance / battle-tested upside. ~175 call sites are not touched. |
+| Composite locks | Deterministic ordering: `(scope, id)` lexicographic, applied **inside** `withEntityLock` | Prevents deadlocks; callers can pass keys in any order. |
+| Re-fetch inside critical section | **Mandatory** — `withEntityLock` does the re-fetch and passes fresh entities to the callback | Closes the bug pattern: any value read before the lock is discarded. |
+| In-process `AsyncLock` | Kept as an **opt-in coalescing optimisation** layered above DB locks | Cheap insurance; not on the critical correctness path. |
+| Integration tests | New `pnpm test:integration` against a real **MariaDB** (local: reuse dev DB with a randomised `prefix`; CI: a `mariadb` service in GitHub Actions) | No `testcontainers` dep. Must run on every PR. |
+| ESLint guard rail | Custom rule forbidding `xxx.save()` outside `withEntityLock`, with allow-list (cron / admin / GDPR / read-only) | Prevents regression after the migration. |
+| Delivery | **Merge train of PRs**, not one mega-PR. This MD ships with every PR. | Faster review, easier revert. Reviewer confirmed: "fais bien toutes les PRs". |
+
+## 2. Public API of the new module
+
+We use **lock helpers attached to the model class** (DDD-friendly, type-safe,
+no magic strings, no global registry). Lib stays generic — it only knows
+`Model` / `ModelStatic` from Sequelize.
+
+```ts
+// Lib/src/locks/withLockedEntities.ts — purely generic
+import { Model, ModelStatic } from "sequelize";
+
+export interface LockKey<M extends Model> {
+  readonly model: ModelStatic<M>;
+  readonly id: number;
+}
+
+// Opens a transaction, sorts keys canonically by (model.tableName, id),
+// dedupes duplicates, acquires SELECT … FOR UPDATE on each row, then
+// passes a tuple of freshly-fetched instances to the callback (in the
+// caller's original order). Any xxx.save() inside `fn` inherits the
+// transaction through Sequelize CLS. Throws ⇒ rollback; resolves ⇒ commit.
+export async function withLockedEntities<
+  K extends readonly LockKey<Model>[],
+  R
+>(
+  keys: K,
+  fn: (entities: { [I in keyof K]: K[I] extends LockKey<infer M> ? M : never }) => Promise<R>
+): Promise<R>;
+```
+
+```ts
+// In Core models — additions to existing Player / Guild / Pet / Home / …
+class Player extends Model {
+  static lockKey(id: number): LockKey<Player> { return { model: Player, id }; }
+  static withLocked<R>(id: number, fn: (p: Player) => Promise<R>): Promise<R> {
+    return withLockedEntities([Player.lockKey(id)], ([p]) => fn(p));
+  }
+}
+```
+
+Call-site shapes:
+
+```ts
+// Single entity
+return Player.withLocked(playerId, async player => {
+  player.money -= cost;
+  await player.save(); // CLS injects the transaction
+});
+
+// Composite (e.g. pet trade)
+return withLockedEntities(
+  [Player.lockKey(sellerId), Player.lockKey(buyerId), Pet.lockKey(petId)],
+  async ([seller, buyer, pet]) => { /* … */ }
+);
+```
+
+## 3. Test strategy
+
+| Layer | Tool | Goal |
+|---|---|---|
+| `AsyncLock`, `LockManager`, key-ordering | Unit (Vitest, no DB) | Behavioural contract |
+| `withEntityLock` end-to-end | **Integration** (Vitest + real MariaDB) | Two parallel callers serialise; rollback on throw; CLS propagation to nested `save()` |
+| Per-handler race tests | **Integration** | For each migrated handler: two concurrent calls + assert at most one passes when only one fits the budget / capacity |
+| Existing unit tests | Vitest | Stay green |
+
+**Integration test infra (PR-B)**:
+- New script `pnpm test:integration` in `Core/package.json`.
+- Helper `Core/__tests__-integration/_setup.ts` that:
+  - reads MariaDB host/port/user/pass from env (defaults pointing at the local dev DB),
+  - generates a unique prefix `crownicles_test_<pid>_<rand>`,
+  - calls the existing migration runner against that prefix,
+  - returns a teardown that drops the schemas.
+- GitHub Actions workflow `integration-tests.yml` with a `services: mariadb` block, runs on every PR.
+
+## 4. Inventory of vulnerable handlers
+
+Generated from `grep player.save / guild.save` + manual review.
+
+### 4.1 Critical — money / treasury / storage (silent overdraft possible)
+
+- [ ] `Core/src/core/report/ReportCityFoodShopService.ts` — `handleFoodShopBuy` (the original bug)
+- [ ] `Core/src/core/report/ReportCityGuildDomainShopService.ts` — already locks guild but reads `player.money` **before** the lock. Migrate + add player lock.
+- [ ] `Core/src/commands/player/ReportCommand.ts` — shop / chest reactions
+- [ ] `Core/src/core/report/ReportCityChestService.ts`
+- [ ] `Core/src/core/report/ReportCityBlacksmithService.ts`
+- [ ] `Core/src/core/report/ReportCityEnchanterService.ts`
+- [ ] `Core/src/core/report/ReportCityHomeService.ts`
+- [ ] `Core/src/core/report/ReportCityInnService.ts`
+- [ ] `Core/src/core/report/ReportTokenHealService.ts`
+- [ ] `Core/src/commands/mission/MissionShopCommand.ts`
+- [ ] `Core/src/core/utils/MissionShopItems.ts`
+- [ ] `Core/src/core/utils/TannerShopItems.ts`
+- [ ] `Core/src/core/utils/VeterinarianShopItems.ts`
+- [ ] `Core/src/core/utils/GeneralShopItems.ts`
+- [ ] `Core/src/core/smallEvents/interfaces/Shop.ts`
+- [ ] `Core/src/core/utils/ShopUtils.ts`
+
+### 4.2 Critical — cross-entity (item / pet duplication possible)
+
+- [ ] `Core/src/commands/pet/PetTransferCommand.ts`
+- [ ] `Core/src/commands/pet/PetSellCommand.ts`
+- [ ] `Core/src/commands/pet/PetFreeCommand.ts`
+- [ ] `Core/src/commands/pet/PetExpeditionCommand.ts`
+- [ ] `Core/src/commands/pet/PetFeedCommand.ts`
+- [ ] `Core/src/core/smallEvents/interactOtherPlayers.ts`
+
+### 4.3 High — guild membership (orphan / duplicate-chief possible)
+
+- [ ] `Core/src/commands/guild/GuildLeaveCommand.ts`
+- [ ] `Core/src/commands/guild/GuildKickCommand.ts`
+- [ ] `Core/src/commands/guild/GuildInviteCommand.ts`
+- [ ] `Core/src/commands/guild/GuildElderCommand.ts`
+- [ ] `Core/src/commands/guild/GuildElderRemoveCommand.ts`
+- [ ] `Core/src/commands/guild/GuildCreateCommand.ts`
+- [ ] `Core/src/commands/guild/GuildDescriptionCommand.ts`
+- [ ] `Core/src/core/report/ReportPveService.ts`
+- [ ] `Core/src/core/report/ReportCookingService.ts`
+
+### 4.4 Medium — single-player state (XP / health / score lost updates)
+
+- [ ] All `Core/src/core/smallEvents/*.ts` ending in `player.save()`. Sweep via codemod, file-by-file review.
+- [ ] `Core/src/core/cooking/CookingService.ts` — already serialised by the cooking menu lock, audit-only.
+- [ ] `Core/src/core/missions/MissionsController.ts` — wrap missions update in the player lock.
+
+### 4.5 Out of scope (allow-listed in the ESLint rule)
+
+- All `Core/src/commands/admin/**` test commands — operator-driven.
+- GDPR exporters — read-only.
+- Cron jobs (`CrowniclesDaily`) — already single-fire.
+- `LogsDatabase` — append-only.
+
+## 5. Implementation stages (one PR per stage in the merge train)
+
+Each PR must keep the project green: `pnpm eslint` + `pnpm test` + `pnpm test:integration` (where applicable) all pass.
+
+- [~] **PR-AB — Foundation (lock infra + integration test framework, merged)**
+  - [x] `Lib` adds `cls-hooked` dependency
+  - [x] `Lib/src/locks/CLSNamespace.ts`: shared CLS namespace + `useCLSOnSequelize(SequelizeCtor)` helper (ctor passed explicitly because pnpm can resolve several physical `sequelize` copies across packages)
+  - [x] `Lib/src/locks/withLockedEntities.ts`: generic, model-agnostic API (see §2)
+  - [x] Wire `Sequelize.useCLS(...)` in `Lib/src/database/Database.ts` **before** any `new Sequelize(...)` call
+  - [x] Add `lockKey()` + `withLocked()` statics to `Player`, `Guild`, `PetEntity`, `Home`
+  - [x] Unit tests for `AsyncLock`, `LockManager`, `withLockedEntities` pure logic (sort/dedup/error paths)
+  - [x] `Core/package.json`: new `test:integration` script
+  - [x] `Core/__tests__-integration/_setup.ts` (DB provisioning helpers)
+  - [x] `Core/__tests__-integration/locks/withLockedEntities.integration.test.ts`
+        (proves serialisation + rollback on throw + dedup + CLS propagation against real MariaDB — 7/7 green)
+  - [x] GitHub Actions workflow `integration-tests.yml` with a `mariadb:11` service
+  - [x] `Core/README.md`: how to run integration tests locally
+  - [x] No call site is migrated yet — purely additive
+
+- [ ] **PR-C — Fix the reported bug**
+  - [ ] Race integration test for `handleFoodShopBuy` (red)
+  - [ ] Migrate `handleFoodShopBuy` to `withLockedEntities` (green)
+
+- [ ] **PR-D — Migrate `handleGuildDomainDepositTreasury`**
+
+- [ ] **PR-E — Migrate critical money/treasury/storage handlers (§4.1)**
+
+- [ ] **PR-F — Migrate cross-entity pet handlers (§4.2)** (pet trade gets a 3-key lock)
+
+- [ ] **PR-G — Migrate guild membership handlers (§4.3)**
+
+- [ ] **PR-H — Sweep medium handlers (§4.4) + ESLint rule + docs**
+  - [ ] Codemod (commit-by-commit review) for §4.4
+  - [ ] `eslint-custom-rules/no-unguarded-save.mjs` with allow-list
+  - [ ] `docs/CONCURRENCY.md` (1-pager)
+
+## 6. Pre-commit checklist (per stage)
+
+- [ ] `pnpm eslint` green in every modified service
+- [ ] `pnpm test` green in every modified service
+- [ ] `pnpm test:integration` green (from PR-B onwards)
+- [ ] Race integration test added for any handler newly migrated
+- [ ] No new `xxx.save()` outside a `withEntityLock` (or allow-listed)
+- [ ] **This document** updated in the same commit
+
+## 7. Open questions
+
+*(none currently — all blockers answered by reviewer 2026-05-07: multi-instance target confirmed, `cls-hooked` accepted, integration tests with MariaDB in GitHub Actions confirmed, merge-train delivery confirmed.)*
+
+## 8. Status legend
+
+- [ ] Not started
+- [~] In progress
+- [x] Done (merged)
+
+---
+
+*Last update: PR-AB foundation **complete and green** — `cls-hooked` dep installed, CLS namespace + `useCLSOnSequelize(SequelizeCtor)` wired into `Lib/Database.ts`, `withLockedEntities()` + `Player/Guild/PetEntity/Home.lockKey/withLocked()` statics in place, unit tests + 7/7 MariaDB integration tests green (`pnpm test:integration`), GitHub Actions `integration-tests.yml` added, Core README updated. No call site migrated yet — that lands in PR-C.*


### PR DESCRIPTION
Tracking issue: #4181

## Summary

PR-AB of the merge train described in [`docs/CONCURRENCY_PLAN.md`](docs/CONCURRENCY_PLAN.md). Adds the **foundation** for fixing the `handleFoodShopBuy`-class of races (and ~175 similar `xxx.save()` call sites) without touching any call site yet.

The actual call-site migrations land in follow-up PRs (PR-C onwards), one cohesive group at a time, each with a dedicated race integration test.

## What this introduces

**Lib**
- `cls-hooked` dep + `Lib/src/locks/CLSNamespace.ts` exposing `useCLSOnSequelize(SequelizeCtor)`. Ctor is passed explicitly because pnpm can resolve several physical \`sequelize\` copies across packages (different \`mariadb\` peer-dep selectors) and \`useCLS\` only affects the constructor it is called on.
- \`Lib/src/locks/withLockedEntities.ts\`: opens a Sequelize transaction, sorts keys canonically by \`(tableName, id)\` for deadlock-freedom, dedupes duplicates, acquires \`SELECT … FOR UPDATE\` per row, re-fetches inside the tx, and surfaces fresh instances to the callback in caller order. Throw → rollback; resolve → commit.
- \`Database.ts\` wires \`useCLSOnSequelize(Sequelize)\` before any \`new Sequelize(...)\`.

**Core**
- \`lockKey()\` + \`withLocked()\` statics on \`Player\`, \`Guild\`, \`PetEntity\`, \`Home\`.
- New \`pnpm test:integration\` script + dedicated vitest config.
- \`__tests__-integration/_setup.ts\`: provisions a one-shot MariaDB schema per suite (CREATE DATABASE + per-host GRANT lookup, schema name embeds pid + random suffix) and tears it down.
- \`withLockedEntities.integration.test.ts\` (7 cases) proves against real MariaDB: commit, rollback on throw, FOR UPDATE serialisation under contention, CLS propagation to nested \`save()\`, canonical-order acquisition + caller-order surfacing, dedup, row-not-found rollback.

**CI**
- \`.github/workflows/integration-tests.yml\` boots a \`mariadb:11\` service container and runs \`pnpm test:integration\`.

**Docs**
- \`docs/CONCURRENCY_PLAN.md\` (single source of truth for the work, updated commit-by-commit).
- \`Core/README.md\` documents how to run integration tests locally and which env vars to override.

## Local validation

\`\`\`
pnpm tsc            # Lib + Core, no errors
pnpm eslint src     # Lib + Core, no warnings
pnpm test           # 547 Lib + 1006 Core, all green
pnpm test:integration   # 7/7 green against local MariaDB
\`\`\`

## Out of scope (next PRs)

- PR-C: \`handleFoodShopBuy\` race test + migration.
- PR-D..PR-G: critical money/treasury/storage, cross-entity pet, guild membership.
- PR-H: codemod sweep of \`smallEvents/*\` + \`no-unguarded-save\` ESLint rule + 1-page docs/CONCURRENCY.md.

Targeting \`guildhouse\` per the active PR train.