### PR TITLE
Stabilise la recette épinglée du fourneau (relance + désépinglage)

### DIFF
--- a/Core/__tests__/core/cooking/CookingService.test.ts
+++ b/Core/__tests__/core/cooking/CookingService.test.ts
@@ -181,13 +181,22 @@ describe("CookingService - pure functions", () => {
 			expect(ids).toContain("potion_health_1");
 		});
 
-		it("should be a no-op when pinned recipe is already present", () => {
-			const existing = { id: "potion_health_1" } as CookingRecipe;
-			const slots: Array<CookingRecipe | null> = [existing, null, null];
-			inject(slots, { pinnedCookingRecipeId: "potion_health_1" }, [], null, 3);
-			expect(slots[0]).toBe(existing);
-			expect(slots[1]).toBe(null);
-			expect(slots[2]).toBe(null);
+it("should anchor the pinned recipe to a stable slot regardless of any pre-existing occurrence", () => {
+				// Reference placement on empty slots gives the deterministic anchor slot.
+				const emptySlots: Array<CookingRecipe | null> = [null, null, null];
+				inject(emptySlots, { pinnedCookingRecipeId: "potion_health_1" }, [], null, 3);
+				const anchorIndex = emptySlots.findIndex(r => r?.id === "potion_health_1");
+				expect(anchorIndex).not.toBe(-1);
+
+				// A natural occurrence in another slot must be moved to the anchor, appearing exactly once.
+				const existing = { id: "potion_health_1" } as CookingRecipe;
+				const otherIndex = anchorIndex === 2 ? 1 : 2;
+				const slots: Array<CookingRecipe | null> = [null, null, null];
+				slots[otherIndex] = existing;
+				inject(slots, { pinnedCookingRecipeId: "potion_health_1" }, [], null, 3);
+
+				expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
+				expect(slots.findIndex(r => r?.id === "potion_health_1")).toBe(anchorIndex);
 		});
 
 		it("should be a no-op when player has no pinned recipe", () => {

--- a/Core/__tests__/core/cooking/CookingService.test.ts
+++ b/Core/__tests__/core/cooking/CookingService.test.ts
@@ -165,43 +165,52 @@ describe("CookingService - pure functions", () => {
 	describe("injectPinnedRecipeIfEligible", () => {
 		// Access the private static helper for direct unit testing
 		const inject = (CookingService as unknown as {
-			injectPinnedRecipeIfEligible: (
-				slotRecipes: Array<CookingRecipe | null>,
-				player: { pinnedCookingRecipeId: string | null },
-				discoveredIds: string[],
-				guild: unknown,
-				cookingSlots: number
-			) => void;
+			injectPinnedRecipeIfEligible: (injection: {
+				slotRecipes: Array<CookingRecipe | null>;
+				player: { pinnedCookingRecipeId: string | null };
+				discoveredIds: string[];
+				guild: unknown;
+				cookingSlots: number;
+			}) => void;
 		}).injectPinnedRecipeIfEligible.bind(CookingService);
+
+		const injectPotion = (slotRecipes: Array<CookingRecipe | null>, pinnedCookingRecipeId: string | null): void =>
+			inject({
+				slotRecipes,
+				player: { pinnedCookingRecipeId },
+				discoveredIds: [],
+				guild: null,
+				cookingSlots: 3
+			});
 
 		it("should inject a pinned potion into an eligible slot when not already present", () => {
 			const slots: Array<CookingRecipe | null> = [null, null, null];
-			inject(slots, { pinnedCookingRecipeId: "potion_health_1" }, [], null, 3);
+			injectPotion(slots, "potion_health_1");
 			const ids = slots.filter((r): r is CookingRecipe => r !== null).map(r => r.id);
 			expect(ids).toContain("potion_health_1");
 		});
 
-it("should anchor the pinned recipe to a stable slot regardless of any pre-existing occurrence", () => {
-				// Reference placement on empty slots gives the deterministic anchor slot.
-				const emptySlots: Array<CookingRecipe | null> = [null, null, null];
-				inject(emptySlots, { pinnedCookingRecipeId: "potion_health_1" }, [], null, 3);
-				const anchorIndex = emptySlots.findIndex(r => r?.id === "potion_health_1");
-				expect(anchorIndex).not.toBe(-1);
+		it("should anchor the pinned recipe to a stable slot regardless of any pre-existing occurrence", () => {
+			// Reference placement on empty slots gives the deterministic anchor slot.
+			const emptySlots: Array<CookingRecipe | null> = [null, null, null];
+			injectPotion(emptySlots, "potion_health_1");
+			const anchorIndex = emptySlots.findIndex(r => r?.id === "potion_health_1");
+			expect(anchorIndex).not.toBe(-1);
 
-				// A natural occurrence in another slot must be moved to the anchor, appearing exactly once.
-				const existing = { id: "potion_health_1" } as CookingRecipe;
-				const otherIndex = anchorIndex === 2 ? 1 : 2;
-				const slots: Array<CookingRecipe | null> = [null, null, null];
-				slots[otherIndex] = existing;
-				inject(slots, { pinnedCookingRecipeId: "potion_health_1" }, [], null, 3);
+			// A natural occurrence in another slot must be moved to the anchor, appearing exactly once.
+			const existing = { id: "potion_health_1" } as CookingRecipe;
+			const otherIndex = anchorIndex === 2 ? 1 : 2;
+			const slots: Array<CookingRecipe | null> = [null, null, null];
+			slots[otherIndex] = existing;
+			injectPotion(slots, "potion_health_1");
 
-				expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
-				expect(slots.findIndex(r => r?.id === "potion_health_1")).toBe(anchorIndex);
+			expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
+			expect(slots.findIndex(r => r?.id === "potion_health_1")).toBe(anchorIndex);
 		});
 
 		it("should be a no-op when player has no pinned recipe", () => {
 			const slots: Array<CookingRecipe | null> = [null, null, null];
-			inject(slots, { pinnedCookingRecipeId: null }, [], null, 3);
+			injectPotion(slots, null);
 			expect(slots.every(s => s === null)).toBe(true);
 		});
 	});

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -82,6 +82,19 @@ interface CookingLevelUpResult {
 	newGrade?: string;
 }
 
+/**
+ * Everything needed to inject the player's pinned recipe into the current
+ * furnace slots. Grouped into a single domain object to keep the pinned-recipe
+ * helpers free of loose primitive arguments.
+ */
+interface PinnedRecipeInjection {
+	slotRecipes: (CookingRecipe | null)[];
+	player: Player;
+	discoveredIds: string[];
+	guild: Guild | null;
+	cookingSlots: number;
+}
+
 export class CookingService {
 	static canStorePetFoodReward(recipe: CookingRecipe, guild: Guild | null): boolean {
 		if (recipe.outputType !== CookingOutputType.PET_FOOD) {
@@ -174,7 +187,9 @@ export class CookingService {
 			maxRecipeLevelWithoutPenalty: grade.maxRecipeLevelWithoutPenalty
 		});
 
-		CookingService.injectPinnedRecipeIfEligible(slotRecipes, player, discoveredIds, guild, cookingSlots);
+		CookingService.injectPinnedRecipeIfEligible({
+			slotRecipes, player, discoveredIds, guild, cookingSlots
+		});
 
 		// Load all plant storages once to avoid N+1 queries
 		const allPlantStorages = await HomePlantStorages.getOfHome(homeId);
@@ -515,11 +530,9 @@ export class CookingService {
 	 * Resolve the player's pinned recipe, or null when there is no pin or it is
 	 * not currently eligible (unknown, undiscovered, or pet food without a guild).
 	 */
-	private static getEligiblePinnedRecipe(
-		player: Player,
-		discoveredIds: string[],
-		guild: Guild | null
-	): CookingRecipe | null {
+	private static getEligiblePinnedRecipe({
+		player, discoveredIds, guild
+	}: PinnedRecipeInjection): CookingRecipe | null {
 		if (!player.pinnedCookingRecipeId) {
 			return null;
 		}
@@ -533,27 +546,22 @@ export class CookingService {
 	}
 
 	/**
-	 * Deterministic index of the first slot compatible with the pinned recipe,
-	 * or -1 when none of the available slots can host it.
+	 * Anchor the pinned recipe to a deterministic slot so its position stays
+	 * stable across furnace re-rolls, dropping any natural occurrence the
+	 * rotation placed in another slot so it never appears twice. No-op when no
+	 * available slot can host the recipe.
 	 */
-	private static findPinnedSlotIndex(pinnedRecipe: CookingRecipe, cookingSlots: number): number {
-		return SLOT_CONFIGS.findIndex((config, idx) =>
+	private static anchorPinnedRecipe({
+		slotRecipes, cookingSlots
+	}: PinnedRecipeInjection, pinnedRecipe: CookingRecipe): void {
+		const compatibleSlotIndex = SLOT_CONFIGS.findIndex((config, idx) =>
 			idx < cookingSlots
 			&& pinnedRecipe.level >= config.minLevel
 			&& pinnedRecipe.level <= config.maxLevel
 			&& config.eligibleTypes.includes(pinnedRecipe.recipeType));
-	}
-
-	/**
-	 * Anchor the pinned recipe to a deterministic slot so its position stays
-	 * stable across furnace re-rolls, dropping any natural occurrence the
-	 * rotation placed in another slot so it never appears twice.
-	 */
-	private static anchorPinnedRecipe(
-		slotRecipes: (CookingRecipe | null)[],
-		pinnedRecipe: CookingRecipe,
-		compatibleSlotIndex: number
-	): void {
+		if (compatibleSlotIndex === -1) {
+			return;
+		}
 		for (let i = 0; i < slotRecipes.length; i++) {
 			if (i !== compatibleSlotIndex && slotRecipes[i]?.id === pinnedRecipe.id) {
 				slotRecipes[i] = null;
@@ -565,22 +573,12 @@ export class CookingService {
 	/**
 	 * Inject the player's pinned recipe into slot recipes if it is eligible for at least one slot
 	 */
-	private static injectPinnedRecipeIfEligible(
-		slotRecipes: (CookingRecipe | null)[],
-		player: Player,
-		discoveredIds: string[],
-		guild: Guild | null,
-		cookingSlots: number
-	): void {
-		const pinnedRecipe = CookingService.getEligiblePinnedRecipe(player, discoveredIds, guild);
+	private static injectPinnedRecipeIfEligible(injection: PinnedRecipeInjection): void {
+		const pinnedRecipe = CookingService.getEligiblePinnedRecipe(injection);
 		if (!pinnedRecipe) {
 			return;
 		}
-		const compatibleSlotIndex = CookingService.findPinnedSlotIndex(pinnedRecipe, cookingSlots);
-		if (compatibleSlotIndex === -1) {
-			return;
-		}
-		CookingService.anchorPinnedRecipe(slotRecipes, pinnedRecipe, compatibleSlotIndex);
+		CookingService.anchorPinnedRecipe(injection, pinnedRecipe);
 	}
 
 	/**

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -512,6 +512,57 @@ export class CookingService {
 	}
 
 	/**
+	 * Resolve the player's pinned recipe, or null when there is no pin or it is
+	 * not currently eligible (unknown, undiscovered, or pet food without a guild).
+	 */
+	private static getEligiblePinnedRecipe(
+		player: Player,
+		discoveredIds: string[],
+		guild: Guild | null
+	): CookingRecipe | null {
+		if (!player.pinnedCookingRecipeId) {
+			return null;
+		}
+		const pinnedRecipe = CookingRecipeDataController.instance.getById(player.pinnedCookingRecipeId);
+		if (!pinnedRecipe) {
+			return null;
+		}
+		const isDiscovered = pinnedRecipe.discoveredByDefault || discoveredIds.includes(pinnedRecipe.id);
+		const isPetFoodAllowed = pinnedRecipe.outputType !== CookingOutputType.PET_FOOD || Boolean(guild);
+		return isDiscovered && isPetFoodAllowed ? pinnedRecipe : null;
+	}
+
+	/**
+	 * Deterministic index of the first slot compatible with the pinned recipe,
+	 * or -1 when none of the available slots can host it.
+	 */
+	private static findPinnedSlotIndex(pinnedRecipe: CookingRecipe, cookingSlots: number): number {
+		return SLOT_CONFIGS.findIndex((config, idx) =>
+			idx < cookingSlots
+			&& pinnedRecipe.level >= config.minLevel
+			&& pinnedRecipe.level <= config.maxLevel
+			&& config.eligibleTypes.includes(pinnedRecipe.recipeType));
+	}
+
+	/**
+	 * Anchor the pinned recipe to a deterministic slot so its position stays
+	 * stable across furnace re-rolls, dropping any natural occurrence the
+	 * rotation placed in another slot so it never appears twice.
+	 */
+	private static anchorPinnedRecipe(
+		slotRecipes: (CookingRecipe | null)[],
+		pinnedRecipe: CookingRecipe,
+		compatibleSlotIndex: number
+	): void {
+		for (let i = 0; i < slotRecipes.length; i++) {
+			if (i !== compatibleSlotIndex && slotRecipes[i]?.id === pinnedRecipe.id) {
+				slotRecipes[i] = null;
+			}
+		}
+		slotRecipes[compatibleSlotIndex] = pinnedRecipe;
+	}
+
+	/**
 	 * Inject the player's pinned recipe into slot recipes if it is eligible for at least one slot
 	 */
 	private static injectPinnedRecipeIfEligible(
@@ -521,38 +572,15 @@ export class CookingService {
 		guild: Guild | null,
 		cookingSlots: number
 	): void {
-		if (!player.pinnedCookingRecipeId) {
-			return;
-		}
-		const pinnedRecipe = CookingRecipeDataController.instance.getById(player.pinnedCookingRecipeId);
+		const pinnedRecipe = CookingService.getEligiblePinnedRecipe(player, discoveredIds, guild);
 		if (!pinnedRecipe) {
 			return;
 		}
-		const isDiscovered = pinnedRecipe.discoveredByDefault || discoveredIds.includes(pinnedRecipe.id);
-		const isPetFoodAllowed = pinnedRecipe.outputType !== CookingOutputType.PET_FOOD || Boolean(guild);
-		if (!isDiscovered || !isPetFoodAllowed) {
-			return;
-		}
-		const compatibleSlotIndex = SLOT_CONFIGS.findIndex((config, idx) =>
-			idx < cookingSlots
-			&& pinnedRecipe.level >= config.minLevel
-			&& pinnedRecipe.level <= config.maxLevel
-			&& config.eligibleTypes.includes(pinnedRecipe.recipeType));
+		const compatibleSlotIndex = CookingService.findPinnedSlotIndex(pinnedRecipe, cookingSlots);
 		if (compatibleSlotIndex === -1) {
 			return;
 		}
-
-		/*
-		 * Anchor the pinned recipe to a deterministic slot so its position stays
-		 * stable across furnace re-rolls, and drop any natural occurrence the
-		 * rotation placed in another slot so it never appears twice.
-		 */
-		for (let i = 0; i < slotRecipes.length; i++) {
-			if (i !== compatibleSlotIndex && slotRecipes[i]?.id === pinnedRecipe.id) {
-				slotRecipes[i] = null;
-			}
-		}
-		slotRecipes[compatibleSlotIndex] = pinnedRecipe;
+		CookingService.anchorPinnedRecipe(slotRecipes, pinnedRecipe, compatibleSlotIndex);
 	}
 
 	/**

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -524,9 +524,6 @@ export class CookingService {
 		if (!player.pinnedCookingRecipeId) {
 			return;
 		}
-		if (slotRecipes.some(r => r?.id === player.pinnedCookingRecipeId)) {
-			return;
-		}
 		const pinnedRecipe = CookingRecipeDataController.instance.getById(player.pinnedCookingRecipeId);
 		if (!pinnedRecipe) {
 			return;
@@ -541,9 +538,21 @@ export class CookingService {
 			&& pinnedRecipe.level >= config.minLevel
 			&& pinnedRecipe.level <= config.maxLevel
 			&& config.eligibleTypes.includes(pinnedRecipe.recipeType));
-		if (compatibleSlotIndex !== -1) {
-			slotRecipes[compatibleSlotIndex] = pinnedRecipe;
+		if (compatibleSlotIndex === -1) {
+			return;
 		}
+
+		/*
+		 * Anchor the pinned recipe to a deterministic slot so its position stays
+		 * stable across furnace re-rolls, and drop any natural occurrence the
+		 * rotation placed in another slot so it never appears twice.
+		 */
+		for (let i = 0; i < slotRecipes.length; i++) {
+			if (i !== compatibleSlotIndex && slotRecipes[i]?.id === pinnedRecipe.id) {
+				slotRecipes[i] = null;
+			}
+		}
+		slotRecipes[compatibleSlotIndex] = pinnedRecipe;
 	}
 
 	/**

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -1014,6 +1014,21 @@ export async function handleCookingUnpin(
 		player, home, cookingSlots
 	} = data;
 
+	/*
+	 * Snapshot the currently displayed slots while the pin is still active,
+	 * so the formerly pinned recipe keeps its slot until the next furnace
+	 * re-roll instead of being immediately swapped for the natural rotation
+	 * recipe (only its "pinned" status is removed).
+	 */
+	let currentSlots: CookingSlotData[] | undefined;
+	if (packet.fromIgnitedView) {
+		currentSlots = await CookingService.getSlotRecipes({
+			player,
+			homeId: home.id,
+			cookingSlots
+		});
+	}
+
 	await Player.withLocked(player.id, async lockedPlayer => {
 		lockedPlayer.pinnedCookingRecipeId = null;
 		await lockedPlayer.save();
@@ -1021,7 +1036,7 @@ export async function handleCookingUnpin(
 	player.pinnedCookingRecipeId = null;
 
 	const menu = await buildCookingMenuSnapshot({
-		player, home, cookingSlots, isIgnited: packet.fromIgnitedView
+		player, home, cookingSlots, isIgnited: packet.fromIgnitedView, currentSlots
 	});
 	response.push(makePacket(CommandReportCookingUnpinRes, { menu }));
 	return response;


### PR DESCRIPTION
Fixes #4357

## Problèmes (2)
1. La recette épinglée changeait de slot (âtre <-> chaudron) entre deux relances du fourneau.
2. Désépingler remplaçait immédiatement la recette par une autre aléatoire, sans relance.

## Cause racine
`injectPinnedRecipeIfEligible` faisait un early-return quand la rotation naturelle contenait déjà la recette (la laissant à une position aléatoire), sinon la forçait au premier slot compatible -> position instable. Au désépinglage, le slot révélait la recette naturelle écrasée -> effet « remplacée ».

## Correctif
- **Bug 1** : la recette épinglée est ancrée à un slot déterministe (premier slot compatible) et dédupliquée des autres slots -> position stable quelle que soit `furnacePosition`.
- **Bug 2** : `handleCookingUnpin` capture les slots affichés pendant que l'épinglage est encore actif et les réutilise après retrait du pin -> la recette reste en place jusqu'à la prochaine relance, seul le statut « épinglé » disparaît.

## Tests
Test unitaire `injectPinnedRecipeIfEligible` remplacé : vérifie l'ancrage stable + déduplication (non-tautologique). 66 tests cuisine verts.
