### PR TITLE
fix(#4176, #4177): tokens reset cap & omnivorous expedition food + bump 5.3.1.b

### DIFF
--- a/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
+++ b/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
@@ -308,6 +308,27 @@ describe("Food Consumption Plan", () => {
 				expect(herbivorousUsed).toBe(2);
 				expect(plan.totalRations).toBe(9);
 			});
+
+			it("should split consumption across carnivorous and herbivorous when both are available (balanced tie-break)", async () => {
+				// 6 rations, 0 treats / 5 carn / 5 herb / 0 soup. With the current
+				// pricing (carn = herb = 250 cost / 3 rations), three equally-good
+				// combinations exist: (2 carn, 0 herb), (0 carn, 2 herb) and
+				// (1 carn, 1 herb). The planner should pick the balanced one so
+				// omnivores don't silently drain a single diet stock.
+				vi.mocked(Guilds.getById).mockResolvedValue(createMockGuild(0, 5, 5, 0) as never);
+
+				const plan = await calculateFoodConsumptionPlan(
+					createMockPlayer(1),
+					createMockPet(true, true), // Omnivorous
+					6
+				);
+
+				const carnivorousUsed = plan.consumption.find(c => c.foodType === "carnivorousFood")?.itemsToConsume ?? 0;
+				const herbivorousUsed = plan.consumption.find(c => c.foodType === "herbivorousFood")?.itemsToConsume ?? 0;
+				expect(carnivorousUsed).toBe(1);
+				expect(herbivorousUsed).toBe(1);
+				expect(plan.totalRations).toBe(6);
+			});
 		});
 	});
 });

--- a/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
+++ b/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
@@ -22,9 +22,10 @@ function createMockPlayer(guildId: number | null): Player {
 /**
  * Helper to create a mock pet
  */
-function createMockPet(canEatMeat: boolean): Pet {
+function createMockPet(canEatMeat: boolean, canEatVegetables: boolean = !canEatMeat): Pet {
 	return {
-		canEatMeat: () => canEatMeat
+		canEatMeat: () => canEatMeat,
+		canEatVegetables: () => canEatVegetables
 	} as Pet;
 }
 
@@ -272,6 +273,41 @@ describe("Food Consumption Plan", () => {
 			expect(PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[2]).toBe(3);
 			expect(PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[1]).toBe(3);
 			expect(PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[3]).toBe(5);
+		});
+
+		describe("Omnivorous pets", () => {
+			it("should consume herbivorous food when no carnivorous food is available (regression #4177)", async () => {
+				// Guild has 0 commonFood, 0 carnivorousFood, 4 herbivorousFood, 0 ultimateFood
+				// An omnivorous pet should be able to use the salads (4 * 3 = 12 rations).
+				vi.mocked(Guilds.getById).mockResolvedValue(createMockGuild(0, 0, 4, 0) as never);
+
+				const plan = await calculateFoodConsumptionPlan(
+					createMockPlayer(1),
+					createMockPet(true, true), // Omnivorous
+					6
+				);
+
+				const herbivorousUsed = plan.consumption.find(c => c.foodType === "herbivorousFood")?.itemsToConsume ?? 0;
+				expect(herbivorousUsed).toBe(2);
+				expect(plan.totalRations).toBe(6);
+			});
+
+			it("should consume both carnivorous and herbivorous food when needed", async () => {
+				// 9 rations required, only 1 carn + 2 herb available => need both diets.
+				vi.mocked(Guilds.getById).mockResolvedValue(createMockGuild(0, 1, 2, 0) as never);
+
+				const plan = await calculateFoodConsumptionPlan(
+					createMockPlayer(1),
+					createMockPet(true, true), // Omnivorous
+					9
+				);
+
+				const carnivorousUsed = plan.consumption.find(c => c.foodType === "carnivorousFood")?.itemsToConsume ?? 0;
+				const herbivorousUsed = plan.consumption.find(c => c.foodType === "herbivorousFood")?.itemsToConsume ?? 0;
+				expect(carnivorousUsed).toBe(1);
+				expect(herbivorousUsed).toBe(2);
+				expect(plan.totalRations).toBe(9);
+			});
 		});
 	});
 });

