### PR TITLE
UX: la boutique de ville reste en place au retour

### DIFF
--- a/Core/src/core/report/ReportCityShopService.ts
+++ b/Core/src/core/report/ReportCityShopService.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { ShopItemType } from "../../../../Lib/src/constants/LogsConstants";
 import {
-	OnShopCloseCallback, ShopUtils
+	OnShopCloseCallback, ShopInformations, ShopUtils
 } from "../utils/ShopUtils";
 import {
 	ShopConstants, ShopCurrency
@@ -77,6 +77,22 @@ function getMaterialsByTypeAndRarity(type: MaterialType, rarity: MaterialRarity)
 		materialsByTypeAndRarityCache.set(key, materials);
 	}
 	return materials;
+}
+
+/**
+ * Logger binding for the classical (money-based) city shops. Returns undefined
+ * when the Core instance is not yet ready (e.g. during boot), mirroring the
+ * optional `logger` contract of {@link ShopInformations}.
+ */
+function classicalShopLogger(): ShopInformations["logger"] {
+	return crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase);
+}
+
+/**
+ * Logger binding for the mission/gem-based city shops (royal market services).
+ */
+function missionShopLogger(): ShopInformations["logger"] {
+	return crowniclesInstance?.logsDatabase.logMissionShopBuyout.bind(crowniclesInstance?.logsDatabase);
 }
 
 /**
@@ -224,7 +240,7 @@ async function openGemShop({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logMissionShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: missionShopLogger(),
 		cityId,
 		additionalShopData: {
 			gemToMoneyRatio: calculateGemsToMoneyRatio(),
@@ -296,7 +312,7 @@ export async function openGeneralShop({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: classicalShopLogger(),
 		cityId: city.id,
 		additionalShopData: {
 			remainingPotions,
@@ -359,7 +375,7 @@ export async function openTanner({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: classicalShopLogger(),
 		cityId: city.id,
 		onClose
 	});
@@ -431,7 +447,7 @@ export async function openHerbalist({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: classicalShopLogger(),
 		cityId: city.id,
 		additionalShopData: {
 			weeklyPlants: weeklyPlants.map((p: PlantType) => p.id)
@@ -491,7 +507,7 @@ export async function openLumberjack({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: classicalShopLogger(),
 		cityId: city.id,
 		onClose
 	});
@@ -513,7 +529,7 @@ export async function openVeterinarian({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: classicalShopLogger(),
 		cityId: city.id,
 		additionalShopData: {
 			currency: ShopCurrency.GEM
@@ -560,7 +576,7 @@ export async function openMaterialMerchant({
 	await ShopUtils.createAndSendShopCollector(context, response, {
 		shopCategories,
 		player,
-		logger: crowniclesInstance?.logsDatabase.logClassicalShopBuyout.bind(crowniclesInstance?.logsDatabase),
+		logger: classicalShopLogger(),
 		cityId: city.id,
 		onClose
 	});

--- a/Discord/src/commands/player/report/cityMenu/MainMenu.ts
+++ b/Discord/src/commands/player/report/cityMenu/MainMenu.ts
@@ -350,6 +350,14 @@ async function handleMainMenuSelection(params: CityCollectorHandlerParams): Prom
 
 	if (selectedValue.startsWith(ReportCityMenuIds.CITY_SHOP_PREFIX)) {
 		handleShopSelection(selectedValue, componentInteraction, context, packet);
+
+		/*
+		 * The shop packet about to arrive replaces the city message in place
+		 * (see shopCollector, #4337). Stop the city collector now without
+		 * disabling the message — editing it here would race with the shop
+		 * render that is going to take over the same message.
+		 */
+		await nestedMenus.stopCurrentCollector({ editMessage: false });
 		return;
 	}
 

--- a/Discord/src/utils/ShopDisplayUtils.ts
+++ b/Discord/src/utils/ShopDisplayUtils.ts
@@ -499,11 +499,16 @@ export async function shopCollector(context: PacketContext, packet: ReactionColl
 		flags: COMPONENTS_V2_FLAGS
 	};
 
+	/*
+	 * The shop is always opened from within the city menu, which has already
+	 * replied (or deferred) to the interaction. We edit that same message in
+	 * place so the shop takes over the city message instead of spawning a new
+	 * one below it. This keeps the whole city visit on a single message and
+	 * lets "Retourner en ville" re-render the menu where the player is already
+	 * looking, instead of reviving the now-stale message above (#4337).
+	 */
 	let msg: Message | null;
-	if (interaction.replied) {
-		msg = await interaction.followUp(messagePayload);
-	}
-	else if (interaction.deferred) {
+	if (interaction.replied || interaction.deferred) {
 		msg = await interaction.editReply(messagePayload);
 	}
 	else {


### PR DESCRIPTION
## Problème

Lors d'une visite de ville, après avoir ouvert une boutique puis cliqué sur « Retourner en ville », le menu ville réapparaissait **au-dessus** dans un message ravivé, tandis que l'embed de la boutique restait affiché et désactivé **en bas**. Mauvaise expérience utilisateur.

Fixes #4337

## Cause racine

- `nestedMenus.send()` cible le message d'origine de l'interaction `/report` via `editReply()` (message #1).
- La boutique se rendait via `followUp()` → un **second** message (message #2).
- À la fermeture, `onClose → sendCityCollector → editReply` ravivait le message #1 (en haut), laissant la boutique (message #2) désactivée en bas.

## Solution

- **`ShopDisplayUtils.shopCollector`** : la boutique se rend désormais **in-place** dans le message ville (`editReply` quand l'interaction a déjà répondu ou est différée, au lieu de `followUp`). Toute la visite tient sur un seul message.
- **`MainMenu.handleMainMenuSelection`** : on stoppe le collector ville (`stopCurrentCollector({ editMessage: false })`) à l'ouverture de la boutique, pour qu'il n'entre pas en concurrence avec le collector boutique qui reprend le même message.
- À la fermeture / au timeout, la ville se re-rend dans **ce même message**, là où le joueur regarde déjà.

### Analyse de course

Les opérations locales de désactivation (`consumeAndDisable` / `disableOnEnd`) s'exécutent toujours **avant** le re-render réseau de la ville. L'état final est donc bien le menu ville actif. ✓

## Cleanup

- Extraction du binding logger répété 7× dans `ReportCityShopService.ts` en deux helpers `classicalShopLogger()` / `missionShopLogger()`.

> Le renommage plus large `CommandShop*` / `ShopCommandPacketHandlers` a été **délibérément écarté** : ces noms suivent la convention du codebase (`Command*` pour les packets résultat, `*CommandPacketHandlers` pour les handlers). Le renommer casserait la cohérence avec les handlers frères et toucherait les noms de routage MQTT.

## Validation

- Core `tsc` ✓, Discord `tsc` ✓ (l'erreur `i18n.ts` TS2589 est pré-existante sur la branche)
- ESLint Core + Discord : 0 erreur
- Tests Core 1227/1227 ✓, Discord 228/228 ✓
