### PR TITLE
La vente d'un familier ne valide plus la mission de dépôt

### DIFF
--- a/Core/src/commands/pet/PetSellCommand.ts
+++ b/Core/src/commands/pet/PetSellCommand.ts
@@ -226,7 +226,6 @@ async function executePetSell(collector: ReactionCollectorInstance, response: Cr
 	// Update missions on the now-committed instances
 	await MissionsController.update(buyer, response, { missionId: "havePet" });
 	await MissionsController.update(sellerInformation.player, response, { missionId: "sellOrTradePet" });
-	await MissionsController.update(sellerInformation.player, response, { missionId: "depositPetInShelter" });
 
 	// Success packet
 	response.push(makePacket(CommandPetSellSuccessPacket, {


### PR DESCRIPTION
Fixes #4318

## Problème
La dernière mission de campagne (`depositPetInShelter`, « Déposer ou libérer son familier ») était validée à tort en **vendant** un familier.

## Correctif
Suppression de l'update `depositPetInShelter` dans `PetSellCommand` lors d'une vente. La vente continue de valider `sellOrTradePet` (mission dédiée). La mission de dépôt ne se complète plus qu'en déposant (transfert au refuge) ou en libérant le familier.

## Cause racine
`PetSellCommand` déclenchait trois missions dont `depositPetInShelter`, incohérent avec la sémantique de la mission.

_Décision de design (issue assignée à @BastLast) : ce PR retire la validation par la vente. Alternative possible : élargir le texte de la mission pour inclure la vente. À trancher au review._
