### PR TITLE
Fix 4 city milestone bugs (expedition name, enchant button, travel score, chest mission)

### DIFF
--- a/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
+++ b/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
@@ -10,7 +10,7 @@ import {
 	ReactionCollectorResetTimerPacketReq
 } from "../../../../../Lib/src/packets/interaction/ReactionCollectorResetTimer";
 import {
-	CommandReportHomeChestActionReq, CommandReportHomeChestActionRes,
+	CommandReportHomeChestActionReq,
 	CommandReportGardenHarvestReq,
 	CommandReportGardenPlantReq,
 	CommandReportGardenWaterReq,
@@ -64,8 +64,7 @@ export default class CoreHandlers {
 
 	@packetHandler(CommandReportHomeChestActionReq)
 	async homeChestAction(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportHomeChestActionReq): Promise<void> {
-		const result = await handleChestAction(context.keycloakId!, packet, response);
-		response.push(makePacket(CommandReportHomeChestActionRes, result));
+		await handleChestAction(context.keycloakId!, packet, response);
 	}
 
 	@packetHandler(CommandEquipActionReq)

--- a/Core/src/core/report/ReportCityChestService.ts
+++ b/Core/src/core/report/ReportCityChestService.ts
@@ -22,7 +22,9 @@ import {
 import InventoryInfo from "../database/game/models/InventoryInfo";
 import { buildChestData } from "./ReportCityService";
 import { withLockedEntities } from "../../../../Lib/src/locks/withLockedEntities";
-import { CrowniclesPacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+import {
+	CrowniclesPacket, makePacket
+} from "../../../../Lib/src/packets/CrowniclesPacket";
 import { MissionsController } from "../missions/MissionsController";
 
 type ChestActionResult = Omit<CommandReportHomeChestActionRes, "name">;
@@ -117,6 +119,15 @@ export async function handleChestAction(
 		[Player.lockKey(chestActionContext.player.id), Home.lockKey(chestActionContext.home.id)] as const,
 		([lockedPlayer, lockedHome]) => runChestActionUnderLock(packet, lockedPlayer, lockedHome)
 	).then(async result => {
+		/*
+		 * Push the chest action response packet BEFORE any mission notification
+		 * packet. The Discord async packet sender matches the first response
+		 * packet carrying the request's packetId to the awaiting callback, so a
+		 * mission-completed packet pushed first would hijack that callback and
+		 * leave the chest response unhandled (broken message). See issue #4342.
+		 */
+		response.push(makePacket(CommandReportHomeChestActionRes, result));
+
 		/*
 		 * Trigger the mission update only after the Player + Home locks are
 		 * released: `MissionsController.update` additionally locks

--- a/Core/src/core/report/ReportCityChestService.ts
+++ b/Core/src/core/report/ReportCityChestService.ts
@@ -112,33 +112,34 @@ export async function handleChestAction(
 	};
 
 	if (!hasChestActionContext(chestActionContext)) {
+		response.push(makePacket(CommandReportHomeChestActionRes, INVALID_CHEST_ACTION));
 		return INVALID_CHEST_ACTION;
 	}
 
-	return await withLockedEntities(
+	const result = await withLockedEntities(
 		[Player.lockKey(chestActionContext.player.id), Home.lockKey(chestActionContext.home.id)] as const,
 		([lockedPlayer, lockedHome]) => runChestActionUnderLock(packet, lockedPlayer, lockedHome)
-	).then(async result => {
-		/*
-		 * Push the chest action response packet BEFORE any mission notification
-		 * packet. The Discord async packet sender matches the first response
-		 * packet carrying the request's packetId to the awaiting callback, so a
-		 * mission-completed packet pushed first would hijack that callback and
-		 * leave the chest response unhandled (broken message). See issue #4342.
-		 */
-		response.push(makePacket(CommandReportHomeChestActionRes, result));
+	);
 
-		/*
-		 * Trigger the mission update only after the Player + Home locks are
-		 * released: `MissionsController.update` additionally locks
-		 * `player_missions_info` then `players`, which would invert the
-		 * already-held `players` lock and risk a deadlock.
-		 */
-		if (result.success && packet.action === HomeConstants.CHEST_ACTIONS.DEPOSIT) {
-			await MissionsController.update(chestActionContext.player, response, { missionId: "depositChestItem" });
-		}
-		return result;
-	});
+	/*
+	 * Push the chest action response packet BEFORE any mission notification
+	 * packet. The Discord async packet sender matches the first response
+	 * packet carrying the request's packetId to the awaiting callback, so a
+	 * mission-completed packet pushed first would hijack that callback and
+	 * leave the chest response unhandled (broken message). See issue #4342.
+	 */
+	response.push(makePacket(CommandReportHomeChestActionRes, result));
+
+	/*
+	 * Trigger the mission update only after the Player + Home locks are
+	 * released: `MissionsController.update` additionally locks
+	 * `player_missions_info` then `players`, which would invert the
+	 * already-held `players` lock and risk a deadlock.
+	 */
+	if (result.success && packet.action === HomeConstants.CHEST_ACTIONS.DEPOSIT) {
+		await MissionsController.update(chestActionContext.player, response, { missionId: "depositChestItem" });
+	}
+	return result;
 }
 
 async function runChestActionUnderLock(

--- a/Core/src/data/events/PossibilityOutcome.ts
+++ b/Core/src/data/events/PossibilityOutcome.ts
@@ -23,10 +23,12 @@ import { BigEventConstants } from "../../../../Lib/src/constants/BigEventConstan
 import { PlayerActiveObjects } from "../../core/database/game/models/PlayerActiveObjects";
 import { InventorySlots } from "../../core/database/game/models/InventorySlot";
 import { BlessingManager } from "../../core/blessings/BlessingManager";
-import { asMilliseconds } from "../../../../Lib/src/utils/TimeUtils";
+import {
+	asMinutes, minutesToMilliseconds
+} from "../../../../Lib/src/utils/TimeUtils";
 
 async function applyOutcomeScore(outcome: PossibilityOutcome, time: number, player: Player, response: CrowniclesPacket[]): Promise<number> {
-	const scoreChange = TravelTime.timeTravelledToScore(asMilliseconds(time))
+	const scoreChange = TravelTime.timeTravelledToScore(minutesToMilliseconds(asMinutes(time)))
 		+ await PlayerSmallEvents.calculateCurrentScore(player)
 		+ (outcome.bonusPoints ?? 0);
 	const scoreParameters = {

--- a/Discord/src/commands/player/report/cityMenu/EnchanterMenu.ts
+++ b/Discord/src/commands/player/report/cityMenu/EnchanterMenu.ts
@@ -62,11 +62,10 @@ function buildEnchantmentBalance(data: EnchanterCityData, lng: Language): string
 		});
 }
 
-async function sendEnchantReaction(params: EnchanterHandlerParams, index: number): Promise<void> {
+function sendEnchantReaction(params: EnchanterHandlerParams, index: number): void {
 	const {
 		selectedValue, buttonInteraction, context, packet, data
 	} = params;
-	await buttonInteraction.deferReply();
 	const item = data.enchantableItems[index];
 	if (!item || !selectedValue.startsWith(ReportCityMenuIds.ENCHANT_ITEM_PREFIX)) {
 		return;
@@ -108,6 +107,7 @@ async function handleEnchantItemSelection(params: EnchanterHandlerParams): Promi
 		confirmLabel: i18n.t("commands:report.city.buttons.enchant", { lng }),
 		confirmEmoji: CrowniclesIcons.city.enchanter,
 		backMenuId: ReportCityMenuIds.ENCHANTER_MENU,
+		confirmAck: "reply",
 		onConfirm: async action => {
 			await sendEnchantReaction({
 				...params,

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -324,7 +324,8 @@
       "27": "les Clairières Mystiques de la Forêt Célestrum",
       "28": "les Souterrains des Portes du Château",
       "29": "les Alcôves de la Salle de Réception",
-      "32": "les Pavés Royaux de la Route vers le Château"
+      "32": "les Pavés Royaux de la Route vers le Château",
+      "41": "les Passages Secrets de la Cour du Château"
     },
     "errors": {
       "noPet": "Les esprits de la nature refusent de vous laisser envoyer un familier... car vous n'en possédez pas !",


### PR DESCRIPTION
## Résumé

Correction de 4 bugs remontés sur la beta (milestone « les villes »).

### Bugs corrigés

- **Nom d'expédition (château)** — Le nouveau lieu 41 « Cour du Château » (ville du continent principal) n'avait pas d'entrée dans `mapLocationExpeditions`, donc les expéditions y affichaient la clé de traduction brute. Ajout de la traduction manquante.
  Closes #4346

- **Bouton « enchanter » inactif** — Double acquittement d'interaction : la confirmation faisait un `deferUpdate` puis `sendEnchantReaction` refaisait un `deferReply`, ce qui levait une exception silencieuse et bloquait l'enchantement. Aligné sur le flux du notaire (`confirmAck: "reply"` + suppression du `deferReply` redondant).
  Closes #4345

- **Temps de trajet non compté dans les points** — Le temps de trajet (en minutes) était passé via `asMilliseconds()` (simple cast, sans conversion) à `timeTravelledToScore()` qui reconvertit en minutes, ramenant le bonus à ~0. Remplacé par `minutesToMilliseconds(asMinutes(time))`.
  Closes #4344

- **Message de complétion de la mission 12 cassé (dépôt coffre)** — Le `MissionsCompletedPacket` était poussé dans la réponse avant le `CommandReportHomeChestActionRes`, détournant le callback async côté Discord (le vrai paquet coffre finissait en « No packet listener found »). Le paquet de réponse du coffre est désormais poussé avant la mise à jour de mission.
  Closes #4342

## Tests

- ESLint vert sur tous les fichiers modifiés (Core, Discord, Lang).
- Tests unitaires : Core 1231 passés, Discord 228 passés.
- Test d'intégration de course du dépôt coffre (`home-chest-deposit.race.integration.test.ts`) : passé (MariaDB).
