### PR TITLE
Reconnaît le dragon dans l'affinité feu du jardinier

### DIFF
--- a/Core/resources/pets/64.json
+++ b/Core/resources/pets/64.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 30,
   "feedDelay": 10,
-  "speed": 25
+  "speed": 25,
+  "tags": ["fire"]
 }

--- a/Core/resources/pets/83.json
+++ b/Core/resources/pets/83.json
@@ -2,5 +2,6 @@
   "rarity": 7,
   "force": 30,
   "feedDelay": 10,
-  "speed": 30
+  "speed": 30,
+  "tags": ["fire"]
 }

--- a/Core/src/core/smallEvents/gardener.ts
+++ b/Core/src/core/smallEvents/gardener.ts
@@ -318,11 +318,14 @@ async function checkFireAffinityCondition(player: Player): Promise<SeedCondition
 	}
 
 	const petEntity = await getOwnedPet(player);
-	if (petEntity?.typeId === PetConstants.PETS.PHOENIX) {
-		return {
-			canObtain: true,
-			conditionKey: SEED_CONDITION_SUCCESS.PHOENIX
-		};
+	if (petEntity) {
+		const petData = PetDataController.instance.getById(petEntity.typeId);
+		if (petData?.tags?.includes(PetConstants.TAGS.FIRE)) {
+			return {
+				canObtain: true,
+				conditionKey: SEED_CONDITION_SUCCESS.FIRE_PET
+			};
+		}
 	}
 
 	const equippedSlots = [

--- a/Core/src/core/smallEvents/gardener.ts
+++ b/Core/src/core/smallEvents/gardener.ts
@@ -309,6 +309,24 @@ async function checkHerbivorePetCondition(player: Player, requireLegendary: bool
 	};
 }
 
+async function hasFireAffinityPet(player: Player): Promise<boolean> {
+	const petEntity = await getOwnedPet(player);
+	if (!petEntity) {
+		return false;
+	}
+	const petData = PetDataController.instance.getById(petEntity.typeId);
+	return Boolean(petData?.tags?.includes(PetConstants.TAGS.FIRE));
+}
+
+async function hasFireAffinityItem(player: Player): Promise<boolean> {
+	const equippedSlots = [
+		await InventorySlots.getMainWeaponSlot(player.id),
+		await InventorySlots.getMainArmorSlot(player.id),
+		await InventorySlots.getMainObjectSlot(player.id)
+	];
+	return equippedSlots.some(slot => slot?.getItem()?.tags?.includes(ItemConstants.TAGS.FIRE));
+}
+
 async function checkFireAffinityCondition(player: Player): Promise<SeedConditionResult> {
 	if (player.class === ClassConstants.CLASSES_ID.MYSTIC_MAGE) {
 		return {
@@ -317,30 +335,18 @@ async function checkFireAffinityCondition(player: Player): Promise<SeedCondition
 		};
 	}
 
-	const petEntity = await getOwnedPet(player);
-	if (petEntity) {
-		const petData = PetDataController.instance.getById(petEntity.typeId);
-		if (petData?.tags?.includes(PetConstants.TAGS.FIRE)) {
-			return {
-				canObtain: true,
-				conditionKey: SEED_CONDITION_SUCCESS.FIRE_PET
-			};
-		}
+	if (await hasFireAffinityPet(player)) {
+		return {
+			canObtain: true,
+			conditionKey: SEED_CONDITION_SUCCESS.FIRE_PET
+		};
 	}
 
-	const equippedSlots = [
-		await InventorySlots.getMainWeaponSlot(player.id),
-		await InventorySlots.getMainArmorSlot(player.id),
-		await InventorySlots.getMainObjectSlot(player.id)
-	];
-
-	for (const slot of equippedSlots) {
-		if (slot?.getItem()?.tags?.includes(ItemConstants.TAGS.FIRE)) {
-			return {
-				canObtain: true,
-				conditionKey: SEED_CONDITION_SUCCESS.FIRE_ITEM
-			};
-		}
+	if (await hasFireAffinityItem(player)) {
+		return {
+			canObtain: true,
+			conditionKey: SEED_CONDITION_SUCCESS.FIRE_ITEM
+		};
 	}
 
 	return {

--- a/Lang/fr/smallEvents.json
+++ b/Lang/fr/smallEvents.json
@@ -2782,7 +2782,7 @@
         ],
         "needFireAffinity": [
           "Théobald secoue la tête. La prochaine graine nécessite une affinité avec le feu. Il vous faudrait être **mage**, posséder un **familier lié au feu** ou porter un **équipement forgé dans les flammes**.",
-          "Le jardinier vous regarde pensivement. Cette graine ardente ne peut être cultivée que par quelqu'un lié au feu : un **mage**, un maître de **familier igné**, ou un porteur d'**arme enflammée**."
+          "Le jardinier vous regarde pensivement. Cette graine ardente ne peut être cultivée que par quelqu'un lié au feu : un **mage**, un maître de **familier des flammes**, ou un porteur d'**arme enflammée**."
         ],
         "needCarnivorePet": [
           "Le jardinier vous explique que la prochaine graine nécessite un compagnon carnivore particulièrement puissant. Il vous faudrait un **familier carnivore de rareté épique ou supérieure**.",

--- a/Lang/fr/smallEvents.json
+++ b/Lang/fr/smallEvents.json
@@ -2742,8 +2742,8 @@
         "mage": [
           "Théobald remarque votre aura de mage et hoche la tête avec respect. Votre maîtrise de la magie saura faire prospérer cette plante ardente, dit-il en vous confiant une **graine** {emote:smallEvents.gardener}."
         ],
-        "phoenix": [
-          "Le jardinier écarquille les yeux devant votre phénix et s'exclame qu'il n'en avait pas vu depuis des décennies. Il vous confie avec émotion une **graine** {emote:smallEvents.gardener}, convaincu que les flammes de votre compagnon l'aideront à grandir."
+        "firePet": [
+          "Le jardinier écarquille les yeux devant votre familier au souffle ardent et s'exclame qu'il n'en avait pas vu depuis des décennies. Il vous confie avec émotion une **graine** {emote:smallEvents.gardener}, convaincu que les flammes de votre compagnon l'aideront à grandir."
         ],
         "fireItem": [
           "Théobald repère votre équipement forgé dans le feu et acquiesce. L'affinité avec les flammes est essentielle pour cultiver cette plante ardente, explique-t-il en vous offrant une **graine** {emote:smallEvents.gardener}."
@@ -2781,8 +2781,8 @@
           "Théobald scrute le firmament en plissant les yeux. Cette graine exige un **puissant clair de lune** pour être offerte. Revenez lors d'une nuit plus lumineuse."
         ],
         "needFireAffinity": [
-          "Théobald secoue la tête. La prochaine graine nécessite une affinité avec le feu. Il vous faudrait être **mage**, posséder un **phénix** ou porter un **équipement forgé dans les flammes**.",
-          "Le jardinier vous regarde pensivement. Cette graine ardente ne peut être cultivée que par quelqu'un lié au feu : un **mage**, un maître de **phénix**, ou un porteur d'**arme enflammée**."
+          "Théobald secoue la tête. La prochaine graine nécessite une affinité avec le feu. Il vous faudrait être **mage**, posséder un **familier lié au feu** ou porter un **équipement forgé dans les flammes**.",
+          "Le jardinier vous regarde pensivement. Cette graine ardente ne peut être cultivée que par quelqu'un lié au feu : un **mage**, un maître de **familier igné**, ou un porteur d'**arme enflammée**."
         ],
         "needCarnivorePet": [
           "Le jardinier vous explique que la prochaine graine nécessite un compagnon carnivore particulièrement puissant. Il vous faudrait un **familier carnivore de rareté épique ou supérieure**.",

--- a/Lib/src/constants/PetConstants.ts
+++ b/Lib/src/constants/PetConstants.ts
@@ -622,6 +622,8 @@ export abstract class PetConstants {
 		5
 	];
 
+	static readonly TAGS = { FIRE: "fire" } as const;
+
 	static readonly FLYING_PETS = [
 		PetConstants.PETS.BIRD,
 		PetConstants.PETS.DUCK,

--- a/Lib/src/constants/PlantConstants.ts
+++ b/Lib/src/constants/PlantConstants.ts
@@ -45,7 +45,7 @@ export const SEED_CONDITION_SUCCESS = {
 	HERBIVORE_PET: "herbivorePet",
 	LEGENDARY_HERBIVORE_PET: "legendaryHerbivorePet",
 	MAGE: "mage",
-	PHOENIX: "phoenix",
+	FIRE_PET: "firePet",
 	FIRE_ITEM: "fireItem",
 	CARNIVORE_PET: "carnivorePet"
 } as const;


### PR DESCRIPTION
Fixes #4354

## Problème
Le mini-event du jardinier n'acceptait que le phénix comme familier « affinité feu » ; le dragon (igné) ne comptait pas.

## Correctif
Approche par data-tag (conforme au review-checklist « data tags over hardcoded ID lists ») :
- ajout de `PetConstants.TAGS.FIRE`,
- tag `"fire"` sur les familiers dragon (`64.json`) et phénix (`83.json`),
- `checkFireAffinityCondition` détecte l'affinité via le tag du familier au lieu de l'ID phénix codé en dur,
- clé de condition renommée `phoenix` -> `firePet` et textes FR généralisés (n'importe quel familier lié au feu).

## Cause racine
Le check a toujours été phénix-only depuis l'implémentation du plant shop (#4082) ; les familiers n'avaient aucun système de tag d'affinité.
