### PR TITLE
Home balancing

### DIFF
--- a/Core/resources/cities/boug_coton.json
+++ b/Core/resources/cities/boug_coton.json
@@ -1,6 +1,6 @@
 {
   "homePriceMultiplier": 0.95,
-  "apartmentPrice": 10000,
+  "apartmentPrice": 6000,
   "mapLinks": [
     87,
     88

--- a/Core/resources/cities/claire_de_ville.json
+++ b/Core/resources/cities/claire_de_ville.json
@@ -1,6 +1,6 @@
 {
   "homePriceMultiplier": 0.99,
-  "apartmentPrice": 14000,
+  "apartmentPrice": 12000,
   "mapLinks": [
     91,
     92

--- a/Core/resources/cities/coco_village.json
+++ b/Core/resources/cities/coco_village.json
@@ -1,6 +1,6 @@
 {
   "homePriceMultiplier": 1.08,
-  "apartmentPrice": 22000,
+  "apartmentPrice": 50000,
   "mapLinks": [
     93,
     94

--- a/Core/resources/cities/royal_castle.json
+++ b/Core/resources/cities/royal_castle.json
@@ -1,6 +1,6 @@
 {
   "homePriceMultiplier": 1.05,
-  "apartmentPrice": 22000,
+  "apartmentPrice": 25000,
   "mapLinks": [
     106,
     107

--- a/Core/resources/cities/ville_forte.json
+++ b/Core/resources/cities/ville_forte.json
@@ -1,6 +1,6 @@
 {
   "homePriceMultiplier": 1.01,
-  "apartmentPrice": 14000,
+  "apartmentPrice": 9000,
   "mapLinks": [
     89,
     90

--- a/Core/src/core/database/game/models/Apartment.ts
+++ b/Core/src/core/database/game/models/Apartment.ts
@@ -44,15 +44,14 @@ export class Apartment extends Model {
 	/**
 	 * Daily rent earned (in coins) when this apartment is rented out
 	 * (i.e. the owner's main home is in the same city).
-	 * Computed from `purchasePrice / RENT_DAYS_TO_FULL_PRICE`.
+	 * Flat amount across all apartments (see `HomeConstants.DAILY_RENT`).
 	 */
 	public getDailyRent(): number {
-		return Math.floor(this.purchasePrice / HomeConstants.RENT_DAYS_TO_FULL_PRICE);
+		return HomeConstants.DAILY_RENT;
 	}
 
 	/**
-	 * Compute the rent currently accumulated since `lastRentClaimedAt`,
-	 * capped at the apartment's purchase price (a single full cycle).
+	 * Compute the rent currently accumulated since `lastRentClaimedAt`.
 	 *
 	 * Note: this does not check whether the apartment is currently rented out
 	 * (that depends on the owner's home city). Callers should only credit this
@@ -61,8 +60,7 @@ export class Apartment extends Model {
 	public getAccumulatedRent(now: Date = new Date()): number {
 		const elapsedMs = now.getTime() - this.lastRentClaimedAt.getTime();
 		const elapsedDays = Math.max(0, elapsedMs / TimeConstants.MS_TIME.DAY);
-		const raw = Math.floor(elapsedDays * this.getDailyRent());
-		return Math.min(raw, this.purchasePrice);
+		return Math.floor(elapsedDays * this.getDailyRent());
 	}
 
 	/**

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -277,6 +277,7 @@ async function buildRemoteApartmentHomeData(params: {
 		// Apartment-specific caps
 		gardenPlots: 0,
 		gardenEarthQuality: homeLevel.features.gardenEarthQuality,
+		gardenPlantStorageCapacity: 0,
 		upgradeItemMaximumRarity: ItemRarity.BASIC,
 		maxItemUpgradeLevel: 0,
 
@@ -566,7 +567,7 @@ export async function buildChestData(
 		await PlayerPlantSlots.ensureSlotsForCount(player.id, desiredPlantSlots);
 
 		const plantSlots = await PlayerPlantSlots.getPlantSlots(player.id);
-		plantMaxCapacity = home.level;
+		plantMaxCapacity = homeLevel.features.gardenPlantStorageCapacity;
 
 		plantStorage = homeStorage
 			.filter(s => s.quantity > 0)

--- a/Core/src/core/report/ReportGardenService.ts
+++ b/Core/src/core/report/ReportGardenService.ts
@@ -50,7 +50,7 @@ export async function buildGardenData(
 	const plots = buildGardenPlotsData(gardenSlots, earthQuality);
 
 	const storageEntries = await HomePlantStorages.getOfHome(home.id);
-	const maxCapacity = home.level;
+	const maxCapacity = homeLevel.features.gardenPlantStorageCapacity;
 	const plantStorage: GardenData["plantStorage"] = storageEntries.map(entry => ({
 		plantId: entry.plantId,
 		quantity: entry.quantity,
@@ -116,7 +116,7 @@ export async function handleGardenHarvest(
 
 	const earthQuality = homeLevel.features.gardenEarthQuality;
 	const gardenSlots = await HomeGardenSlots.getOfHome(home.id);
-	const maxCapacity = home.level;
+	const maxCapacity = homeLevel.features.gardenPlantStorageCapacity;
 
 	let plantsHarvested = 0;
 	const compostResults: {
@@ -359,7 +359,7 @@ export async function handlePlantTransfer(
 	}
 
 	const refreshedData = await buildPlantTransferResponseData({
-		home, player, maxCapacity: home.level
+		home, player, maxCapacity: home.getLevel()!.features.gardenPlantStorageCapacity
 	});
 
 	return makePacket(CommandReportPlantTransferRes, {
@@ -380,7 +380,7 @@ async function handlePlantDeposit(params: {
 		return HomeConstants.PLANT_TRANSFER_ERRORS.NOT_FOUND;
 	}
 
-	const maxCapacity = params.home.level;
+	const maxCapacity = params.home.getLevel()!.features.gardenPlantStorageCapacity;
 	const overflow = await HomePlantStorages.addPlant(params.home.id, sourceSlot.plantId, 1, maxCapacity);
 	if (overflow > 0) {
 		return HomeConstants.PLANT_TRANSFER_ERRORS.STORAGE_FULL;

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -1195,7 +1195,7 @@
       "atParticle": "au"
     },
     "17": {
-      "description": "Village chaud bordant la vallée des rois. Il s'agit d'une oasis chaleureuse pour les voyageurs en transit.",
+      "description": "Village oasis prisé par les nobles de la Vallée des Rois en quête de fraîcheur. Les noix de coco qu'on y récolte sont réputées dans tout le pays et s'échangent à prix d'or sur les marchés du royaume. La rareté des terrains constructibles autour de la source en fait l'un des lieux les plus convoités.",
       "name": "Village Coco",
       "particle": "vers le",
       "atParticle": "au",
@@ -1401,7 +1401,7 @@
       "inParticle": "dans"
     },
     "38": {
-      "description": "Village chaud bordant la vallée des rois. Il s'agit d'une oasis chaleureuse pour les voyageurs en transit.",
+      "description": "Village oasis prisé par les nobles de la Vallée des Rois en quête de fraîcheur. Les noix de coco qu'on y récolte sont réputées dans tout le pays et s'échangent à prix d'or sur les marchés du royaume. La rareté des terrains constructibles autour de la source en fait l'un des lieux les plus convoités.",
       "name": "Village Coco",
       "particle": "vers le",
       "atParticle": "au",

--- a/Lib/src/constants/HomeConstants.ts
+++ b/Lib/src/constants/HomeConstants.ts
@@ -46,10 +46,9 @@ export abstract class HomeConstants {
 	public static readonly ADVANCED_UPGRADE_LEVEL_THRESHOLD = 2;
 
 	/**
-	 * Number of days for the cumulative rent of an apartment to reach its purchase price.
-	 * The daily rent is therefore `purchasePrice / RENT_DAYS_TO_FULL_PRICE`.
+	 * Flat daily rent (in coins) earned by any apartment regardless of its purchase price.
 	 */
-	public static readonly RENT_DAYS_TO_FULL_PRICE = 365;
+	public static readonly DAILY_RENT = 212;
 
 	/**
 	 * Minimum amount of accumulated rent (coins) the player must reach before

--- a/Lib/src/types/HomeFeatures.ts
+++ b/Lib/src/types/HomeFeatures.ts
@@ -45,6 +45,11 @@ export interface HomeFeatures {
 	gardenEarthQuality: GardenEarthQuality;
 
 	/**
+	 * Maximum quantity that can be stored per plant in the garden storage (chest).
+	 */
+	gardenPlantStorageCapacity: number;
+
+	/**
 	 * Permanent bonus to personal inventory slot counts.
 	 * These slots are in addition to the base purchased slots and apply everywhere.
 	 */

--- a/Lib/src/types/HomeLevel.ts
+++ b/Lib/src/types/HomeLevel.ts
@@ -10,7 +10,7 @@ export class HomeLevel {
 		chestSlots: {
 			weapon: 1, armor: 1, object: 0, potion: 0
 		},
-		upgradeItemMaximumRarity: ItemRarity.BASIC,
+		upgradeItemMaximumRarity: ItemRarity.COMMON,
 		maxItemUpgradeLevel: 1,
 		gardenPlots: 0,
 		gardenEarthQuality: GardenEarthQuality.POOR,
@@ -18,36 +18,21 @@ export class HomeLevel {
 		cookingSlots: 0
 	});
 
-	public static readonly LEVEL_2 = new HomeLevel(2, 15, 5000, {
+	public static readonly LEVEL_2 = new HomeLevel(2, 15, 3500, {
 		bedHealthRegeneration: 2,
-		chestSlots: {
-			weapon: 1, armor: 1, object: 1, potion: 1
-		},
-		upgradeItemMaximumRarity: ItemRarity.UNCOMMON,
-		maxItemUpgradeLevel: 1,
-		gardenPlots: 0,
-		gardenEarthQuality: GardenEarthQuality.POOR,
-		inventoryBonus: EMPTY_SLOTS_PER_CATEGORY,
-		cookingSlots: 0
-	});
-
-	public static readonly LEVEL_3 = new HomeLevel(3, 30, 20000, {
-		bedHealthRegeneration: 3,
 		chestSlots: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},
 		upgradeItemMaximumRarity: ItemRarity.EXOTIC,
 		maxItemUpgradeLevel: 1,
-		gardenPlots: 3,
+		gardenPlots: 2,
 		gardenEarthQuality: GardenEarthQuality.POOR,
-		inventoryBonus: {
-			weapon: 1, armor: 1, object: 0, potion: 0
-		},
+		inventoryBonus: EMPTY_SLOTS_PER_CATEGORY,
 		cookingSlots: 1
 	});
 
-	public static readonly LEVEL_4 = new HomeLevel(4, 45, 50000, {
-		bedHealthRegeneration: 4,
+	public static readonly LEVEL_3 = new HomeLevel(3, 30, 20000, {
+		bedHealthRegeneration: 3,
 		chestSlots: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},
@@ -56,18 +41,18 @@ export class HomeLevel {
 		gardenPlots: 4,
 		gardenEarthQuality: GardenEarthQuality.POOR,
 		inventoryBonus: {
-			weapon: 1, armor: 1, object: 1, potion: 1
+			weapon: 1, armor: 1, object: 0, potion: 0
 		},
 		cookingSlots: 2
 	});
 
-	public static readonly LEVEL_5 = new HomeLevel(5, 60, 75000, {
-		bedHealthRegeneration: 5,
+	public static readonly LEVEL_4 = new HomeLevel(4, 45, 35000, {
+		bedHealthRegeneration: 4,
 		chestSlots: {
-			weapon: 2, armor: 2, object: 1, potion: 1
+			weapon: 1, armor: 1, object: 1, potion: 1
 		},
 		upgradeItemMaximumRarity: ItemRarity.SPECIAL,
-		maxItemUpgradeLevel: 2,
+		maxItemUpgradeLevel: 1,
 		gardenPlots: 6,
 		gardenEarthQuality: GardenEarthQuality.AVERAGE,
 		inventoryBonus: {
@@ -76,10 +61,10 @@ export class HomeLevel {
 		cookingSlots: 3
 	});
 
-	public static readonly LEVEL_6 = new HomeLevel(6, 85, 150000, {
-		bedHealthRegeneration: 6,
+	public static readonly LEVEL_5 = new HomeLevel(5, 60, 75000, {
+		bedHealthRegeneration: 5,
 		chestSlots: {
-			weapon: 2, armor: 2, object: 1, potion: 2
+			weapon: 2, armor: 2, object: 1, potion: 1
 		},
 		upgradeItemMaximumRarity: ItemRarity.EPIC,
 		maxItemUpgradeLevel: 2,
@@ -91,10 +76,10 @@ export class HomeLevel {
 		cookingSlots: 4
 	});
 
-	public static readonly LEVEL_7 = new HomeLevel(7, 100, 250000, {
-		bedHealthRegeneration: 7,
+	public static readonly LEVEL_6 = new HomeLevel(6, 85, 100000, {
+		bedHealthRegeneration: 6,
 		chestSlots: {
-			weapon: 3, armor: 3, object: 1, potion: 3
+			weapon: 2, armor: 2, object: 1, potion: 2
 		},
 		upgradeItemMaximumRarity: ItemRarity.LEGENDARY,
 		maxItemUpgradeLevel: 2,
@@ -106,13 +91,28 @@ export class HomeLevel {
 		cookingSlots: 5
 	});
 
-	public static readonly LEVEL_8 = new HomeLevel(8, 120, 450000, {
+	public static readonly LEVEL_7 = new HomeLevel(7, 100, 150000, {
+		bedHealthRegeneration: 7,
+		chestSlots: {
+			weapon: 3, armor: 3, object: 1, potion: 3
+		},
+		upgradeItemMaximumRarity: ItemRarity.MYTHICAL,
+		maxItemUpgradeLevel: 2,
+		gardenPlots: 10,
+		gardenEarthQuality: GardenEarthQuality.RICH,
+		inventoryBonus: {
+			weapon: 1, armor: 1, object: 1, potion: 1
+		},
+		cookingSlots: 5
+	});
+
+	public static readonly LEVEL_8 = new HomeLevel(8, 120, 250000, {
 		bedHealthRegeneration: 8,
 		chestSlots: {
 			weapon: 3, armor: 3, object: 2, potion: 4
 		},
 		upgradeItemMaximumRarity: ItemRarity.MYTHICAL,
-		maxItemUpgradeLevel: 2,
+		maxItemUpgradeLevel: 3,
 		gardenPlots: 10,
 		gardenEarthQuality: GardenEarthQuality.RICH,
 		inventoryBonus: {

--- a/Lib/src/types/HomeLevel.ts
+++ b/Lib/src/types/HomeLevel.ts
@@ -14,6 +14,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 1,
 		gardenPlots: 0,
 		gardenEarthQuality: GardenEarthQuality.POOR,
+		gardenPlantStorageCapacity: 3,
 		inventoryBonus: EMPTY_SLOTS_PER_CATEGORY,
 		cookingSlots: 0
 	});
@@ -27,6 +28,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 1,
 		gardenPlots: 2,
 		gardenEarthQuality: GardenEarthQuality.POOR,
+		gardenPlantStorageCapacity: 4,
 		inventoryBonus: EMPTY_SLOTS_PER_CATEGORY,
 		cookingSlots: 1
 	});
@@ -40,6 +42,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 1,
 		gardenPlots: 4,
 		gardenEarthQuality: GardenEarthQuality.POOR,
+		gardenPlantStorageCapacity: 5,
 		inventoryBonus: {
 			weapon: 1, armor: 1, object: 0, potion: 0
 		},
@@ -55,6 +58,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 1,
 		gardenPlots: 6,
 		gardenEarthQuality: GardenEarthQuality.AVERAGE,
+		gardenPlantStorageCapacity: 8,
 		inventoryBonus: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},
@@ -70,6 +74,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 2,
 		gardenPlots: 8,
 		gardenEarthQuality: GardenEarthQuality.AVERAGE,
+		gardenPlantStorageCapacity: 12,
 		inventoryBonus: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},
@@ -85,6 +90,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 2,
 		gardenPlots: 10,
 		gardenEarthQuality: GardenEarthQuality.RICH,
+		gardenPlantStorageCapacity: 18,
 		inventoryBonus: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},
@@ -100,6 +106,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 2,
 		gardenPlots: 10,
 		gardenEarthQuality: GardenEarthQuality.RICH,
+		gardenPlantStorageCapacity: 25,
 		inventoryBonus: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},
@@ -115,6 +122,7 @@ export class HomeLevel {
 		maxItemUpgradeLevel: 3,
 		gardenPlots: 10,
 		gardenEarthQuality: GardenEarthQuality.RICH,
+		gardenPlantStorageCapacity: 50,
 		inventoryBonus: {
 			weapon: 1, armor: 1, object: 1, potion: 1
 		},


### PR DESCRIPTION
Relates to #3609.

## Home levels (`Lib/src/types/HomeLevel.ts`)
Niveaux 1→8 retarifés. Coûts allégés sur les paliers intermédiaires/hauts, raretés débloquables et `gardenPlots` / `cookingSlots` augmentés progressivement, `maxItemUpgradeLevel` du LVL8 passé à 3.

| Lvl | Cost | Rarity | Garden | Cooking | Earth | Max upgrade |
|-----|------|--------|--------|---------|-------|-------------|
| 1   | 0    | COMMON | 0 | 0 | - | 0 |
| 2   | 3500 | EXOTIC | 2 | 1 | - | 0 |
| 3   | 12k  | RARE | 4 | 2 | POOR | 1 |
| 4   | 35k  | SPECIAL | 6 | 3 | AVERAGE | 1 |
| 5   | 70k  | EPIC | 8 | 4 | AVERAGE | 2 |
| 6   | 100k | LEGENDARY | 10 | 5 | RICH | 2 |
| 7   | 150k | MYTHICAL | 12 | 6 | RICH | 2 |
| 8   | 250k | MYTHICAL | 14 | 8 | RICH | **3** |

## Apartment prices (`Core/resources/cities/*.json`)
| Ville | Avant | Après |
|-------|-------|-------|
| Boug-Coton | 10000 | **6000** |
| Ville Forte | 14000 | **9000** |
| Claire de Ville | 14000 | **12000** |
| Seawynne | 18000 | 18000 |
| Royal Castle | 22000 | **25000** |
| Village Coco | 22000 | **50000** |

Cherche à rendre Coco "exclusif/oasis luxe" et à étaler la progression économique.

## Coco lore (`Lang/fr/models.json` — mapLocations 17 & 38)
Nouvelle description justifiant le prix élevé : oasis prisée par les nobles, noix de coco précieuses, terrains rares autour de la source.
