### PR TITLE
Affiche les limites d'achat chez le marchand de jetons

### DIFF
--- a/Discord/src/commands/player/report/tokenMerchant/TokenMerchantHandlers.ts
+++ b/Discord/src/commands/player/report/tokenMerchant/TokenMerchantHandlers.ts
@@ -17,6 +17,7 @@ import {
 import { sendInteractionNotForYou } from "../../../../utils/ErrorUtils";
 import { ReactionCollectorReturnTypeOrNull } from "../../../../packetHandlers/handlers/ReactionCollectorHandlers";
 import { Language } from "../../../../../../Lib/src/Language";
+import { ShopConstants } from "../../../../../../Lib/src/constants/ShopConstants";
 import i18n from "../../../../translations/i18n";
 import { escapeUsername } from "../../../../utils/StringUtils";
 
@@ -40,7 +41,9 @@ function buildMerchantEmbed(
 			lng,
 			pricePerToken: data.pricePerToken,
 			playerMoney: data.playerMoney,
-			playerTokens: data.playerTokens
+			playerTokens: data.playerTokens,
+			maxDaily: ShopConstants.MAX_DAILY_TOKEN_BUYOUTS,
+			maxWeekly: ShopConstants.MAX_WEEKLY_TOKEN_BUYOUTS
 		}));
 }
 

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -1453,7 +1453,7 @@
     "tokensUsedRefusedDescription": "{emote:messages.refuse} Vous avez décidé de conserver vos jetons.",
     "tokenMerchant": {
       "title": "{{pseudo}}, un marchand de jetons",
-      "description": "{emote:unitValues.token} Alors que vous fouillez vos poches à la recherche de jetons, un marchand ambulant surgit au détour du chemin. Il étale devant vous une bourse pleine de jetons scintillants, prêts à être échangés contre quelques pièces d'or.\n\n{emote:unitValues.money} **Votre or** : {{playerMoney, number}}\n{emote:unitValues.token} **Vos jetons** : {{playerTokens, number}}\n\nChaque jeton vous coûtera **{{pricePerToken, number}}** {emote:unitValues.money}.",
+      "description": "{emote:unitValues.token} Alors que vous fouillez vos poches à la recherche de jetons, un marchand ambulant surgit au détour du chemin. Il étale devant vous une bourse pleine de jetons scintillants, prêts à être échangés contre quelques pièces d'or.\n\n{emote:unitValues.money} **Votre or** : {{playerMoney, number}}\n{emote:unitValues.token} **Vos jetons** : {{playerTokens, number}}\n\nChaque jeton vous coûtera **{{pricePerToken, number}}** {emote:unitValues.money}.\n\n{emote:collectors.warning} Vous pouvez en acheter jusqu'à {{maxDaily, number}} par jour et {{maxWeekly, number}} par semaine.",
       "buyButton_one": "Acheter {{count}} jeton — {{price, number}} or",
       "buyButton_other": "Acheter {{count}} jetons — {{price, number}} or",
       "refuseButton": "Ne rien acheter",


### PR DESCRIPTION
Fixes #4353

## Problème
Le marchand de jetons de `/report` (qui apparaît quand on manque de jetons) n'indiquait pas les limites d'achat, contrairement au magasin V5.

## Correctif
La description mentionne désormais les plafonds, passés en paramètres i18n depuis `ShopConstants` (`MAX_DAILY_TOKEN_BUYOUTS` = 10, `MAX_WEEKLY_TOKEN_BUYOUTS` = 30), avec l'émoji d'avertissement en interpolation.

## Cause racine
Fonctionnalité V6 neuve (#4340) : la précision présente dans le magasin V5 n'y avait jamais été portée.

Fichiers : `Lang/fr/commands.json`, `Discord/.../tokenMerchant/TokenMerchantHandlers.ts`.

_Note : une erreur `tsc` préexistante (TS2589 dans `Discord/src/translations/i18n.ts`) est présente sur `develop` indépendamment de ce changement._
