### PR TITLE
Buff findMaterial : loot biome + quantité

### DIFF
--- a/Core/src/core/smallEvents/findMaterial.ts
+++ b/Core/src/core/smallEvents/findMaterial.ts
@@ -1,22 +1,48 @@
 import { SmallEventFuncs } from "../../data/SmallEvent";
 import { Maps } from "../maps/Maps";
+import { TravelTime } from "../maps/TravelTime";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { SmallEventConstants } from "../../../../Lib/src/constants/SmallEventConstants";
-import { ExpeditionConstants } from "../../../../Lib/src/constants/ExpeditionConstants";
+import {
+	ExpeditionConstants, ExpeditionLocationType
+} from "../../../../Lib/src/constants/ExpeditionConstants";
 import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
 import { MaterialDataController } from "../../data/Material";
 import { Materials } from "../database/game/models/Material";
 import { makePacket } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { SmallEventFindMaterialPacket } from "../../../../Lib/src/packets/smallEvents/SmallEventFindMaterialPacket";
+import { Player } from "../database/game/models/Player";
+
+/**
+ * Resolve the expedition biome associated with a map location type, falling back to the default biome.
+ */
+function getBiomeExpeditionType(mapType: string | undefined): ExpeditionLocationType {
+	return ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE[mapType ?? ExpeditionConstants.DEFAULT_MAP_TYPE]
+		?? ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE[ExpeditionConstants.DEFAULT_MAP_TYPE];
+}
+
+/**
+ * Compute the travel progress of the player (0 at the start of the trip, 1 once arrived).
+ */
+function getTravelProgress(player: Player): number {
+	const travelData = TravelTime.getTravelDataSimplified(player, new Date());
+	const tripDuration = travelData.travelEndTime - travelData.travelStartTime - travelData.effectDuration;
+	if (tripDuration <= 0) {
+		return 1;
+	}
+	return Math.min(1, Math.max(0, travelData.playerTravelledTime / tripDuration));
+}
 
 export const smallEventFuncs: SmallEventFuncs = {
 	canBeExecuted(player): boolean {
 		return Maps.isOnContinent(player) || Maps.isOnPveIsland(player);
 	},
 	executeSmallEvent: async (response, player): Promise<void> => {
-		const mapType = player.getDestination()?.type ?? player.getPreviousMap()?.type ?? ExpeditionConstants.DEFAULT_MAP_TYPE;
-		const expeditionType = ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE[mapType]
-			?? ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE[ExpeditionConstants.DEFAULT_MAP_TYPE];
+		// Loot blends the origin and destination biomes: the further along the trip, the more likely the destination biome is used
+		const progress = getTravelProgress(player);
+		const expeditionType = RandomUtils.crowniclesRandom.realZeroToOneInclusive() < progress
+			? getBiomeExpeditionType(player.getDestination()?.type)
+			: getBiomeExpeditionType(player.getPreviousMap()?.type);
 		const materialType = RandomUtils.crowniclesRandom.pick(SmallEventConstants.FIND_MATERIAL.BIOME_MATERIAL_TYPES[expeditionType]);
 
 		const randomNumber = RandomUtils.crowniclesRandom.realZeroToOneInclusive();
@@ -33,7 +59,11 @@ export const smallEventFuncs: SmallEventFuncs = {
 			throw new Error(`No material found for rarity ${MaterialRarity[materialRarity]}`);
 		}
 
-		const quantity = RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.QUANTITY);
+		// Base quantity, with a small chance to multiply the haul for a lucky jackpot
+		let quantity = RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.QUANTITY);
+		if (RandomUtils.crowniclesRandom.realZeroToOneInclusive() < SmallEventConstants.FIND_MATERIAL.LUCKY_MULTIPLIER.PROBABILITY) {
+			quantity *= RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.LUCKY_MULTIPLIER);
+		}
 
 		await Materials.giveMaterial(player.id, parseInt(material.id, 10), quantity);
 

--- a/Core/src/core/smallEvents/findMaterial.ts
+++ b/Core/src/core/smallEvents/findMaterial.ts
@@ -2,6 +2,7 @@ import { SmallEventFuncs } from "../../data/SmallEvent";
 import { Maps } from "../maps/Maps";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { SmallEventConstants } from "../../../../Lib/src/constants/SmallEventConstants";
+import { ExpeditionConstants } from "../../../../Lib/src/constants/ExpeditionConstants";
 import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
 import { MaterialDataController } from "../../data/Material";
 import { Materials } from "../database/game/models/Material";
