### PR TITLE
Fix attack stat emoji + player avatars in view commands (#4316, #4241)

### DIFF
--- a/Discord/src/commands/pet/PetCommand.ts
+++ b/Discord/src/commands/pet/PetCommand.ts
@@ -15,6 +15,7 @@ import { DiscordCache } from "../../bot/DiscordCache";
 import { KeycloakUser } from "../../../../Lib/src/keycloak/KeycloakUser";
 import { PacketUtils } from "../../utils/PacketUtils";
 import { DisplayUtils } from "../../utils/DisplayUtils";
+import { resolveKeycloakDiscordUser } from "../../utils/KeycloakPlayerUtils";
 import {
 	escapeUsername, StringUtils
 } from "../../utils/StringUtils";
@@ -171,8 +172,10 @@ async function createPetEmbed(
 ): Promise<CrowniclesEmbed> {
 	const lng = interaction.userLanguage;
 	let foundPlayerUsername;
+	let authorUser = interaction.user;
 	if (packet.askedKeycloakId) {
 		foundPlayerUsername = await DisplayUtils.getEscapedUsername(packet.askedKeycloakId, lng);
+		authorUser = await resolveKeycloakDiscordUser(packet.askedKeycloakId) ?? interaction.user;
 	}
 
 	let description = DisplayUtils.getOwnedPetFieldDisplay(packet.pet, lng);
@@ -188,7 +191,7 @@ async function createPetEmbed(
 				lng,
 				pseudo: escapeUsername(foundPlayerUsername ?? interaction.user.displayName)
 			}),
-			interaction.user
+			authorUser
 		)
 		.setDescription(description);
 }

--- a/Discord/src/commands/player/InventoryCommand.ts
+++ b/Discord/src/commands/player/InventoryCommand.ts
@@ -112,10 +112,6 @@ function getOwnedTalismanLabels(packet: CommandInventoryPacketRes, lng: Language
 		.map(talisman => i18n.t(talisman.translationKey, { lng }));
 }
 
-function applyInventoryHeader(embed: CrowniclesEmbed, title: string, targetUser: User | null): CrowniclesEmbed {
-	return targetUser ? embed.formatAuthor(title, targetUser) : embed.setTitle(title);
-}
-
 function getEquippedEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language, targetUser: User | null): CrowniclesEmbed {
 	if (!packet.data) {
 		throw new Error("Inventory packet data must not be undefined");
@@ -133,7 +129,7 @@ function getEquippedEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng
 				inline: false
 			}
 		]);
