### PR TITLE
fix(fight): make fight display resilient to shard reconnects

### DIFF
--- a/Discord/src/commands/player/FightCommand.ts
+++ b/Discord/src/commands/player/FightCommand.ts
@@ -228,11 +228,11 @@ export async function handleCommandFightIntroduceFightersRes(context: PacketCont
 			await buttonInteraction.editReply({ embeds: [embed] });
 		}
 		await CrowniclesCachedMessages.getOrCreate(interaction.id, CrowniclesHistoryCachedMessage)
-			.post({ content: DiscordConstants.EMPTY_MESSAGE });
+			.post({ content: DiscordConstants.EMPTY_MESSAGE }, context.discord?.channel);
 		await CrowniclesCachedMessages.getOrCreate(interaction.id, CrowniclesFightStatusCachedMessage)
-			.post({ content: DiscordConstants.EMPTY_MESSAGE });
+			.post({ content: DiscordConstants.EMPTY_MESSAGE }, context.discord?.channel);
 		await CrowniclesCachedMessages.getOrCreate(interaction.id, CrowniclesActionChooseCachedMessage)
-			.post({ content: DiscordConstants.EMPTY_MESSAGE });
+			.post({ content: DiscordConstants.EMPTY_MESSAGE }, context.discord?.channel);
 	}
 	catch (e) {
 		CrowniclesLogger.errorWithObj("Fight introduction failed", e);
@@ -287,9 +287,9 @@ export async function handleCommandFightAIFightActionChoose(context: PacketConte
 	}
 
 	try {
-		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
+		const lng = DiscordCache.getInteraction(context.discord!.interaction)?.userLanguage ?? context.discord!.language;
 		await CrowniclesCachedMessages.getOrCreate(context.discord.interaction, CrowniclesActionChooseCachedMessage)
-			.post({ embeds: [new CrowniclesEmbed().setDescription(i18n.t("commands:fight.actions.aiChoose", { lng: interaction.userLanguage }))] });
+			.post({ embeds: [new CrowniclesEmbed().setDescription(i18n.t("commands:fight.actions.aiChoose", { lng }))] }, context.discord.channel);
 		await new Promise(f => setTimeout(f, packet.ms));
 	}
 	catch (e) {

--- a/Discord/src/commands/player/FightCommand.ts
+++ b/Discord/src/commands/player/FightCommand.ts
@@ -193,6 +193,26 @@ function addFightProfileFor(introEmbed: CrowniclesEmbed, lng: Language, fighterN
  * @param context
  * @param packet
  */
+/**
+ * Resolve the display name of the fight opponent (player, monster or fallback).
+ * @param packet
+ * @param lng
+ */
+async function resolveOpponentDisplayName(packet: CommandFightIntroduceFightersPacket, lng: Language): Promise<string> {
+	if (packet.fightOpponentKeycloakId) {
+		const getUser = await KeycloakUtils.getUserByKeycloakId(keycloakConfig, packet.fightOpponentKeycloakId);
+		if (getUser && !getUser.isError) {
+			return getUser.payload.user.attributes.gameUsername[0];
+		}
+	}
+	if (packet.fightOpponentMonsterId) {
+		return i18n.t(`models:monsters.${packet.fightOpponentMonsterId}.name`, { lng });
+	}
+
+	// Fallback for test players or unknown opponents
+	return packet.fightOpponentKeycloakId ?? "???";
+}
+
 export async function handleCommandFightIntroduceFightersRes(context: PacketContext, packet: CommandFightIntroduceFightersPacket): Promise<void> {
 	if (buggedFights.has(packet.fightId)) {
 		return;
@@ -202,19 +222,7 @@ export async function handleCommandFightIntroduceFightersRes(context: PacketCont
 		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
 		const buttonInteraction = DiscordCache.getButtonInteraction(context.discord!.buttonInteraction!);
 		const lng = interaction.userLanguage;
-		const getUser = packet.fightOpponentKeycloakId ? await KeycloakUtils.getUserByKeycloakId(keycloakConfig, packet.fightOpponentKeycloakId) : undefined;
-
-		let opponentDisplayName: string;
-		if (getUser && !getUser.isError) {
-			opponentDisplayName = getUser.payload.user.attributes.gameUsername[0];
-		}
-		else if (packet.fightOpponentMonsterId) {
-			opponentDisplayName = i18n.t(`models:monsters.${packet.fightOpponentMonsterId}.name`, { lng });
-		}
-		else {
-			// Fallback for test players or unknown opponents
-			opponentDisplayName = packet.fightOpponentKeycloakId ?? "???";
-		}
+		const opponentDisplayName = await resolveOpponentDisplayName(packet, lng);
 		const embed = new CrowniclesEmbed().formatAuthor(i18n.t("commands:fight.fightIntroTitle", {
 			lng,
 			fightInitiator: escapeUsername(interaction.user.displayName),

--- a/Discord/src/messages/CrowniclesActionChooseCachedMessage.ts
+++ b/Discord/src/messages/CrowniclesActionChooseCachedMessage.ts
@@ -1,6 +1,7 @@
 import { CrowniclesCachedMessage } from "./CrowniclesCachedMessage";
 import { PacketContext } from "../../../Lib/src/packets/CrowniclesPacket";
 import { DiscordCache } from "../bot/DiscordCache";
+import { crowniclesClient } from "../bot/CrowniclesShard";
 import { CrowniclesEmbed } from "./CrowniclesEmbed";
 import i18n from "../translations/i18n";
 import {
@@ -30,16 +31,17 @@ export class CrowniclesActionChooseCachedMessage extends CrowniclesCachedMessage
 	}
 
 	updateMessage = async (packet: ReactionCollectorFightChooseActionPacket, context: PacketContext): Promise<ReactionCollectorReturnTypeOrNull> => {
-		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
+		const interaction = DiscordCache.getInteraction(context.discord!.interaction);
 		const data = packet.data.data;
-		const lng = interaction.userLanguage;
+		const lng = interaction?.userLanguage ?? context.discord!.language;
+		const user = interaction?.user ?? await crowniclesClient.users.fetch(context.discord!.user);
 		if (!this.usernameCache) {
-			this.usernameCache = await DisplayUtils.getEscapedUsername(data.fighterKeycloakId, interaction.userLanguage);
+			this.usernameCache = await DisplayUtils.getEscapedUsername(data.fighterKeycloakId, lng);
 		}
 		const embed = new CrowniclesEmbed().formatAuthor(i18n.t("commands:fight.fightActionChoose.turnIndicationTitle", {
 			lng,
 			pseudo: this.usernameCache
-		}), interaction.user)
+		}), user)
 			.setDescription(i18n.t("commands:fight.fightActionChoose.turnIndicationDescription", { lng }));
 		const rows = [new ActionRowBuilder<ButtonBuilder>()];
 		const reactions = packet.reactions as {
@@ -62,8 +64,11 @@ export class CrowniclesActionChooseCachedMessage extends CrowniclesCachedMessage
 		const msg = await this.post({
 			embeds: [embed],
 			components: rows
-		});
-		const buttonCollector = msg!.createMessageComponentCollector({
+		}, context.discord!.channel);
+		if (!msg) {
+			return null;
+		}
+		const buttonCollector = msg.createMessageComponentCollector({
 			time: packet.endTime - Date.now()
 		});
 		buttonCollector.on("collect", async (buttonInteraction: ButtonInteraction) => {

--- a/Discord/src/messages/CrowniclesCachedMessage.ts
+++ b/Discord/src/messages/CrowniclesCachedMessage.ts
@@ -8,6 +8,7 @@ import {
 	asMinutes, minutesToMilliseconds
 } from "../../../Lib/src/utils/TimeUtils";
 import { DiscordCache } from "../bot/DiscordCache";
+import { crowniclesClient } from "../bot/CrowniclesShard";
 import { ReactionCollectorReturnTypeOrNull } from "../packetHandlers/handlers/ReactionCollectorHandlers";
 
 export abstract class CrowniclesCachedMessage<T extends CrowniclesPacket = CrowniclesPacket> {
@@ -16,6 +17,9 @@ export abstract class CrowniclesCachedMessage<T extends CrowniclesPacket = Crown
 
 	// The id of the original message
 	readonly originalMessageId: string;
+
+	// The id of the channel the message lives in, used as a fallback to (re)send through the bot token when the cached interaction is gone (e.g. after a shard reconnect or interaction expiry)
+	channelId?: string;
 
 	// Message linked to this cached message
 	storedMessage?: Message;
@@ -38,10 +42,16 @@ export abstract class CrowniclesCachedMessage<T extends CrowniclesPacket = Crown
 	abstract updateMessage(packet: T, context: PacketContext): Promise<ReactionCollectorReturnTypeOrNull>;
 
 	async update(packet: T, context: PacketContext): Promise<ReactionCollectorReturnTypeOrNull> {
+		if (context.discord?.channel) {
+			this.channelId = context.discord.channel;
+		}
 		return await this.updateMessage(packet, context);
 	}
 
-	async post(options: BaseMessageOptions): Promise<Message | null> {
+	async post(options: BaseMessageOptions, fallbackChannelId?: string): Promise<Message | null> {
+		if (fallbackChannelId) {
+			this.channelId = fallbackChannelId;
+		}
 		if (this.reuploadMessage) {
 			this.storedMessage?.delete().then();
 			this.storedMessage = undefined;
@@ -51,10 +61,30 @@ export abstract class CrowniclesCachedMessage<T extends CrowniclesPacket = Crown
 			return await this.storedMessage.edit(options);
 		}
 		const mainMessage = DiscordCache.getInteraction(this.originalMessageId);
-		if (!mainMessage) {
+		if (mainMessage) {
+			const message = await mainMessage.channel.send(options) as Message;
+			this.storedMessage = message;
+			return message;
+		}
+
+		/*
+		 * Fallback: the cached interaction is gone (e.g. shard reconnect or 15-min interaction expiry).
+		 * Re-send through the channel using the bot token, which does not depend on the interaction,
+		 * so the fight display keeps working transparently for the player.
+		 */
+		return await this.postThroughChannel(options);
+	}
+
+	private async postThroughChannel(options: BaseMessageOptions): Promise<Message | null> {
+		if (!this.channelId) {
 			return null;
 		}
-		const message = await mainMessage.channel.send(options) as Message;
+		const channel = await crowniclesClient.channels.fetch(this.channelId)
+			.catch(() => null);
+		if (!channel?.isSendable()) {
+			return null;
+		}
+		const message = await channel.send(options);
 		this.storedMessage = message;
 		return message;
 	}

--- a/Discord/src/messages/CrowniclesFightStatusCachedMessage.ts
+++ b/Discord/src/messages/CrowniclesFightStatusCachedMessage.ts
@@ -16,8 +16,7 @@ export class CrowniclesFightStatusCachedMessage extends CrowniclesCachedMessage<
 	}
 
 	updateMessage = async (packet: CommandFightStatusPacket, context: PacketContext): Promise<null> => {
-		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
-		const lng = interaction.userLanguage;
+		const lng = DiscordCache.getInteraction(context.discord!.interaction)?.userLanguage ?? context.discord!.language;
 		if (!this.usernamesCache) {
 			this.usernamesCache = new Map<string, string>();
 			if (packet.activeFighter.keycloakId) {

--- a/Discord/src/messages/CrowniclesHistoryCachedMessage.ts
+++ b/Discord/src/messages/CrowniclesHistoryCachedMessage.ts
@@ -126,11 +126,7 @@ export class CrowniclesHistoryCachedMessage extends CrowniclesCachedMessage<Comm
 			// The fightAction is an alteration or pet assistance
 			return i18n.t(`models:fight_actions.${packet.fightActionId}.${packet.status}`, {
 				lng,
-				petNickname: packet.pet
-					? packet.pet.nickname
-						? packet.pet.nickname
-						: DisplayUtils.getPetTypeName(lng, packet.pet.typeId, packet.pet.sex)
-					: undefined
+				petNickname: this.resolvePetNickname(packet, lng)
 			});
 		}
 		else if (packet.customMessage) {
@@ -155,6 +151,19 @@ export class CrowniclesHistoryCachedMessage extends CrowniclesCachedMessage<Comm
 				})
 			}
 		);
+	}
+
+	/**
+	 * Resolve the pet nickname to display for an alteration or pet assistance message,
+	 * or undefined when no pet is involved.
+	 * @param packet
+	 * @param lng
+	 */
+	private resolvePetNickname(packet: CommandFightHistoryItemPacket, lng: Language): string | undefined {
+		if (!packet.pet) {
+			return undefined;
+		}
+		return packet.pet.nickname ? packet.pet.nickname : DisplayUtils.getPetTypeName(lng, packet.pet.typeId, packet.pet.sex);
 	}
 
 	private manageReceivedEffects(packet: CommandFightHistoryItemPacket, lng: Language): string {

--- a/Discord/src/messages/CrowniclesHistoryCachedMessage.ts
+++ b/Discord/src/messages/CrowniclesHistoryCachedMessage.ts
@@ -35,8 +35,7 @@ export class CrowniclesHistoryCachedMessage extends CrowniclesCachedMessage<Comm
 	}
 
 	updateMessage = async (packet: CommandFightHistoryItemPacket, context: PacketContext): Promise<null> => {
-		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
-		const lng = interaction.userLanguage;
+		const lng = DiscordCache.getInteraction(context.discord!.interaction)?.userLanguage ?? context.discord!.language;
 		if (packet.fighterKeycloakId && !this.usernamesCachePlayer.has(packet.fighterKeycloakId)) {
 			this.usernamesCachePlayer.set(packet.fighterKeycloakId, await DisplayUtils.getEscapedUsername(packet.fighterKeycloakId, lng));
 		}

--- a/Discord/src/messages/CrowniclesHistoryCachedMessage.ts
+++ b/Discord/src/messages/CrowniclesHistoryCachedMessage.ts
@@ -36,20 +36,9 @@ export class CrowniclesHistoryCachedMessage extends CrowniclesCachedMessage<Comm
 
 	updateMessage = async (packet: CommandFightHistoryItemPacket, context: PacketContext): Promise<null> => {
 		const lng = DiscordCache.getInteraction(context.discord!.interaction)?.userLanguage ?? context.discord!.language;
-		if (packet.fighterKeycloakId && !this.usernamesCachePlayer.has(packet.fighterKeycloakId)) {
-			this.usernamesCachePlayer.set(packet.fighterKeycloakId, await DisplayUtils.getEscapedUsername(packet.fighterKeycloakId, lng));
-		}
-		else if (packet.monsterId && !this.usernamesCacheMonster.has(packet.monsterId)) {
-			this.usernamesCacheMonster.set(packet.monsterId, i18n.t(`models:monsters.${packet.monsterId}.name`, { lng }));
-		}
+		await this.ensureFighterNameCached(packet, lng);
 
-		let newLine = i18n.t("commands:fight.actions.intro", {
-			lng,
-			emote: packet.pet
-				? CrowniclesIcons.pets[packet.pet.typeId][packet.pet.sex === StringConstants.SEX.FEMALE.short ? "emoteFemale" : "emoteMale"]
-				: CrowniclesIcons.fightActions[packet.fightActionId],
-			fighter: packet.fighterKeycloakId ? this.usernamesCachePlayer?.get(packet.fighterKeycloakId) : this.usernamesCacheMonster?.get(packet.monsterId!)
-		}) + this.manageMainMessage(packet, lng);
+		let newLine = this.buildIntroLine(packet, lng);
 
 		if (packet.fightActionEffectReceived) {
 			newLine += this.manageReceivedEffects(packet, lng);
@@ -72,6 +61,37 @@ export class CrowniclesHistoryCachedMessage extends CrowniclesCachedMessage<Comm
 		CrowniclesCachedMessages.markAsReupload(CrowniclesCachedMessages.getOrCreate(this.originalMessageId, CrowniclesActionChooseCachedMessage));
 		return null;
 	};
+
+	/**
+	 * Cache the display name of the fighter (player or monster) of the given history item.
+	 * @param packet
+	 * @param lng
+	 */
+	private async ensureFighterNameCached(packet: CommandFightHistoryItemPacket, lng: Language): Promise<void> {
+		if (packet.fighterKeycloakId && !this.usernamesCachePlayer.has(packet.fighterKeycloakId)) {
+			this.usernamesCachePlayer.set(packet.fighterKeycloakId, await DisplayUtils.getEscapedUsername(packet.fighterKeycloakId, lng));
+		}
+		else if (packet.monsterId && !this.usernamesCacheMonster.has(packet.monsterId)) {
+			this.usernamesCacheMonster.set(packet.monsterId, i18n.t(`models:monsters.${packet.monsterId}.name`, { lng }));
+		}
+	}
+
+	/**
+	 * Build the intro line of a history item (emote + fighter name + main message).
+	 * @param packet
+	 * @param lng
+	 */
+	private buildIntroLine(packet: CommandFightHistoryItemPacket, lng: Language): string {
+		const emote = packet.pet
+			? CrowniclesIcons.pets[packet.pet.typeId][packet.pet.sex === StringConstants.SEX.FEMALE.short ? "emoteFemale" : "emoteMale"]
+			: CrowniclesIcons.fightActions[packet.fightActionId];
+		const fighter = packet.fighterKeycloakId ? this.usernamesCachePlayer?.get(packet.fighterKeycloakId) : this.usernamesCacheMonster?.get(packet.monsterId!);
+		return i18n.t("commands:fight.actions.intro", {
+			lng,
+			emote,
+			fighter
+		}) + this.manageMainMessage(packet, lng);
+	}
 
 	private manageSideEffects(packet: CommandFightHistoryItemPacket, lng: Language): string {
 		let sideEffectString = "";


### PR DESCRIPTION
When a Discord shard reconnects (or the interaction expires after 15 min) mid-fight, the cached interaction is gone and CrowniclesCachedMessage.post() returned null silently: the action menu was never displayed, the player could not click, the Core action collector timed out and killed the player as inactive (winner=2) with no log on either side.

Add a channel-based fallback (bot token, channel.send) so the fight display keeps working transparently, and make language/user lookups fall back to the packet context instead of throwing when the interaction is missing.

Does not change FightView inactivity kill (anti-abuse). Uses send, never reply.