@@ -13,6 +14,11 @@ export const smallEventFuncs: SmallEventFuncs = {
 		return Maps.isOnContinent(player) || Maps.isOnPveIsland(player);
 	},
 	executeSmallEvent: async (response, player): Promise<void> => {
+		const mapType = player.getDestination()?.type ?? player.getPreviousMap()?.type ?? ExpeditionConstants.DEFAULT_MAP_TYPE;
+		const expeditionType = ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE[mapType]
+			?? ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE[ExpeditionConstants.DEFAULT_MAP_TYPE];
+		const materialType = RandomUtils.crowniclesRandom.pick(SmallEventConstants.FIND_MATERIAL.BIOME_MATERIAL_TYPES[expeditionType]);
+
 		const randomNumber = RandomUtils.crowniclesRandom.realZeroToOneInclusive();
 		const materialRarity = randomNumber < SmallEventConstants.FIND_MATERIAL.RARE_PROBABILITY
 			? MaterialRarity.RARE
@@ -20,18 +26,22 @@ export const smallEventFuncs: SmallEventFuncs = {
 				? MaterialRarity.UNCOMMON
 				: MaterialRarity.COMMON;
 
-		const material = MaterialDataController.instance.getRandomMaterialFromRarity(materialRarity);
+		const material = MaterialDataController.instance.getRandomMaterialFromTypeAndRarity(materialType, materialRarity)
+			?? MaterialDataController.instance.getRandomMaterialFromRarity(materialRarity);
 
 		if (!material) {
 			throw new Error(`No material found for rarity ${MaterialRarity[materialRarity]}`);
 		}
 
-		await Materials.giveMaterial(player.id, parseInt(material.id, 10), 1);
+		const quantity = RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.QUANTITY);
+
+		await Materials.giveMaterial(player.id, parseInt(material.id, 10), quantity);
 
 		response.push(makePacket(SmallEventFindMaterialPacket, {
 			materialId: material.id,
 			materialRarity: material.rarity,
-			materialType: material.type
+			materialType: material.type,
+			quantity
 		}));
 	}
 };

--- a/Core/src/core/smallEvents/findMaterial.ts
+++ b/Core/src/core/smallEvents/findMaterial.ts
@@ -33,24 +33,49 @@ function getTravelProgress(player: Player): number {
 	return Math.min(1, Math.max(0, travelData.playerTravelledTime / tripDuration));
 }
 
+/**
+ * Pick the biome to loot from: it blends the origin and destination biomes, the destination being
+ * more likely the further along the trip the player is.
+ */
+function pickBiomeExpeditionType(player: Player): ExpeditionLocationType {
+	const progress = getTravelProgress(player);
+	return RandomUtils.crowniclesRandom.realZeroToOneInclusive() < progress
+		? getBiomeExpeditionType(player.getDestination()?.type)
+		: getBiomeExpeditionType(player.getPreviousMap()?.type);
+}
+
+/**
+ * Roll the rarity of the looted material following the find material probability ladder.
+ */
+function rollMaterialRarity(): MaterialRarity {
+	const randomNumber = RandomUtils.crowniclesRandom.realZeroToOneInclusive();
+	if (randomNumber < SmallEventConstants.FIND_MATERIAL.RARE_PROBABILITY) {
+		return MaterialRarity.RARE;
+	}
+	if (randomNumber < SmallEventConstants.FIND_MATERIAL.RARE_PROBABILITY + SmallEventConstants.FIND_MATERIAL.UNCOMMON_PROBABILITY) {
+		return MaterialRarity.UNCOMMON;
+	}
+	return MaterialRarity.COMMON;
+}
+
+/**
+ * Roll the looted quantity, with a small chance to multiply the haul for a lucky jackpot.
+ */
+function rollQuantity(): number {
+	const quantity = RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.QUANTITY);
+	if (RandomUtils.crowniclesRandom.realZeroToOneInclusive() < SmallEventConstants.FIND_MATERIAL.LUCKY_MULTIPLIER.PROBABILITY) {
+		return quantity * RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.LUCKY_MULTIPLIER);
+	}
+	return quantity;
+}
+
 export const smallEventFuncs: SmallEventFuncs = {
 	canBeExecuted(player): boolean {
 		return Maps.isOnContinent(player) || Maps.isOnPveIsland(player);
 	},
 	executeSmallEvent: async (response, player): Promise<void> => {
-		// Loot blends the origin and destination biomes: the further along the trip, the more likely the destination biome is used
-		const progress = getTravelProgress(player);
-		const expeditionType = RandomUtils.crowniclesRandom.realZeroToOneInclusive() < progress
-			? getBiomeExpeditionType(player.getDestination()?.type)
-			: getBiomeExpeditionType(player.getPreviousMap()?.type);
-		const materialType = RandomUtils.crowniclesRandom.pick(SmallEventConstants.FIND_MATERIAL.BIOME_MATERIAL_TYPES[expeditionType]);
-
-		const randomNumber = RandomUtils.crowniclesRandom.realZeroToOneInclusive();
-		const materialRarity = randomNumber < SmallEventConstants.FIND_MATERIAL.RARE_PROBABILITY
-			? MaterialRarity.RARE
-			: randomNumber < SmallEventConstants.FIND_MATERIAL.RARE_PROBABILITY + SmallEventConstants.FIND_MATERIAL.UNCOMMON_PROBABILITY
-				? MaterialRarity.UNCOMMON
-				: MaterialRarity.COMMON;
+		const materialType = RandomUtils.crowniclesRandom.pick(SmallEventConstants.FIND_MATERIAL.BIOME_MATERIAL_TYPES[pickBiomeExpeditionType(player)]);
+		const materialRarity = rollMaterialRarity();
 
 		const material = MaterialDataController.instance.getRandomMaterialFromTypeAndRarity(materialType, materialRarity)
 			?? MaterialDataController.instance.getRandomMaterialFromRarity(materialRarity);
@@ -59,11 +84,7 @@ export const smallEventFuncs: SmallEventFuncs = {
 			throw new Error(`No material found for rarity ${MaterialRarity[materialRarity]}`);
 		}
 
-		// Base quantity, with a small chance to multiply the haul for a lucky jackpot
-		let quantity = RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.QUANTITY);
-		if (RandomUtils.crowniclesRandom.realZeroToOneInclusive() < SmallEventConstants.FIND_MATERIAL.LUCKY_MULTIPLIER.PROBABILITY) {
-			quantity *= RandomUtils.rangedInt(SmallEventConstants.FIND_MATERIAL.LUCKY_MULTIPLIER);
-		}
+		const quantity = rollQuantity();
 
 		await Materials.giveMaterial(player.id, parseInt(material.id, 10), quantity);
 

--- a/Core/src/data/Material.ts
+++ b/Core/src/data/Material.ts
@@ -37,4 +37,12 @@ export class MaterialDataController extends DataControllerString<Material> {
 		}
 		return RandomUtils.crowniclesRandom.pick(materials);
 	}