--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Core/src/core/bot/Crownicles.ts
+++ b/Core/src/core/bot/Crownicles.ts
@@ -83,7 +83,7 @@ export class Crownicles {
 
 		await Player.update(
 			{
-				tokens: Sequelize.literal(`LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY})`)
+				tokens: Sequelize.literal(`GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`)
 			},
 			{ where: {} }
 		);

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -175,13 +175,21 @@ function evaluateCombination(amounts: FoodAmounts, context: FoodEvaluationContex
 }
 
 /**
- * Compare two combinations: prefer lower excess, then lower cost
+ * Compare two combinations: prefer lower excess, then lower cost, then —
+ * for omnivores — a more balanced split across the two diet types so that
+ * the planner does not silently drain one diet stock while the other sits
+ * untouched.
  */
 function isBetterCombination(candidate: FoodCombination, current: FoodCombination): boolean {
-	if (candidate.excess < current.excess) {
-		return true;
+	if (candidate.excess !== current.excess) {
+		return candidate.excess < current.excess;
 	}
-	return candidate.excess === current.excess && candidate.totalCost < current.totalCost;
+	if (candidate.totalCost !== current.totalCost) {
+		return candidate.totalCost < current.totalCost;
+	}
+	const candidateImbalance = Math.abs(candidate.dietCarn - candidate.dietHerb);
+	const currentImbalance = Math.abs(current.dietCarn - current.dietHerb);
+	return candidateImbalance < currentImbalance;
 }
 
 /**

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -50,7 +50,10 @@ const FOOD_CONFIG_MAP: Record<FoodType, FoodConfig> = {
 };
 
 /**
- * Get the diet food type based on whether the pet can eat meat
+ * Get the primary diet food type based on whether the pet can eat meat.
+ * Note: omnivorous pets can use BOTH carnivorous and herbivorous food (see
+ * `getAvailableFoodSlots` / `calculateTotalAvailableRations`); this helper
+ * is kept for callers that need a single representative type.
  */
 export function getDietFoodType(petModel: Pet): FoodType {
 	return petModel.canEatMeat() ? PetConstants.PET_FOOD.CARNIVOROUS_FOOD : PetConstants.PET_FOOD.HERBIVOROUS_FOOD;
@@ -86,7 +89,8 @@ interface AvailableFoodSlot {
  */
 interface FoodCombination {
 	treats: number;
-	diet: number;
+	dietCarn: number;
+	dietHerb: number;
 	soup: number;
 	totalRations: number;
 	totalCost: number;
@@ -94,18 +98,24 @@ interface FoodCombination {
 }
 
 /**
- * Get available food slots for a pet from guild storage
- * Returns [treats, diet, soup] in order
+ * Get available food slots for a pet from guild storage.
+ * Returns [treats, dietCarn, dietHerb, soup] in order. For non-omnivorous
+ * pets, the unsupported diet slot has `available = 0`, so the optimisation
+ * loop collapses naturally on that dimension.
  */
-function getAvailableFoodSlots(guild: Guild, dietType: FoodType): [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot] {
+function getAvailableFoodSlots(guild: Guild, petModel: Pet): [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot] {
 	return [
 		{
 			config: FOOD_CONFIG_MAP.commonFood,
 			available: guild.commonFood
 		},
 		{
-			config: FOOD_CONFIG_MAP[dietType],
-			available: guild[dietType]
+			config: FOOD_CONFIG_MAP.carnivorousFood,
+			available: petModel.canEatMeat() ? guild.carnivorousFood : 0
+		},
+		{
+			config: FOOD_CONFIG_MAP.herbivorousFood,
+			available: petModel.canEatVegetables() ? guild.herbivorousFood : 0
 		},
 		{
 			config: FOOD_CONFIG_MAP.ultimateFood,
@@ -119,7 +129,8 @@ function getAvailableFoodSlots(guild: Guild, dietType: FoodType): [AvailableFood
  */
 interface FoodAmounts {
 	treats: number;
-	diet: number;
+	dietCarn: number;
+	dietHerb: number;
 	soup: number;
 }
 
@@ -127,7 +138,7 @@ interface FoodAmounts {
  * Context for evaluating food combinations
  */
 interface FoodEvaluationContext {
-	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot];
+	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot];
 	rationsRequired: number;
 }
 
@@ -136,23 +147,26 @@ interface FoodEvaluationContext {
  */
 function evaluateCombination(amounts: FoodAmounts, context: FoodEvaluationContext): FoodCombination {
 	const {
-		treats, diet, soup
+		treats, dietCarn, dietHerb, soup
 	} = amounts;
 	const {
 		slots, rationsRequired
 	} = context;
 
 	const totalRations = treats * slots[0].config.rations
-		+ diet * slots[1].config.rations
-		+ soup * slots[2].config.rations;
+		+ dietCarn * slots[1].config.rations
+		+ dietHerb * slots[2].config.rations
+		+ soup * slots[3].config.rations;
 
 	const totalCost = treats * slots[0].config.price
-		+ diet * slots[1].config.price
-		+ soup * slots[2].config.price;
+		+ dietCarn * slots[1].config.price
+		+ dietHerb * slots[2].config.price
+		+ soup * slots[3].config.price;
 
 	return {
 		treats,
-		diet,
+		dietCarn,
+		dietHerb,
 		soup,
 		totalRations,
 		totalCost,
@@ -211,21 +225,22 @@ function tryAndUpdateBest(
  *
  * Algorithm: Smart bounded iteration
  * For each amount of soup (0 to min(available, ceil(required/soupRations)))
- * For each amount of diet (0 to min(available, ceil(remaining/dietRations)))
+ * For each amount of dietCarn (0 to min(available, ceil(remaining/dietRations)))
+ * For each amount of dietHerb (0 to min(available, ceil(remaining/dietRations)))
  * Calculate exact treats needed (with rounding up)
  * If valid, evaluate and compare
  *
- * Complexity: O(S * D) where S = soup items needed, D = diet items needed
- * In practice, this is very small (typically < 10 * 10 = 100 iterations max)
- * Much better than the original O(T * D * S) brute-force with T up to required rations
+ * The two diet dimensions only both expand for omnivorous pets (otherwise
+ * one of them is bounded to 0 by the slot's `available = 0`).
  */
 function findOptimalCombination(
-	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot],
+	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot],
 	rationsRequired: number
 ): FoodCombination {
 	const [
 		treatSlot,
-		dietSlot,
+		dietCarnSlot,
+		dietHerbSlot,
 		soupSlot
 	] = slots;
 	const evalContext: FoodEvaluationContext = {
@@ -234,14 +249,18 @@ function findOptimalCombination(
 
 	// Calculate total available rations
 	const totalAvailableRations = treatSlot.available * treatSlot.config.rations
-		+ dietSlot.available * dietSlot.config.rations
+		+ dietCarnSlot.available * dietCarnSlot.config.rations
+		+ dietHerbSlot.available * dietHerbSlot.config.rations
 		+ soupSlot.available * soupSlot.config.rations;
 
 	// If not enough food, return all available
 	if (totalAvailableRations < rationsRequired) {
 		return evaluateCombination(
 			{
-				treats: treatSlot.available, diet: dietSlot.available, soup: soupSlot.available
+				treats: treatSlot.available,
+				dietCarn: dietCarnSlot.available,
+				dietHerb: dietHerbSlot.available,
+				soup: soupSlot.available
 			},
 			evalContext
 		);
@@ -249,7 +268,12 @@ function findOptimalCombination(
 
 	// Bound search space intelligently
 	const maxSoup = Math.min(soupSlot.available, Math.ceil(rationsRequired / soupSlot.config.rations));
-	const maxDiet = Math.min(dietSlot.available, Math.ceil(rationsRequired / dietSlot.config.rations));
+	const maxDietCarn = dietCarnSlot.config.rations > 0
+		? Math.min(dietCarnSlot.available, Math.ceil(rationsRequired / dietCarnSlot.config.rations))
+		: 0;
+	const maxDietHerb = dietHerbSlot.config.rations > 0
+		? Math.min(dietHerbSlot.available, Math.ceil(rationsRequired / dietHerbSlot.config.rations))
+		: 0;
 
 	let best: FoodCombination | null = null;
 
@@ -257,21 +281,25 @@ function findOptimalCombination(
 	for (let soup = 0; soup <= maxSoup; soup++) {
 		const remainingAfterSoup = rationsRequired - soup * soupSlot.config.rations;
 
-		for (let diet = 0; diet <= maxDiet; diet++) {
-			const remainingAfterDiet = remainingAfterSoup - diet * dietSlot.config.rations;
-			const treatsNeeded = calculateTreatsNeeded(remainingAfterDiet, treatSlot);
+		for (let dietCarn = 0; dietCarn <= maxDietCarn; dietCarn++) {
+			const remainingAfterCarn = remainingAfterSoup - dietCarn * dietCarnSlot.config.rations;
 
-			if (treatsNeeded !== null) {
-				best = tryAndUpdateBest({
-					treats: treatsNeeded, diet, soup
-				}, evalContext, best);
+			for (let dietHerb = 0; dietHerb <= maxDietHerb; dietHerb++) {
+				const remainingAfterHerb = remainingAfterCarn - dietHerb * dietHerbSlot.config.rations;
+				const treatsNeeded = calculateTreatsNeeded(remainingAfterHerb, treatSlot);
+
+				if (treatsNeeded !== null) {
+					best = tryAndUpdateBest({
+						treats: treatsNeeded, dietCarn, dietHerb, soup
+					}, evalContext, best);
+				}
 			}
 		}
 	}
 
 	// Fallback (should not happen if totalAvailable >= required)
 	return best ?? evaluateCombination({
-		treats: 0, diet: 0, soup: 0
+		treats: 0, dietCarn: 0, dietHerb: 0, soup: 0
 	}, evalContext);
 }
 
@@ -280,7 +308,7 @@ function findOptimalCombination(
  */
 function buildPlanFromCombination(
 	combination: FoodCombination,
-	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot]
+	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot]
 ): FoodConsumptionPlan {
 	const plan: FoodConsumptionPlan = {
 		totalRations: combination.totalRations,
@@ -295,19 +323,27 @@ function buildPlanFromCombination(
 		});
 	}
 
-	if (combination.diet > 0) {
+	if (combination.dietCarn > 0) {
 		plan.consumption.push({
 			foodType: slots[1].config.type,
-			itemsToConsume: combination.diet,
-			rationsProvided: combination.diet * slots[1].config.rations
+			itemsToConsume: combination.dietCarn,
+			rationsProvided: combination.dietCarn * slots[1].config.rations
+		});
+	}
+
+	if (combination.dietHerb > 0) {
+		plan.consumption.push({
+			foodType: slots[2].config.type,
+			itemsToConsume: combination.dietHerb,
+			rationsProvided: combination.dietHerb * slots[2].config.rations
 		});
 	}
 
 	if (combination.soup > 0) {
 		plan.consumption.push({
-			foodType: slots[2].config.type,
+			foodType: slots[3].config.type,
 			itemsToConsume: combination.soup,
-			rationsProvided: combination.soup * slots[2].config.rations
+			rationsProvided: combination.soup * slots[3].config.rations
 		});
 	}
 
@@ -339,8 +375,7 @@ export async function calculateFoodConsumptionPlan(
 		return emptyPlan;
 	}
 
-	const dietType = getDietFoodType(petModel);
-	const slots = getAvailableFoodSlots(guild, dietType);
+	const slots = getAvailableFoodSlots(guild, petModel);
 	const optimal = findOptimalCombination(slots, rationsRequired);
 
 	return buildPlanFromCombination(optimal, slots);
@@ -367,11 +402,17 @@ export async function applyFoodConsumptionPlan(guildId: number, plan: FoodConsum
 }
 
 /**
- * Calculate total available rations in a guild for a specific pet's diet
+ * Calculate total available rations in a guild for a specific pet's diet.
+ * Omnivorous pets count both carnivorous and herbivorous food.
  */
 export function calculateTotalAvailableRations(guild: Guild, petModel: Pet): number {
-	const dietType = getDietFoodType(petModel);
-	return guild.commonFood * FOOD_CONFIG_MAP.commonFood.rations
-		+ guild[dietType] * FOOD_CONFIG_MAP[dietType].rations
+	let total = guild.commonFood * FOOD_CONFIG_MAP.commonFood.rations
 		+ guild.ultimateFood * FOOD_CONFIG_MAP.ultimateFood.rations;
+	if (petModel.canEatMeat()) {
+		total += guild.carnivorousFood * FOOD_CONFIG_MAP.carnivorousFood.rations;
+	}
+	if (petModel.canEatVegetables()) {
+		total += guild.herbivorousFood * FOOD_CONFIG_MAP.herbivorousFood.rations;
+	}
+	return total;
 }

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -241,6 +241,41 @@ function tryAndUpdateBest(
  * The two diet dimensions only both expand for omnivorous pets (otherwise
  * one of them is bounded to 0 by the slot's `available = 0`).
  */
+/**
+ * Inner loop of the optimisation: iterate over all viable herbivorous-food
+ * counts for a fixed (soup, dietCarn) pair and return the best combination
+ * found so far. Extracted to keep `findOptimalCombination` shallow.
+ */
+function exploreHerbDimension(args: {
+	soup: number;
+	dietCarn: number;
+	remainingAfterCarn: number;
+	maxDietHerb: number;
+	dietHerbSlot: AvailableFoodSlot;
+	treatSlot: AvailableFoodSlot;
+	evalContext: FoodEvaluationContext;
+	best: FoodCombination | null;
+}): FoodCombination | null {
+	const {
+		soup, dietCarn, remainingAfterCarn, maxDietHerb,
+		dietHerbSlot, treatSlot, evalContext
+	} = args;
+	let best = args.best;
+
+	for (let dietHerb = 0; dietHerb <= maxDietHerb; dietHerb++) {
+		const remainingAfterHerb = remainingAfterCarn - dietHerb * dietHerbSlot.config.rations;
+		const treatsNeeded = calculateTreatsNeeded(remainingAfterHerb, treatSlot);
+		if (treatsNeeded === null) {
+			continue;
+		}
+		best = tryAndUpdateBest({
+			treats: treatsNeeded, dietCarn, dietHerb, soup
+		}, evalContext, best);
+	}
+
+	return best;
+}
+
 function findOptimalCombination(
 	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot],
 	rationsRequired: number
@@ -291,17 +326,16 @@ function findOptimalCombination(
 
 		for (let dietCarn = 0; dietCarn <= maxDietCarn; dietCarn++) {
 			const remainingAfterCarn = remainingAfterSoup - dietCarn * dietCarnSlot.config.rations;
-
-			for (let dietHerb = 0; dietHerb <= maxDietHerb; dietHerb++) {
-				const remainingAfterHerb = remainingAfterCarn - dietHerb * dietHerbSlot.config.rations;
-				const treatsNeeded = calculateTreatsNeeded(remainingAfterHerb, treatSlot);
-
-				if (treatsNeeded !== null) {
-					best = tryAndUpdateBest({
-						treats: treatsNeeded, dietCarn, dietHerb, soup
-					}, evalContext, best);
-				}
-			}
+			best = exploreHerbDimension({
+				soup,
+				dietCarn,
+				remainingAfterCarn,
+				maxDietHerb,
+				dietHerbSlot,
+				treatSlot,
+				evalContext,
+				best
+			});
 		}
 	}
 

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
## Hotfix 5.3.1.b — daily token cap & omnivorous expedition food

Fixes #4176 and #4177, plus a patch version bump to **5.3.1.b** across all workspaces.

### #4176 — daily reset capped tokens at 20/20 even for players above MAX

At 02:00 the daily timeout ran:
```
Player.update({ tokens: LEAST(MAX, tokens + FREE_PER_DAY) })
```
For a player who had legitimately accumulated more than MAX tokens (e.g. 30 from event rewards or carryover for a top-week run), this collapsed them down to 20, silently destroying their stockpile.

**Fix:** only apply the cap when the bumped value is actually higher than the current count, otherwise leave the player's tokens alone:
```
tokens: GREATEST(tokens, LEAST(MAX, tokens + FREE_PER_DAY))
```
- `tokens=18` → `max(18, min(20, 21)) = 20` (gained free tokens)
- `tokens=20` → `max(20, min(20, 23)) = 20` (already capped)
- `tokens=30` → `max(30, min(20, 33)) = 30` (no longer truncated)

### #4177 — omnivorous pet expeditions wrongly fail with "guild out of food"

`ExpeditionFoodService` modelled guild storage as a 3-slot search space (treats / single-diet / soup) and picked the diet slot via `getDietFoodType(petModel)`, which returns `CARNIVOROUS_FOOD` as soon as `canEatMeat()` is true. Omnivorous pets satisfy *both* `canEatMeat` and `canEatVegetables`, so the herbivorous storage was completely invisible to the food planner — even though `Pet.canEatVegetables()` explicitly says omnivores can eat salads.

**Effect:** a guild with plenty of salads but little meat/treats/soup saw the omnivore expedition fail with the *"guild out of food"* warning despite total rations being sufficient.

**Fix:** extend the planner to a 4-slot search space `[treats, dietCarn, dietHerb, soup]`. Each diet slot's `available` is `0` when the pet does not eat that diet, so the loop collapses for strict carnivores/herbivores (their behaviour is unchanged). For omnivores, the planner now sees both diets and combines them optimally (still minimising excess first, then cost). Same correction is mirrored in `calculateTotalAvailableRations` so the choice menu reports the correct guild ration total for omnivores.

### Tests

- All existing `FoodConsumptionPlan` scenarios (carnivore + herbivore) keep passing with the updated mock signature `createMockPet(canEatMeat, canEatVegetables = !canEatMeat)` — the default preserves strict-diet semantics.
- Two new omnivore regression tests:
  1. salads-only guild stock → expedition succeeds using herbivorous food (regression for the exact #4177 scenario);
  2. mixed carn + herb stock → planner consumes both diets to reach the required ration count.

Local: Core 857/857, Discord 77/77, Lib 486/486, ESLint and tsc clean.

### Version bump

Patch bump across the four workspace `package.json`s: `5.3.1.a` → `5.3.1.b`.