-	return applyInventoryHeader(embed, i18n.t("commands:inventory.title", {
+	return embed.formatAuthorOrTitle(i18n.t("commands:inventory.title", {
 		lng,
 		pseudo
 	}), targetUser);
@@ -148,7 +144,7 @@ function getBackupEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: 
 				getBackupField(lng, packet.data.backupPotions, packet.data.slots.potions, DiscordItemUtils.getPotionField, "potions"),
 				getBackupField(lng, packet.data.backupObjects, packet.data.slots.objects, DiscordItemUtils.getObjectField, "objects")
 			]);
-		return applyInventoryHeader(embed, i18n.t("commands:inventory.stockTitle", {
+		return embed.formatAuthorOrTitle(i18n.t("commands:inventory.stockTitle", {
 			lng,
 			pseudo
 		}), targetUser);
@@ -230,7 +226,7 @@ function getMaterialsEmbed(packet: CommandInventoryPacketRes, pseudo: string, ln
 	}
 
 	const materials = packet.data.materials;
-	const embed = applyInventoryHeader(new CrowniclesEmbed(), i18n.t("commands:inventory.materialsTitle", {
+	const embed = new CrowniclesEmbed().formatAuthorOrTitle(i18n.t("commands:inventory.materialsTitle", {
 		lng,
 		pseudo
 	}), targetUser);
@@ -282,7 +278,7 @@ function getPlantsEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: 
 		throw new Error("Inventory packet data must not be undefined");
 	}
 
-	const embed = applyInventoryHeader(new CrowniclesEmbed(), i18n.t("commands:inventory.plantsTitle", {
+	const embed = new CrowniclesEmbed().formatAuthorOrTitle(i18n.t("commands:inventory.plantsTitle", {
 		lng,
 		pseudo
 	}), targetUser);

--- a/Discord/src/commands/player/InventoryCommand.ts
+++ b/Discord/src/commands/player/InventoryCommand.ts
@@ -24,6 +24,7 @@ import { sendInteractionNotForYou } from "../../utils/ErrorUtils";
 import { PacketUtils } from "../../utils/PacketUtils";
 import { MessageFlags } from "discord-api-types/v10";
 import { DisplayUtils } from "../../utils/DisplayUtils";
+import { resolveKeycloakDiscordUser } from "../../utils/KeycloakPlayerUtils";
 import { disableRows } from "../../utils/DiscordCollectorUtils";
 import { ItemWithDetails } from "../../../../Lib/src/types/ItemWithDetails";
 import { CrowniclesIcons } from "../../../../Lib/src/CrowniclesIcons";
@@ -367,6 +368,7 @@ export async function handleCommandInventoryPacketRes(packet: CommandInventoryPa
 		return;
 	}
 	const username = await DisplayUtils.getEscapedUsername(packet.keycloakId!, lng);
+	const avatarUrl = (await resolveKeycloakDiscordUser(packet.keycloakId!))?.displayAvatarURL() ?? null;
 	let currentView = InventoryView.EQUIPPED;
 
 	const embeds = [
@@ -375,6 +377,9 @@ export async function handleCommandInventoryPacketRes(packet: CommandInventoryPa
 		getMaterialsEmbed(packet, username, lng),
 		getPlantsEmbed(packet, username, lng)
 	];
+	if (avatarUrl) {
+		embeds.forEach(embed => embed.setThumbnail(avatarUrl));
+	}
 
 	/**
 	 * All views with their button labels and custom IDs, in fixed display order

--- a/Discord/src/commands/player/InventoryCommand.ts
+++ b/Discord/src/commands/player/InventoryCommand.ts
@@ -8,7 +8,7 @@ import { SlashCommandBuilderGenerator } from "../SlashCommandBuilderGenerator";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CrowniclesEmbed } from "../../messages/CrowniclesEmbed";
 import {
-	ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedField
+	ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedField, User
 } from "discord.js";
 import { Constants } from "../../../../Lib/src/constants/Constants";
 import { DiscordCache } from "../../bot/DiscordCache";
@@ -112,16 +112,16 @@ function getOwnedTalismanLabels(packet: CommandInventoryPacketRes, lng: Language
 		.map(talisman => i18n.t(talisman.translationKey, { lng }));
 }
 
-function getEquippedEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language): CrowniclesEmbed {
+function applyInventoryHeader(embed: CrowniclesEmbed, title: string, targetUser: User | null): CrowniclesEmbed {
+	return targetUser ? embed.formatAuthor(title, targetUser) : embed.setTitle(title);
+}
+
+function getEquippedEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language, targetUser: User | null): CrowniclesEmbed {
 	if (!packet.data) {
 		throw new Error("Inventory packet data must not be undefined");
 	}
 
-	return new CrowniclesEmbed()
-		.setTitle(i18n.t("commands:inventory.title", {
-			lng,
-			pseudo
-		}))
+	const embed = new CrowniclesEmbed()
 		.addFields([
 			DiscordItemUtils.getWeaponField(packet.data.weapon, lng),
 			DiscordItemUtils.getArmorField(packet.data.armor, lng),
@@ -133,21 +133,25 @@ function getEquippedEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng
 				inline: false
 			}
 		]);
+	return applyInventoryHeader(embed, i18n.t("commands:inventory.title", {
+		lng,
+		pseudo
+	}), targetUser);
 }
 
-function getBackupEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language): CrowniclesEmbed {
+function getBackupEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language, targetUser: User | null): CrowniclesEmbed {
 	if (packet.data) {
-		return new CrowniclesEmbed()
-			.setTitle(i18n.t("commands:inventory.stockTitle", {
-				lng,
-				pseudo
-			}))
+		const embed = new CrowniclesEmbed()
 			.addFields([
 				getBackupField(lng, packet.data.backupWeapons, packet.data.slots.weapons, DiscordItemUtils.getWeaponField, "weapons"),
 				getBackupField(lng, packet.data.backupArmors, packet.data.slots.armors, DiscordItemUtils.getArmorField, "armors"),
 				getBackupField(lng, packet.data.backupPotions, packet.data.slots.potions, DiscordItemUtils.getPotionField, "potions"),
 				getBackupField(lng, packet.data.backupObjects, packet.data.slots.objects, DiscordItemUtils.getObjectField, "objects")
 			]);
+		return applyInventoryHeader(embed, i18n.t("commands:inventory.stockTitle", {
+			lng,
+			pseudo
+		}), targetUser);
 	}
 
 	throw new Error("Inventory packet data must not be undefined");
@@ -220,17 +224,16 @@ function buildColumnField(params: BuildColumnFieldParams): EmbedField[] {
 	return fields;
 }
 
-function getMaterialsEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language): CrowniclesEmbed {
+function getMaterialsEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language, targetUser: User | null): CrowniclesEmbed {
 	if (!packet.data) {
 		throw new Error("Inventory packet data must not be undefined");
 	}
 
 	const materials = packet.data.materials;
-	const embed = new CrowniclesEmbed()
-		.setTitle(i18n.t("commands:inventory.materialsTitle", {
-			lng,
-			pseudo
-		}));
+	const embed = applyInventoryHeader(new CrowniclesEmbed(), i18n.t("commands:inventory.materialsTitle", {
+		lng,
+		pseudo
+	}), targetUser);
 
 	if (materials.length === 0) {
 		embed.addFields([
@@ -274,16 +277,15 @@ function getMaterialsEmbed(packet: CommandInventoryPacketRes, pseudo: string, ln
 	return embed;
 }
 
-function getPlantsEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language): CrowniclesEmbed {
+function getPlantsEmbed(packet: CommandInventoryPacketRes, pseudo: string, lng: Language, targetUser: User | null): CrowniclesEmbed {
 	if (!packet.data) {
 		throw new Error("Inventory packet data must not be undefined");
 	}
 
-	const embed = new CrowniclesEmbed()
-		.setTitle(i18n.t("commands:inventory.plantsTitle", {
-			lng,
-			pseudo
-		}));
+	const embed = applyInventoryHeader(new CrowniclesEmbed(), i18n.t("commands:inventory.plantsTitle", {
+		lng,
+		pseudo
+	}), targetUser);
 
 	const plants = packet.data.plants;
 	if (!plants) {
@@ -368,18 +370,15 @@ export async function handleCommandInventoryPacketRes(packet: CommandInventoryPa
 		return;
 	}
 	const username = await DisplayUtils.getEscapedUsername(packet.keycloakId!, lng);
-	const avatarUrl = (await resolveKeycloakDiscordUser(packet.keycloakId!))?.displayAvatarURL() ?? null;
+	const targetUser = await resolveKeycloakDiscordUser(packet.keycloakId!);
 	let currentView = InventoryView.EQUIPPED;
 
 	const embeds = [
-		getEquippedEmbed(packet, username, lng),
-		getBackupEmbed(packet, username, lng),
-		getMaterialsEmbed(packet, username, lng),
-		getPlantsEmbed(packet, username, lng)
+		getEquippedEmbed(packet, username, lng, targetUser),
+		getBackupEmbed(packet, username, lng, targetUser),
+		getMaterialsEmbed(packet, username, lng, targetUser),
+		getPlantsEmbed(packet, username, lng, targetUser)
 	];
-	if (avatarUrl) {
-		embeds.forEach(embed => embed.setThumbnail(avatarUrl));
-	}
 
 	/**
 	 * All views with their button labels and custom IDs, in fixed display order

--- a/Discord/src/commands/player/ProfileCommand.ts
+++ b/Discord/src/commands/player/ProfileCommand.ts
@@ -298,13 +298,8 @@ export async function handleCommandProfilePacketRes(packet: CommandProfilePacket
 	});
 	const embed = new CrowniclesEmbed()
 		.setColor(<ColorResolvable>(packet.playerData.color ?? ColorConstants.PROFILE_DEFAULT))
-		.addFields(generateFields(packet, lng));
-	if (targetUser) {
-		embed.formatAuthor(title, targetUser);
-	}
-	else {
-		embed.setTitle(title);
-	}
+		.addFields(generateFields(packet, lng))
+		.formatAuthorOrTitle(title, targetUser);
 	const reply = await interaction.reply({
 		embeds: [embed],
 		withResponse: true

--- a/Discord/src/commands/player/ProfileCommand.ts
+++ b/Discord/src/commands/player/ProfileCommand.ts
@@ -25,6 +25,7 @@ import {
 	asMilliseconds, millisecondsToMinutes
 } from "../../../../Lib/src/utils/TimeUtils";
 import { DisplayUtils } from "../../utils/DisplayUtils";
+import { resolveKeycloakDiscordUser } from "../../utils/KeycloakPlayerUtils";
 import { Badge } from "../../../../Lib/src/types/Badge";
 import { TokensConstants } from "../../../../Lib/src/constants/TokensConstants";
 import { ColorConstants } from "../../../../Lib/src/constants/ColorConstants";
@@ -288,10 +289,12 @@ export async function handleCommandProfilePacketRes(packet: CommandProfilePacket
 	const lng = interaction.userLanguage;
 	const titleEffect = packet.playerData.effect.healed ? "healed" : packet.playerData.effect.effect;
 	const pseudo = await DisplayUtils.getEscapedUsername(packet.keycloakId, lng);
+	const avatarUrl = (await resolveKeycloakDiscordUser(packet.keycloakId))?.displayAvatarURL() ?? null;
 	const reply = await interaction.reply({
 		embeds: [
 			new CrowniclesEmbed()
 				.setColor(<ColorResolvable>(packet.playerData.color ?? ColorConstants.PROFILE_DEFAULT))
+				.setThumbnail(avatarUrl)
 				.setTitle(i18n.t("commands:profile.title", {
 					lng,
 					effectId: titleEffect,

--- a/Discord/src/commands/player/ProfileCommand.ts
+++ b/Discord/src/commands/player/ProfileCommand.ts
@@ -289,20 +289,24 @@ export async function handleCommandProfilePacketRes(packet: CommandProfilePacket
 	const lng = interaction.userLanguage;
 	const titleEffect = packet.playerData.effect.healed ? "healed" : packet.playerData.effect.effect;
 	const pseudo = await DisplayUtils.getEscapedUsername(packet.keycloakId, lng);
-	const avatarUrl = (await resolveKeycloakDiscordUser(packet.keycloakId))?.displayAvatarURL() ?? null;
+	const targetUser = await resolveKeycloakDiscordUser(packet.keycloakId);
+	const title = i18n.t("commands:profile.title", {
+		lng,
+		effectId: titleEffect,
+		pseudo,
+		level: packet.playerData?.level
+	});
+	const embed = new CrowniclesEmbed()
+		.setColor(<ColorResolvable>(packet.playerData.color ?? ColorConstants.PROFILE_DEFAULT))
+		.addFields(generateFields(packet, lng));
+	if (targetUser) {
+		embed.formatAuthor(title, targetUser);
+	}
+	else {
+		embed.setTitle(title);
+	}
 	const reply = await interaction.reply({
-		embeds: [
-			new CrowniclesEmbed()
-				.setColor(<ColorResolvable>(packet.playerData.color ?? ColorConstants.PROFILE_DEFAULT))
-				.setThumbnail(avatarUrl)
-				.setTitle(i18n.t("commands:profile.title", {
-					lng,
-					effectId: titleEffect,
-					pseudo,
-					level: packet.playerData?.level
-				}))
-				.addFields(generateFields(packet, lng))
-		],
+		embeds: [embed],
 		withResponse: true
 	});
 	if (!reply?.resource?.message) {

--- a/Discord/src/commands/player/UnlockCommand.ts
+++ b/Discord/src/commands/player/UnlockCommand.ts
@@ -25,6 +25,7 @@ import { UnlockConstants } from "../../../../Lib/src/constants/UnlockConstants";
 import { ReactionCollectorReturnTypeOrNull } from "../../packetHandlers/handlers/ReactionCollectorHandlers";
 import { escapeUsername } from "../../utils/StringUtils";
 import { DisplayUtils } from "../../utils/DisplayUtils";
+import { resolveKeycloakDiscordUser } from "../../utils/KeycloakPlayerUtils";
 
 /**
  * Free a player from the prison
@@ -70,10 +71,11 @@ export async function createUnlockCollector(context: PacketContext, packet: Reac
 	const lng = interaction.userLanguage;
 	const data = packet.data.data;
 	const pseudo = await DisplayUtils.getEscapedUsername(data.unlockedKeycloakId, lng);
+	const unlockedUser = await resolveKeycloakDiscordUser(data.unlockedKeycloakId);
 	const embed = new CrowniclesEmbed().formatAuthor(i18n.t("commands:unlock.title", {
 		lng,
 		pseudo
-	}), interaction.user)
+	}), unlockedUser ?? interaction.user)
 		.setDescription(
 			i18n.t("commands:unlock.confirmDesc", {
 				lng,
@@ -123,12 +125,13 @@ export async function handleCommandUnlockAcceptPacketRes(packet: CommandUnlockAc
 	}
 	const lng = originalInteraction.userLanguage;
 	const buttonInteraction = DiscordCache.getButtonInteraction(context.discord!.buttonInteraction!);
+	const unlockedUser = await resolveKeycloakDiscordUser(packet.unlockedKeycloakId);
 	await buttonInteraction?.editReply({
 		embeds: [
 			new CrowniclesEmbed().formatAuthor(i18n.t("commands:unlock.title", {
 				lng,
 				pseudo: await DisplayUtils.getEscapedUsername(packet.unlockedKeycloakId, lng)
-			}), originalInteraction.user)
+			}), unlockedUser ?? originalInteraction.user)
 				.setDescription(
 					i18n.t("commands:unlock.acceptedDesc", {
 						lng,

--- a/Discord/src/messages/CrowniclesEmbed.ts
+++ b/Discord/src/messages/CrowniclesEmbed.ts
@@ -22,6 +22,15 @@ export class CrowniclesEmbed extends EmbedBuilder {
 	}
 
 	/**
+	 * Set the author with the user's avatar when a user is provided, otherwise fall back to a plain title
+	 * @param title
+	 * @param user
+	 */
+	formatAuthorOrTitle(title: string, user: User | null): this {
+		return user ? this.formatAuthor(title, user) : this.setTitle(title);
+	}
+
+	/**
 	 *Set the color of the embed to the error color
 	 */
 	setErrorColor(): this {

--- a/Discord/src/utils/KeycloakPlayerUtils.ts
+++ b/Discord/src/utils/KeycloakPlayerUtils.ts
@@ -1,8 +1,11 @@
 import { Language } from "../../../Lib/src/Language";
 import i18n from "../translations/i18n";
 import { KeycloakUtils } from "../../../Lib/src/keycloak/KeycloakUtils";
-import { keycloakConfig } from "../bot/CrowniclesShard";
+import {
+	crowniclesClient, keycloakConfig
+} from "../bot/CrowniclesShard";
 import { escapeUsername } from "./StringUtils";
+import { User } from "discord.js";
 
 /**
  * Resolve a keycloak ID to a player display name, with a fallback for unknown players
@@ -16,4 +19,22 @@ export async function resolveKeycloakPlayerName(keycloakId: string | undefined |
 		return escapeUsername(getUser.payload.user.attributes.gameUsername[0]);
 	}
 	return i18n.t("error:unknownPlayer", { lng });
+}
+
+/**
+ * Resolve a keycloak ID to its Discord user (for avatar display), or null if it cannot be found
+ */
+export async function resolveKeycloakDiscordUser(keycloakId: string | undefined | null): Promise<User | null> {
+	if (!keycloakId) {
+		return null;
+	}
+	const getUser = await KeycloakUtils.getUserByKeycloakId(keycloakConfig, keycloakId);
+	if (getUser.isError) {
+		return null;
+	}
+	const discordId = getUser.payload.user.attributes.discordId?.[0];
+	if (!discordId || discordId === "0") {
+		return null;
+	}
+	return crowniclesClient.users.cache.get(discordId) ?? await crowniclesClient.users.fetch(discordId).catch(() => null);
 }

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -606,15 +606,15 @@
     "seeBackupItems": "{emote:inventory.stock} Réserve",
     "seeEquippedItems": "{emote:commands.inventory} Équipement",
     "seeMaterials": "{emote:inventory.materials} Matériaux",
-    "stockTitle": "{emote:inventory.stock} **Réserve d'objets de {{pseudo}}**",
-    "title": "{emote:commands.inventory} **Inventaire de {{pseudo}}**",
-    "materialsTitle": "{emote:inventory.materials} **Matériaux de {{pseudo}}**",
+    "stockTitle": "Réserve d'objets de {{pseudo}}",
+    "title": "Inventaire de {{pseudo}}",
+    "materialsTitle": "Matériaux de {{pseudo}}",
     "materialsField_zero": "Matériaux (0) :",
     "materialsField_one": "Matériau ({{count}}) :",
     "materialsField_other": "Matériaux ({{count}}) :",
     "noMaterials": "{emote:inventory.empty} **Aucun matériau**",
     "seePlants": "{emote:city.homeUpgrades.garden} Plantes",
-    "plantsTitle": "{emote:city.homeUpgrades.garden} **Plantes de {{pseudo}}**",
+    "plantsTitle": "Plantes de {{pseudo}}",
     "plantsField_zero": "Plante (0) :",
     "plantsField_one": "Plante ({{count}}) :",
     "plantsField_other": "Plantes ({{count}}) :",
@@ -768,7 +768,7 @@
       "fieldName": "Temps restant :",
       "fieldValue": "{emote:effects.{{effectId}}} {{timeLeft}}"
     },
-    "title": "{emote:effects.{{effectId}}} | {{pseudo}} | Niveau {{level, number}}"
+    "title": "{{pseudo}} | Niveau {{level, number}}"
   },
   "rarity": {
     "earlyAvailable": "Possédé en début de jeu",

--- a/Lib/src/CrowniclesIcons.ts
+++ b/Lib/src/CrowniclesIcons.ts
@@ -2646,7 +2646,7 @@ export const CrowniclesIcons: {
 		"❌",
 		"❤️",
 		"🚀",
-		"⚔️",
+		"🗡️",
 		"🛡️",
 		"🕥",
 		"💰",


### PR DESCRIPTION
## Résumé

Cette PR corrige deux tickets liés à l'affichage :

### #4316 — Incohérence d'émoji de la stat attaque (🗡️ vs ⚔️)
La stat « attaque » utilisait 🗡️ pour les armes/armures (`unitValues.attack`) mais ⚔️ pour les potions/objets (`itemNatures[3]`). Alignement de `itemNatures[3]` sur 🗡️ (l'icône utilisée partout ailleurs : combats, profil, stats d'armes). Le correctif est dans le code (`CrowniclesIcons`), donc appliqué à toutes les langues.

### #4241 — Avatar incohérent (`/familier` affichait la PP de l'appelant au lieu du joueur ciblé)
Audit de **tous** les `formatAuthor` des commandes. Principe : quand l'auteur nomme un joueur, l'avatar doit être celui de ce joueur.

Corrections :
- **`/familier`** : affiche désormais l'avatar du joueur ciblé (bug d'origine du ticket).
- **`/unlock`** : le titre « Libération de X » affiche l'avatar du joueur libéré.
- **`/profile`** et **`/inventaire`** : ajout de l'avatar du joueur ciblé (en ligne auteur, comme `/missions`). Émojis/gras retirés des titres FR concernés car ils ne se rendent pas en ligne auteur.

Nouveau helper réutilisable `resolveKeycloakDiscordUser(keycloakId)` (résout l'objet `User` Discord depuis un keycloakId) pour éviter la duplication.

## Notes
- Seules les traductions **françaises** ont été modifiées (les autres langues sont synchronisées depuis le FR via Crowdin).
- `effectId` reste passé au titre du profil pour ne pas casser le rendu des langues non-FR en attendant la synchro.

## Tests
- ESLint vert sur Lib et Discord.
- Aucune erreur TypeScript.

Closes #4316
Closes #4241