+
+	public getRandomMaterialFromTypeAndRarity(type: MaterialType, rarity: MaterialRarity): Material | null {
+		const materials = this.getMaterialsFromType(type).filter(material => material.rarity === rarity);
+		if (materials.length === 0) {
+			return null;
+		}
+		return RandomUtils.crowniclesRandom.pick(materials);
+	}
 }

--- a/Discord/src/packetHandlers/handlers/smallEvents/findMaterial.ts
+++ b/Discord/src/packetHandlers/handlers/smallEvents/findMaterial.ts
@@ -18,7 +18,8 @@ export default class FindMaterialSmallEventHandler {
 			lng,
 			materialId: packet.materialId,
 			materialEmote: CrowniclesIcons.materials[packet.materialId],
-			rarityEmote: CrowniclesIcons.rarity[packet.materialRarity - 1]
+			rarityEmote: CrowniclesIcons.rarity[packet.materialRarity - 1],
+			quantity: packet.quantity
 		});
 
 		await interaction?.editReply({

--- a/Lang/fr/smallEvents.json
+++ b/Lang/fr/smallEvents.json
@@ -2572,9 +2572,9 @@
       "spiritual": "vous trouvez un endroit empreint de sérénité, où l'atmosphère est paisible et propice à votre bien être. Vous fouillez les environs à la recherche d'éléments ou d'objets."
     },
     "foundStories": {
-      "1": "Vous avez trouvé le matériau {{rarityEmote}} commun suivant : {{materialEmote}} **$t(models:materials.{{materialId}})**.",
-      "2": "Incroyable ! Vous avez mis la main sur un matériau {{rarityEmote}} peu commun : {{materialEmote}} **$t(models:materials.{{materialId}})**.",
-      "3": "Quelle chance inouïe ! Vous avez découvert un matériau {{rarityEmote}} rare : {{materialEmote}} **$t(models:materials.{{materialId}})**."
+      "1": "Vous repartez avec {{materialEmote}} **{{quantity}}× $t(models:materials.{{materialId}})** ({{rarityEmote}} commun).",
+      "2": "Belle trouvaille ! Vous repartez avec {{materialEmote}} **{{quantity}}× $t(models:materials.{{materialId}})** ({{rarityEmote}} peu commun).",
+      "3": "Quelle chance inouïe ! Vous repartez avec {{materialEmote}} **{{quantity}}× $t(models:materials.{{materialId}})** ({{rarityEmote}} rare)."
     }
   },
   "expeditionAdvice": {

--- a/Lib/src/constants/SmallEventConstants.ts
+++ b/Lib/src/constants/SmallEventConstants.ts
@@ -1,4 +1,6 @@
 import { MapLocationConstants } from "./MapLocationConstants";
+import { MaterialType } from "../types/MaterialType";
+import type { ExpeditionLocationType } from "./ExpeditionConstants";
 
 export abstract class SmallEventConstants {
 	static readonly HEALTH = {
@@ -542,7 +544,52 @@ export abstract class SmallEventConstants {
 	static readonly FIND_MATERIAL = {
 		SMALL_EVENT_NAME: "findMaterial",
 		RARE_PROBABILITY: 0.1,
-		UNCOMMON_PROBABILITY: 0.3
+		UNCOMMON_PROBABILITY: 0.3,
+		QUANTITY: {
+			MIN: 2,
+			MAX: 4
+		},
+		BIOME_MATERIAL_TYPES: {
+			forest: [
+				MaterialType.WOOD,
+				MaterialType.NATURE,
+				MaterialType.LEATHER
+			],
+			mountain: [
+				MaterialType.METAL,
+				MaterialType.ALLOY
+			],
+			desert: [
+				MaterialType.POISON,
+				MaterialType.EXPLOSIVE,
+				MaterialType.SPIRITUAL
+			],
+			swamp: [
+				MaterialType.POISON,
+				MaterialType.NATURE,
+				MaterialType.ROPE
+			],
+			ruins: [
+				MaterialType.SPIRITUAL,
+				MaterialType.MAGIC,
+				MaterialType.ALLOY
+			],
+			cave: [
+				MaterialType.METAL,
+				MaterialType.ALLOY,
+				MaterialType.EXPLOSIVE
+			],
+			plains: [
+				MaterialType.NATURE,
+				MaterialType.ROPE,
+				MaterialType.LEATHER
+			],
+			coast: [
+				MaterialType.ROPE,
+				MaterialType.NATURE,
+				MaterialType.LEATHER
+			]
+		} satisfies Record<ExpeditionLocationType, readonly MaterialType[]>
 	} as const;
 
 	static readonly INTERACT_OTHER_PLAYERS = {

--- a/Lib/src/constants/SmallEventConstants.ts
+++ b/Lib/src/constants/SmallEventConstants.ts
@@ -549,6 +549,11 @@ export abstract class SmallEventConstants {
 			MIN: 2,
 			MAX: 4
 		},
+		LUCKY_MULTIPLIER: {
+			PROBABILITY: 0.2,
+			MIN: 2,
+			MAX: 4
+		},
 		BIOME_MATERIAL_TYPES: {
 			forest: [
 				MaterialType.WOOD,

--- a/Lib/src/packets/smallEvents/SmallEventFindMaterialPacket.ts
+++ b/Lib/src/packets/smallEvents/SmallEventFindMaterialPacket.ts
@@ -11,4 +11,6 @@ export class SmallEventFindMaterialPacket extends SmallEventPacket {
 	materialType!: string;
 
 	materialRarity!: MaterialRarity;
+
+	quantity!: number;
 }


### PR DESCRIPTION
Fixes #4329

## Changement

Buff du small event `findMaterial` :

- **Type de matériau lié au biome** : le type looté est tiré d'une table biome → types (`SmallEventConstants.FIND_MATERIAL.BIOME_MATERIAL_TYPES`), le biome étant déterminé via l'infra existante `ExpeditionConstants.MAP_TYPE_TO_EXPEDITION_TYPE` à partir de la destination du joueur (fallback : case précédente, puis `DEFAULT_MAP_TYPE`).
- **Quantité 2–4** au lieu d'1 (`FIND_MATERIAL.QUANTITY`, via `RandomUtils.rangedInt`).
- Nouvelle méthode `MaterialDataController.getRandomMaterialFromTypeAndRarity` (fallback sur `getRandomMaterialFromRarity` si aucun matériau ne correspond au couple type+rareté).
- Packet `SmallEventFindMaterialPacket` : ajout de `quantity`.
- Traductions **fr uniquement** : `foundStories` affiche désormais `{{quantity}}×`.

Aucun big event ni l'économie d'expédition n'est touché.

## Qualité

| Package | ESLint | tsc | Tests |
|---------|--------|-----|-------|
| Lib     | ✅     | ✅  | ✅ 565 |
| Core    | ✅     | ✅  | ✅ 1074 |
| Discord | ✅     | ✅  | ✅ 228 |

Note : sur develop, `Discord/src/translations/i18n.ts` produit une erreur tsc TS2589 préexistante tant que `pnpm interface` n'a pas généré `src/@types/resources.d.ts` ; une fois généré, tsc est vert (sans rapport avec ce changement).
