### PR TITLE
Corrige la description de La Bourse (Claire de Ville)

### DIFF
--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -888,7 +888,7 @@
         },
         "stockExchange": {
           "label": "La Bourse",
-          "description": "Des gemmes de toutes tailles scintillent derrière les vitrines. On y échange pierres précieuses contre objets de prestige."
+          "description": "Des courtiers s'affairent devant de grands tableaux de cours en perpétuel mouvement. On peut y acquérir un prestigieux badge de fortune ou commander une étude de marché anticipant les tendances de l'argent du roi et des prix des plantes."
         },
         "tanner": {
           "label": "Le Tanneur",


### PR DESCRIPTION
Fixes #4358

## Problème
La description de « La Bourse » (Claire de Ville) parlait d'échange de gemmes, alors que ce bâtiment donne le badge « Money Mouth » et permet une étude de marché.

## Correctif
Réécriture de la description FR (`stockExchange.description`) pour refléter le vrai comportement (badge de prestige + étude de marché des tendances de l'argent du roi et des prix des plantes).

## Cause racine
Une réécriture de flavour text a confondu La Bourse avec le Marché royal (échange de gemmes), contaminant la description voisine.
