### PR TITLE
fix: restore cracked goblet icon + merge develop into cities2 #4256

### DIFF
--- a/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
+++ b/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
@@ -308,6 +308,27 @@ describe("Food Consumption Plan", () => {
 				expect(herbivorousUsed).toBe(2);
 				expect(plan.totalRations).toBe(9);
 			});
+
+			it("should split consumption across carnivorous and herbivorous when both are available (balanced tie-break)", async () => {
+				// 6 rations, 0 treats / 5 carn / 5 herb / 0 soup. With the current
+				// pricing (carn = herb = 250 cost / 3 rations), three equally-good
+				// combinations exist: (2 carn, 0 herb), (0 carn, 2 herb) and
+				// (1 carn, 1 herb). The planner should pick the balanced one so
+				// omnivores don't silently drain a single diet stock.
+				vi.mocked(Guilds.getById).mockResolvedValue(createMockGuild(0, 5, 5, 0) as never);
+
+				const plan = await calculateFoodConsumptionPlan(
+					createMockPlayer(1),
+					createMockPet(true, true), // Omnivorous
+					6
+				);
+
+				const carnivorousUsed = plan.consumption.find(c => c.foodType === "carnivorousFood")?.itemsToConsume ?? 0;
+				const herbivorousUsed = plan.consumption.find(c => c.foodType === "herbivorousFood")?.itemsToConsume ?? 0;
+				expect(carnivorousUsed).toBe(1);
+				expect(herbivorousUsed).toBe(1);
+				expect(plan.totalRations).toBe(6);
+			});
 		});
 	});
 });

--- a/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
+++ b/Core/__tests__/core/commands/pet/FoodConsumptionPlan.test.ts
@@ -22,9 +22,10 @@ function createMockPlayer(guildId: number | null): Player {
 /**
  * Helper to create a mock pet
  */
-function createMockPet(canEatMeat: boolean): Pet {
+function createMockPet(canEatMeat: boolean, canEatVegetables: boolean = !canEatMeat): Pet {
 	return {
-		canEatMeat: () => canEatMeat
+		canEatMeat: () => canEatMeat,
+		canEatVegetables: () => canEatVegetables
 	} as Pet;
 }
 
@@ -272,6 +273,41 @@ describe("Food Consumption Plan", () => {
 			expect(PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[2]).toBe(3);
 			expect(PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[1]).toBe(3);
 			expect(PetConstants.PET_FOOD_LOVE_POINTS_AMOUNT[3]).toBe(5);
+		});
+
+		describe("Omnivorous pets", () => {
+			it("should consume herbivorous food when no carnivorous food is available (regression #4177)", async () => {
+				// Guild has 0 commonFood, 0 carnivorousFood, 4 herbivorousFood, 0 ultimateFood
+				// An omnivorous pet should be able to use the salads (4 * 3 = 12 rations).
+				vi.mocked(Guilds.getById).mockResolvedValue(createMockGuild(0, 0, 4, 0) as never);
+
+				const plan = await calculateFoodConsumptionPlan(
+					createMockPlayer(1),
+					createMockPet(true, true), // Omnivorous
+					6
+				);
+
+				const herbivorousUsed = plan.consumption.find(c => c.foodType === "herbivorousFood")?.itemsToConsume ?? 0;
+				expect(herbivorousUsed).toBe(2);
+				expect(plan.totalRations).toBe(6);
+			});
+
+			it("should consume both carnivorous and herbivorous food when needed", async () => {
+				// 9 rations required, only 1 carn + 2 herb available => need both diets.
+				vi.mocked(Guilds.getById).mockResolvedValue(createMockGuild(0, 1, 2, 0) as never);
+
+				const plan = await calculateFoodConsumptionPlan(
+					createMockPlayer(1),
+					createMockPet(true, true), // Omnivorous
+					9
+				);
+
+				const carnivorousUsed = plan.consumption.find(c => c.foodType === "carnivorousFood")?.itemsToConsume ?? 0;
+				const herbivorousUsed = plan.consumption.find(c => c.foodType === "herbivorousFood")?.itemsToConsume ?? 0;
+				expect(carnivorousUsed).toBe(1);
+				expect(herbivorousUsed).toBe(2);
+				expect(plan.totalRations).toBe(9);
+			});
 		});
 	});
 });

