### PR TITLE
Remove obsolete /ilovedraftbot advice

### DIFF
--- a/Lang/fr/advices.json
+++ b/Lang/fr/advices.json
@@ -100,7 +100,6 @@
     "La commande {command:profile} affiche votre état de santé actuel.",
     "Les familiers plus rares vous permettront de récolter de meilleures récompenses.",
     "Lors de la vente d'un familier, le vendeur ne reçoit pas d'argent mais de l'expérience pour sa guilde.",
-    "La commande `/ilovedraftbot` n'existe plus.",
     "Les badges sont des récompenses rares et difficiles à obtenir.",
     "Votre progression sur Crownicles est conservée même si vous jouez sur plusieurs serveurs.",
     "Il existe 5 paliers de classes différentes.",


### PR DESCRIPTION
Removes the obsolete advice `La commande `/ilovedraftbot` n'existe plus.` from `Lang/fr/advices.json` since the command no longer exists and the tip is no longer relevant.