--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Core/resources/smallEvents/bonusGuildPVEIsland.json
+++ b/Core/resources/smallEvents/bonusGuildPVEIsland.json
@@ -16,33 +16,9 @@
       "life": {
         "min": 3,
         "max": 10
-      },
-      "energy": {
-        "min": 10,
-        "max": 25
       }
     },
     "events": [
-      {
-        "success": {
-          "withGuild": "expOrPointsGuild",
-          "solo": "experience"
-        },
-        "lose": {
-          "withGuild": "money",
-          "solo": "life"
-        }
-      },
-      {
-        "success": {
-          "withGuild": "expOrPointsGuild",
-          "solo": "experience"
-        },
-        "lose": {
-          "withGuild": "energy",
-          "solo": "life"
-        }
-      },
       {
         "success": {
           "withGuild": "expOrPointsGuild",
@@ -79,11 +55,31 @@
           "solo": "experience"
         },
         "lose": {
-          "withGuild": "energy",
-          "solo": "energy"
+          "withGuild": "money",
+          "solo": "life"
+        }
+      },
+      {
+        "success": {
+          "withGuild": "expOrPointsGuild",
+          "solo": "experience"
+        },
+        "lose": {
+          "withGuild": "life",
+          "solo": "life"
+        }
+      },
+      {
+        "success": {
+          "withGuild": "expOrPointsGuild",
+          "solo": "experience"
+        },
+        "lose": {
+          "withGuild": "life",
+          "solo": "life"
         }
       }
     ]
   },
-  "rarity": 8
+  "rarity": 6
 }

--- a/Core/src/core/bot/Crownicles.ts
+++ b/Core/src/core/bot/Crownicles.ts
@@ -83,7 +83,7 @@ export class Crownicles {
 
 		await Player.update(
 			{
-				tokens: Sequelize.literal(`LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY})`)
+				tokens: Sequelize.literal(`GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`)
 			},
 			{ where: {} }
 		);

--- a/Core/src/core/database/logs/LogsDatabase.ts
+++ b/Core/src/core/database/logs/LogsDatabase.ts
@@ -113,6 +113,7 @@ import {
 import {
 	LogsBlessingLogger, BlessingActivationParams, BlessingContributionParams
 } from "./LogsBlessingLogger";
+import { MapCache } from "../../maps/MapCache";
 
 /**
  * Data structure for expedition log entries
@@ -749,12 +750,15 @@ export class LogsDatabase extends Database {
 		if (!player) {
 			return;
 		}
-		const [maplinkLog] = await LogsMapLinks.findOrCreate({
+		const [maplinkLog, created] = await LogsMapLinks.findOrCreate({
 			where: {
 				start: mapLink.startMap,
 				end: mapLink.endMap
 			}
 		});
+		if (created && MapCache.pveIslandMapLinks.includes(mapLink.id)) {
+			MapCache.logsPveIslandMapLinks.push(maplinkLog.id);
+		}
 		await LogsPlayersTravels.create({
 			playerId: player.id,
 			mapLinkId: maplinkLog.id,

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -175,13 +175,21 @@ function evaluateCombination(amounts: FoodAmounts, context: FoodEvaluationContex
 }
 
 /**
- * Compare two combinations: prefer lower excess, then lower cost
+ * Compare two combinations: prefer lower excess, then lower cost, then —
+ * for omnivores — a more balanced split across the two diet types so that
+ * the planner does not silently drain one diet stock while the other sits
+ * untouched.
  */
 function isBetterCombination(candidate: FoodCombination, current: FoodCombination): boolean {
-	if (candidate.excess < current.excess) {
-		return true;
+	if (candidate.excess !== current.excess) {
+		return candidate.excess < current.excess;
 	}
-	return candidate.excess === current.excess && candidate.totalCost < current.totalCost;
+	if (candidate.totalCost !== current.totalCost) {
+		return candidate.totalCost < current.totalCost;
+	}
+	const candidateImbalance = Math.abs(candidate.dietCarn - candidate.dietHerb);
+	const currentImbalance = Math.abs(current.dietCarn - current.dietHerb);
+	return candidateImbalance < currentImbalance;
 }
 
 /**

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -50,7 +50,10 @@ const FOOD_CONFIG_MAP: Record<FoodType, FoodConfig> = {
 };
 
 /**
- * Get the diet food type based on whether the pet can eat meat
+ * Get the primary diet food type based on whether the pet can eat meat.
+ * Note: omnivorous pets can use BOTH carnivorous and herbivorous food (see
+ * `getAvailableFoodSlots` / `calculateTotalAvailableRations`); this helper
+ * is kept for callers that need a single representative type.
  */
 export function getDietFoodType(petModel: Pet): FoodType {
 	return petModel.canEatMeat() ? PetConstants.PET_FOOD.CARNIVOROUS_FOOD : PetConstants.PET_FOOD.HERBIVOROUS_FOOD;
@@ -86,7 +89,8 @@ interface AvailableFoodSlot {
  */
 interface FoodCombination {
 	treats: number;
-	diet: number;
+	dietCarn: number;
+	dietHerb: number;
 	soup: number;
 	totalRations: number;
 	totalCost: number;
@@ -94,18 +98,24 @@ interface FoodCombination {
 }
 
 /**
- * Get available food slots for a pet from guild storage
- * Returns [treats, diet, soup] in order
+ * Get available food slots for a pet from guild storage.
+ * Returns [treats, dietCarn, dietHerb, soup] in order. For non-omnivorous
+ * pets, the unsupported diet slot has `available = 0`, so the optimisation
+ * loop collapses naturally on that dimension.
  */
-function getAvailableFoodSlots(guild: Guild, dietType: FoodType): [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot] {
+function getAvailableFoodSlots(guild: Guild, petModel: Pet): [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot] {
 	return [
 		{
 			config: FOOD_CONFIG_MAP.commonFood,
 			available: guild.commonFood
 		},
 		{
-			config: FOOD_CONFIG_MAP[dietType],
-			available: guild[dietType]
+			config: FOOD_CONFIG_MAP.carnivorousFood,
+			available: petModel.canEatMeat() ? guild.carnivorousFood : 0
+		},
+		{
+			config: FOOD_CONFIG_MAP.herbivorousFood,
+			available: petModel.canEatVegetables() ? guild.herbivorousFood : 0
 		},
 		{
 			config: FOOD_CONFIG_MAP.ultimateFood,
@@ -119,7 +129,8 @@ function getAvailableFoodSlots(guild: Guild, dietType: FoodType): [AvailableFood
  */
 interface FoodAmounts {
 	treats: number;
-	diet: number;
+	dietCarn: number;
+	dietHerb: number;
 	soup: number;
 }
 
@@ -127,7 +138,7 @@ interface FoodAmounts {
  * Context for evaluating food combinations
  */
 interface FoodEvaluationContext {
-	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot];
+	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot];
 	rationsRequired: number;
 }
 
@@ -136,23 +147,26 @@ interface FoodEvaluationContext {
  */
 function evaluateCombination(amounts: FoodAmounts, context: FoodEvaluationContext): FoodCombination {
 	const {
-		treats, diet, soup
+		treats, dietCarn, dietHerb, soup
 	} = amounts;
 	const {
 		slots, rationsRequired
 	} = context;
 
 	const totalRations = treats * slots[0].config.rations
-		+ diet * slots[1].config.rations
-		+ soup * slots[2].config.rations;
+		+ dietCarn * slots[1].config.rations
+		+ dietHerb * slots[2].config.rations
+		+ soup * slots[3].config.rations;
 
 	const totalCost = treats * slots[0].config.price
-		+ diet * slots[1].config.price
-		+ soup * slots[2].config.price;
+		+ dietCarn * slots[1].config.price
+		+ dietHerb * slots[2].config.price
+		+ soup * slots[3].config.price;
 
 	return {
 		treats,
-		diet,
+		dietCarn,
+		dietHerb,
 		soup,
 		totalRations,
 		totalCost,
@@ -211,21 +225,22 @@ function tryAndUpdateBest(
  *
  * Algorithm: Smart bounded iteration
  * For each amount of soup (0 to min(available, ceil(required/soupRations)))
- * For each amount of diet (0 to min(available, ceil(remaining/dietRations)))
+ * For each amount of dietCarn (0 to min(available, ceil(remaining/dietRations)))
+ * For each amount of dietHerb (0 to min(available, ceil(remaining/dietRations)))
  * Calculate exact treats needed (with rounding up)
  * If valid, evaluate and compare
  *
- * Complexity: O(S * D) where S = soup items needed, D = diet items needed
- * In practice, this is very small (typically < 10 * 10 = 100 iterations max)
- * Much better than the original O(T * D * S) brute-force with T up to required rations
+ * The two diet dimensions only both expand for omnivorous pets (otherwise
+ * one of them is bounded to 0 by the slot's `available = 0`).
  */
 function findOptimalCombination(
-	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot],
+	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot],
 	rationsRequired: number
 ): FoodCombination {
 	const [
 		treatSlot,
-		dietSlot,
+		dietCarnSlot,
+		dietHerbSlot,
 		soupSlot
 	] = slots;
 	const evalContext: FoodEvaluationContext = {
@@ -234,14 +249,18 @@ function findOptimalCombination(
 
 	// Calculate total available rations
 	const totalAvailableRations = treatSlot.available * treatSlot.config.rations
-		+ dietSlot.available * dietSlot.config.rations
+		+ dietCarnSlot.available * dietCarnSlot.config.rations
+		+ dietHerbSlot.available * dietHerbSlot.config.rations
 		+ soupSlot.available * soupSlot.config.rations;
 
 	// If not enough food, return all available
 	if (totalAvailableRations < rationsRequired) {
 		return evaluateCombination(
 			{
-				treats: treatSlot.available, diet: dietSlot.available, soup: soupSlot.available
+				treats: treatSlot.available,
+				dietCarn: dietCarnSlot.available,
+				dietHerb: dietHerbSlot.available,
+				soup: soupSlot.available
 			},
 			evalContext
 		);
@@ -249,7 +268,12 @@ function findOptimalCombination(
 
 	// Bound search space intelligently
 	const maxSoup = Math.min(soupSlot.available, Math.ceil(rationsRequired / soupSlot.config.rations));
-	const maxDiet = Math.min(dietSlot.available, Math.ceil(rationsRequired / dietSlot.config.rations));
+	const maxDietCarn = dietCarnSlot.config.rations > 0
+		? Math.min(dietCarnSlot.available, Math.ceil(rationsRequired / dietCarnSlot.config.rations))
+		: 0;
+	const maxDietHerb = dietHerbSlot.config.rations > 0
+		? Math.min(dietHerbSlot.available, Math.ceil(rationsRequired / dietHerbSlot.config.rations))
+		: 0;
 
 	let best: FoodCombination | null = null;
 
@@ -257,21 +281,25 @@ function findOptimalCombination(
 	for (let soup = 0; soup <= maxSoup; soup++) {
 		const remainingAfterSoup = rationsRequired - soup * soupSlot.config.rations;
 
-		for (let diet = 0; diet <= maxDiet; diet++) {
-			const remainingAfterDiet = remainingAfterSoup - diet * dietSlot.config.rations;
-			const treatsNeeded = calculateTreatsNeeded(remainingAfterDiet, treatSlot);
+		for (let dietCarn = 0; dietCarn <= maxDietCarn; dietCarn++) {
+			const remainingAfterCarn = remainingAfterSoup - dietCarn * dietCarnSlot.config.rations;
 
-			if (treatsNeeded !== null) {
-				best = tryAndUpdateBest({
-					treats: treatsNeeded, diet, soup
-				}, evalContext, best);
+			for (let dietHerb = 0; dietHerb <= maxDietHerb; dietHerb++) {
+				const remainingAfterHerb = remainingAfterCarn - dietHerb * dietHerbSlot.config.rations;
+				const treatsNeeded = calculateTreatsNeeded(remainingAfterHerb, treatSlot);
+
+				if (treatsNeeded !== null) {
+					best = tryAndUpdateBest({
+						treats: treatsNeeded, dietCarn, dietHerb, soup
+					}, evalContext, best);
+				}
 			}
 		}
 	}
 
 	// Fallback (should not happen if totalAvailable >= required)
 	return best ?? evaluateCombination({
-		treats: 0, diet: 0, soup: 0
+		treats: 0, dietCarn: 0, dietHerb: 0, soup: 0
 	}, evalContext);
 }
 
@@ -280,7 +308,7 @@ function findOptimalCombination(
  */
 function buildPlanFromCombination(
 	combination: FoodCombination,
-	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot]
+	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot]
 ): FoodConsumptionPlan {
 	const plan: FoodConsumptionPlan = {
 		totalRations: combination.totalRations,
@@ -295,19 +323,27 @@ function buildPlanFromCombination(
 		});
 	}
 
-	if (combination.diet > 0) {
+	if (combination.dietCarn > 0) {
 		plan.consumption.push({
 			foodType: slots[1].config.type,
-			itemsToConsume: combination.diet,
-			rationsProvided: combination.diet * slots[1].config.rations
+			itemsToConsume: combination.dietCarn,
+			rationsProvided: combination.dietCarn * slots[1].config.rations
+		});
+	}
+
+	if (combination.dietHerb > 0) {
+		plan.consumption.push({
+			foodType: slots[2].config.type,
+			itemsToConsume: combination.dietHerb,
+			rationsProvided: combination.dietHerb * slots[2].config.rations
 		});
 	}
 
 	if (combination.soup > 0) {
 		plan.consumption.push({
-			foodType: slots[2].config.type,
+			foodType: slots[3].config.type,
 			itemsToConsume: combination.soup,
-			rationsProvided: combination.soup * slots[2].config.rations
+			rationsProvided: combination.soup * slots[3].config.rations
 		});
 	}
 
@@ -339,8 +375,7 @@ export async function calculateFoodConsumptionPlan(
 		return emptyPlan;
 	}
 
-	const dietType = getDietFoodType(petModel);
-	const slots = getAvailableFoodSlots(guild, dietType);
+	const slots = getAvailableFoodSlots(guild, petModel);
 	const optimal = findOptimalCombination(slots, rationsRequired);
 
 	return buildPlanFromCombination(optimal, slots);
@@ -367,11 +402,17 @@ export async function applyFoodConsumptionPlan(guildId: number, plan: FoodConsum
 }
 
 /**
- * Calculate total available rations in a guild for a specific pet's diet
+ * Calculate total available rations in a guild for a specific pet's diet.
+ * Omnivorous pets count both carnivorous and herbivorous food.
  */
 export function calculateTotalAvailableRations(guild: Guild, petModel: Pet): number {
-	const dietType = getDietFoodType(petModel);
-	return guild.commonFood * FOOD_CONFIG_MAP.commonFood.rations
-		+ guild[dietType] * FOOD_CONFIG_MAP[dietType].rations
+	let total = guild.commonFood * FOOD_CONFIG_MAP.commonFood.rations
 		+ guild.ultimateFood * FOOD_CONFIG_MAP.ultimateFood.rations;
+	if (petModel.canEatMeat()) {
+		total += guild.carnivorousFood * FOOD_CONFIG_MAP.carnivorousFood.rations;
+	}
+	if (petModel.canEatVegetables()) {
+		total += guild.herbivorousFood * FOOD_CONFIG_MAP.herbivorousFood.rations;
+	}
+	return total;
 }

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -241,6 +241,41 @@ function tryAndUpdateBest(
  * The two diet dimensions only both expand for omnivorous pets (otherwise
  * one of them is bounded to 0 by the slot's `available = 0`).
  */
+/**
+ * Inner loop of the optimisation: iterate over all viable herbivorous-food
+ * counts for a fixed (soup, dietCarn) pair and return the best combination
+ * found so far. Extracted to keep `findOptimalCombination` shallow.
+ */
+function exploreHerbDimension(args: {
+	soup: number;
+	dietCarn: number;
+	remainingAfterCarn: number;
+	maxDietHerb: number;
+	dietHerbSlot: AvailableFoodSlot;
+	treatSlot: AvailableFoodSlot;
+	evalContext: FoodEvaluationContext;
+	best: FoodCombination | null;
+}): FoodCombination | null {
+	const {
+		soup, dietCarn, remainingAfterCarn, maxDietHerb,
+		dietHerbSlot, treatSlot, evalContext
+	} = args;
+	let best = args.best;
+
+	for (let dietHerb = 0; dietHerb <= maxDietHerb; dietHerb++) {
+		const remainingAfterHerb = remainingAfterCarn - dietHerb * dietHerbSlot.config.rations;
+		const treatsNeeded = calculateTreatsNeeded(remainingAfterHerb, treatSlot);
+		if (treatsNeeded === null) {
+			continue;
+		}
+		best = tryAndUpdateBest({
+			treats: treatsNeeded, dietCarn, dietHerb, soup
+		}, evalContext, best);
+	}
+
+	return best;
+}
+
 function findOptimalCombination(
 	slots: [AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot, AvailableFoodSlot],
 	rationsRequired: number
@@ -291,17 +326,16 @@ function findOptimalCombination(
 
 		for (let dietCarn = 0; dietCarn <= maxDietCarn; dietCarn++) {
 			const remainingAfterCarn = remainingAfterSoup - dietCarn * dietCarnSlot.config.rations;
-
-			for (let dietHerb = 0; dietHerb <= maxDietHerb; dietHerb++) {
-				const remainingAfterHerb = remainingAfterCarn - dietHerb * dietHerbSlot.config.rations;
-				const treatsNeeded = calculateTreatsNeeded(remainingAfterHerb, treatSlot);
-
-				if (treatsNeeded !== null) {
-					best = tryAndUpdateBest({
-						treats: treatsNeeded, dietCarn, dietHerb, soup
-					}, evalContext, best);
-				}
-			}
+			best = exploreHerbDimension({
+				soup,
+				dietCarn,
+				remainingAfterCarn,
+				maxDietHerb,
+				dietHerbSlot,
+				treatSlot,
+				evalContext,
+				best
+			});
 		}
 	}
 

--- a/Core/src/core/smallEvents/bonusGuildPVEIsland.ts
+++ b/Core/src/core/smallEvents/bonusGuildPVEIsland.ts
@@ -20,7 +20,6 @@ enum Outcome {
 	EXPERIENCE = "experience",
 	MONEY = "money",
 	LIFE = "life",
-	ENERGY = "energy",
 	EXP_OR_POINTS_GUILD = "expOrPointsGuild"
 }
 
@@ -84,12 +83,6 @@ async function manageClassicReward(response: CrowniclesPacket[], player: Player,
 				response,
 				reason
 			});
-			break;
-		case Outcome.ENERGY:
-			player.addEnergy(-result.amount, reason);
-			if (player.getCumulativeEnergy() <= 0) {
-				await player.leavePVEIslandIfNoEnergy(response);
-			}
 			break;
 		case Outcome.EXPERIENCE:
 			await player.addExperience({

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Lang/fr/error.json
+++ b/Lang/fr/error.json
@@ -52,7 +52,9 @@
     "test": "test",
     "unlock": "libération de quelqu'un",
     "witchChoose": "choix d'une action pour la sorcière",
-    "altarSmallEvent": "contribution à l'autel de l'Oracle"
+    "altarSmallEvent": "contribution à l'autel de l'Oracle",
+    "badPetSmallEvent": "réaction face au nain hostile Moltiar",
+    "limogesSmallEvent": "réponse aux questions du voyageur encapuchonné"
   },
   "commandDoesntExist": "ERREUR: Commande inconnue",
   "interactionNotForYou": "Cette interaction n'est pas pour vous !",

--- a/Lang/fr/smallEvents.json
+++ b/Lang/fr/smallEvents.json
@@ -1405,7 +1405,7 @@
           "solo": "Paniqué, vous essayez d'esquiver les dégâts potentiels du séisme. Après quelques instants, la secousse ne se ressent plus. Au retour à l'endroit où vous vouliez vous reposer, vous constatez les dégâts du séisme. Heureusement que vous n'y étiez pas resté..."
         },
         "lose": {
-          "withGuild": "Vous vous dites que ce séisme sera court, et demandez au reste de la guilde de braver celui-ci. Quelle erreur ! Un rocher s'écrase sur vous et vous assomme. Vous perdez **{{amount, number}} {emote:unitValues.energy}**.",
+          "withGuild": "Vous vous dites que ce séisme sera court, et demandez au reste de la guilde de braver celui-ci. Quelle erreur ! Un rocher s'écrase sur vous et vous assomme. Vous perdez **{{amount, number}} {emote:unitValues.lostHealth}**.",
           "solo": "Vous disant qu'il n'y aura que peu de dégâts, vous continuez à vous reposer. Cependant, une crevasse se forme sous votre corps. Par peur de tomber dedans, vous essayez de courir le plus loin possible, mais vous trébuchez et vous entaillez le bras. Vous perdez **{{amount, number}} {emote:unitValues.lostHealth}**."
         }
       },
@@ -1469,8 +1469,8 @@
           "solo": "Heureusement pour vous, ce n'était qu'un malaise passager, et vous parvenez à reprendre votre route après quelques minutes de repos."
         },
         "lose": {
-          "withGuild": "Face à ce soudain malaise, vos compagnons de guilde, ne sachant comment vous aider, décident de vous porter jusqu'à la prochaine étape, mais l'épuisement vous harcèle et vous vous évanouissez. Vous perdez **{{amount, number}} {emote:unitValues.energy}**.",
-          "solo": "Complètement épuisé, le ciel se met à tourner autour de vous. Vous tentez de vous relever, mais les forces vous manquant et ayant l'impression d'être sur une mer déchaînée, vous vous évanouissez au beau milieu du chemin. Vous perdez **{{amount, number}} {emote:unitValues.energy}**."
+          "withGuild": "Face à ce soudain malaise, vos compagnons de guilde, ne sachant comment vous aider, décident de vous porter jusqu'à la prochaine étape, mais l'épuisement vous harcèle et vous vous évanouissez. Vous perdez **{{amount, number}} {emote:unitValues.lostHealth}**.",
+          "solo": "Complètement épuisé, le ciel se met à tourner autour de vous. Vous tentez de vous relever, mais les forces vous manquant et ayant l'impression d'être sur une mer déchaînée, vous vous évanouissez au beau milieu du chemin. Vous perdez **{{amount, number}} {emote:unitValues.lostHealth}**."
         }
       }
     ]

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/Lib/src/CrowniclesIcons.ts
+++ b/Lib/src/CrowniclesIcons.ts
@@ -2438,7 +2438,8 @@ export const CrowniclesIcons: {
 	goblets: {
 		metal: "🐲",
 		biggest: "🪣",
-		sparkling: "✨"
+		sparkling: "✨",
+		cracked: "💀"
 	},
 	sex: {
 		male: "♂️",

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "5.3.1.a",
+  "version": "5.3.1.b",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
## Contexte

Le 4ᵉ gobelet (`cracked` 💀) du Small Event Goblets était invisible sur `cities2` : aucun bouton ne s'affichait pour celui-ci. Ce fix restaure l'icône perdue et remet `cities2` au niveau de `develop`.

## Cause racine

Lors du merge `32aafc4951` (`Merge origin/develop into cities2` — 12 avril 2026), la ligne `cracked: "💀"` du registre `CrowniclesIcons.goblets` (ajoutée par #3846 le 14 décembre 2025 sur `develop`) a été perdue dans la résolution de conflit. Le côté `cities2` (^1) ne contenait pas l'entrée, le côté `develop` (^2) si, et le merge a accidentellement gardé la version `cities2`.

Côté Discord, `gobletsGame.ts` itère `Object.entries(CrowniclesIcons.goblets)` pour générer les boutons → une entrée manquante = un bouton manquant. Côté JSON ressource (`Core/resources/smallEvents/gobletsGame.json`) et locale (`Lang/*/smallEvents.json`), tout était déjà présent.

Closes #4256.

## Changements

1. **Restauration de l'icône** (`Lib/src/CrowniclesIcons.ts`) : ajout de `cracked: "💀"` dans `goblets` — commit `04191cd77`.
2. **Merge `develop` → `cities2`** (commit `0fcba5c57`) — 6 commits rattrapés :
   - `9be9fac47` Remove energy malus on island #4217 (#4238)
   - `aa93d74cd` add missing blockedContext translations (limoges & badPet) #4213
   - `49ad6909e` Fix #4197
   - `217a16ca7` refactor ExpeditionFoodService
   - `b558e56bb` balance omnivore expedition food #4177
   - `2e1ee684b` tokens reset cap + bump 5.3.1.b

### Résolutions de conflits

- **`Core/src/core/bot/Crownicles.ts`** (`dailyTimeout`) : conservé le `daysToMilliseconds(asDays(1))` typé de `cities2` **+** le `Player.update` de `develop` (cap des tokens via `GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`). Ajout de l'import `TokensConstants`.
- **`Core/src/core/database/logs/LogsDatabase.ts`** : conservé les deux blocs d'imports — `LogsCityLogger` complet + `transactionBelongsToSequelize` de `cities2`, et `MapCache` de `develop`.
- **`Core/src/core/smallEvents/bonusGuildPVEIsland.ts`** : version de `develop` retenue — suppression du case `Outcome.ENERGY` (l'enum n'a plus que MONEY/LIFE/EXPERIENCE/EXP_OR_POINTS_GUILD) conformément à #4217.

## Audit complémentaire

Après le merge, audit de toutes les fusions précédentes `develop → cities2` (`30e8f0006`, `32aafc495`, `7215a8e0d`, `1cdc3f64e`, `2fe123e90`) à la recherche d'autres lignes orphelines. 33 candidats détectés, tous explicables :

- **Bumps de version** (`package.json` ×4 par merge) — `cities2` a depuis bumpé à `5.3.1.b`, donc faux positifs.
- **Monstres oceanic-island** (`celestialLightning`, `drowning`, `sepulcralHunger`, `wateryGust`) — rééquilibrage volontaire fait dans `cities2` (commit `5155417f3 feat(oceanic-island): submerged alteration rework`).
- **`Lang/fr/models.json`** — correction de typo `"finit" → "sort"` et reformulation de `submerged`.
- **`Campaign.ts pointsToWin: 0`, `ReportPveService` missionIds, `altar.ts contributeToBlessing`** — extractions en constantes / types, valeurs toujours présentes.
- **`Lang/en/commands.json` & `smallEvents.json`** — reformulations mineures (`{emote:diet.herbivorous}` au lieu de `🥬`, `pot` au lieu de `kitty`).

**Aucune autre perte réelle n'a été détectée.**

## Vérifications

- ✅ `pnpm tsc --noEmit` : Lib, Core, Discord
- ✅ `pnpm eslint` : Lib, Core, Discord
- ✅ `pnpm test` : Lib 555/555, Core 1028/1028, Discord 220/220
- ✅ Aucun marqueur de conflit résiduel

Base : `cities2`.
