### PR TITLE
Convertit FLYING_PETS et AQUATIC_PETS en tags de données

### DIFF
--- a/Core/resources/pets/102.json
+++ b/Core/resources/pets/102.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 12,
   "speed": 25,
-  "feedDelay": 5
+  "feedDelay": 5,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/11.json
+++ b/Core/resources/pets/11.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 1,
   "feedDelay": 2,
-  "speed": 20
+  "speed": 20,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/12.json
+++ b/Core/resources/pets/12.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 1,
   "feedDelay": 1,
-  "speed": 8
+  "speed": 8,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/26.json
+++ b/Core/resources/pets/26.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 4,
   "feedDelay": 5,
-  "speed": 18
+  "speed": 18,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/27.json
+++ b/Core/resources/pets/27.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 3,
   "feedDelay": 5,
-  "speed": 22
+  "speed": 22,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/33.json
+++ b/Core/resources/pets/33.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 5,
   "feedDelay": 4,
-  "speed": 14
+  "speed": 14,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/34.json
+++ b/Core/resources/pets/34.json
@@ -2,5 +2,6 @@
   "rarity": 3,
   "force": 2,
   "feedDelay": 3,
-  "speed": 10
+  "speed": 10,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/54.json
+++ b/Core/resources/pets/54.json
@@ -2,5 +2,6 @@
   "rarity": 5,
   "force": 3,
   "feedDelay": 3,
-  "speed": 16
+  "speed": 16,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/58.json
+++ b/Core/resources/pets/58.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 8,
   "feedDelay": 7,
-  "speed": 28
+  "speed": 28,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/62.json
+++ b/Core/resources/pets/62.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 1,
   "feedDelay": 2,
-  "speed": 15
+  "speed": 15,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/64.json
+++ b/Core/resources/pets/64.json
@@ -4,5 +4,5 @@
   "force": 30,
   "feedDelay": 10,
   "speed": 25,
-  "tags": ["fire"]
+  "tags": ["fire", "flying"]
 }

--- a/Core/resources/pets/68.json
+++ b/Core/resources/pets/68.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 30,
   "feedDelay": 1,
-  "speed": 8
+  "speed": 8,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/71.json
+++ b/Core/resources/pets/71.json
@@ -2,5 +2,6 @@
   "rarity": 5,
   "force": 7,
   "feedDelay": 4,
-  "speed": 10
+  "speed": 10,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/73.json
+++ b/Core/resources/pets/73.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 4,
   "feedDelay": 3,
-  "speed": 15
+  "speed": 15,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/74.json
+++ b/Core/resources/pets/74.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 4,
   "feedDelay": 2,
-  "speed": 14
+  "speed": 14,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/75.json
+++ b/Core/resources/pets/75.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 3,
   "feedDelay": 3,
-  "speed": 5
+  "speed": 5,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/76.json
+++ b/Core/resources/pets/76.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 6,
   "feedDelay": 9,
-  "speed": 3
+  "speed": 3,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/77.json
+++ b/Core/resources/pets/77.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 26,
   "feedDelay": 7,
-  "speed": 28
+  "speed": 28,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/78.json
+++ b/Core/resources/pets/78.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 30,
   "feedDelay": 4,
-  "speed": 18
+  "speed": 18,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/79.json
+++ b/Core/resources/pets/79.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 30,
   "feedDelay": 4,
-  "speed": 17
+  "speed": 17,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/80.json
+++ b/Core/resources/pets/80.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 1,
   "feedDelay": 1,
-  "speed": 8
+  "speed": 8,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/81.json
+++ b/Core/resources/pets/81.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 5,
   "feedDelay": 5,
-  "speed": 5
+  "speed": 5,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/82.json
+++ b/Core/resources/pets/82.json
@@ -3,5 +3,6 @@
   "diet": "carnivorous",
   "force": 12,
   "feedDelay": 5,
-  "speed": 29
+  "speed": 29,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/83.json
+++ b/Core/resources/pets/83.json
@@ -3,5 +3,5 @@
   "force": 30,
   "feedDelay": 10,
   "speed": 30,
-  "tags": ["fire"]
+  "tags": ["fire", "flying"]
 }

--- a/Core/resources/pets/85.json
+++ b/Core/resources/pets/85.json
@@ -3,5 +3,6 @@
   "diet": "herbivorous",
   "force": 1,
   "feedDelay": 5,
-  "speed": 1
+  "speed": 1,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/86.json
+++ b/Core/resources/pets/86.json
@@ -2,5 +2,6 @@
   "rarity": 4,
   "force": 3,
   "feedDelay": 3,
-  "speed": 7
+  "speed": 7,
+  "tags": ["aquatic"]
 }

--- a/Core/resources/pets/94.json
+++ b/Core/resources/pets/94.json
@@ -2,5 +2,6 @@
   "rarity": 7,
   "force": 1,
   "feedDelay": 2,
-  "speed": 18
+  "speed": 18,
+  "tags": ["flying"]
 }

--- a/Core/resources/pets/95.json
+++ b/Core/resources/pets/95.json
@@ -2,5 +2,6 @@
   "rarity": 7,
   "force": 3,
   "feedDelay": 5,
-  "speed": 17
+  "speed": 17,
+  "tags": ["flying"]
 }

--- a/Core/src/core/fights/actions/interfaces/monsters/hammerQuakeAttack.ts
+++ b/Core/src/core/fights/actions/interfaces/monsters/hammerQuakeAttack.ts
@@ -8,11 +8,12 @@ import {
 } from "../../../../../../../Lib/src/types/FightActionResult";
 import { RealPlayerFighter } from "../../../fighter/RealPlayerFighter";
 import { PetConstants } from "../../../../../../../Lib/src/constants/PetConstants";
+import { PetDataController } from "../../../../../data/Pet";
 import { simpleDamageFightAction } from "../../templates/SimpleDamageFightActionTemplate";
 
 const use: FightActionFunc = (sender, receiver) => {
 	// This attack will fail if the opponent has a flying pet
-	if (receiver instanceof RealPlayerFighter && receiver.pet && PetConstants.FLYING_PETS.includes(receiver.pet.typeId)) {
+	if (receiver instanceof RealPlayerFighter && receiver.pet && PetDataController.instance.getById(receiver.pet.typeId)?.hasTag(PetConstants.TAGS.FLYING)) {
 		return {
 			...customMessageActionResult(),
 			damages: 0

--- a/Core/src/core/smallEvents/interactOtherPlayers.ts
+++ b/Core/src/core/smallEvents/interactOtherPlayers.ts
@@ -36,6 +36,7 @@ import { PlayerBadgesManager } from "../database/game/models/PlayerBadges";
 import { PlayerMissionsInfos } from "../database/game/models/PlayerMissionsInfo";
 import { PlayerTalismansManager } from "../database/game/models/PlayerTalismans";
 import { PetConstants } from "../../../../Lib/src/constants/PetConstants";
+import { PetDataController } from "../../data/Pet";
 import { LogsDatabase } from "../database/logs/LogsDatabase";
 import { LogsPveFightsResults } from "../database/logs/models/LogsPveFightsResults";
 import { SmallEventConstants } from "../../../../Lib/src/constants/SmallEventConstants";
@@ -348,10 +349,16 @@ function checkTalismans(hasTalisman: boolean, hasCloneTalisman: boolean, interac
  * @param otherPet
  * @param interactionsList
  */
-const PET_TYPE_TO_INTERACTION = new Map<number, InteractOtherPlayerInteraction>([
-	...PetConstants.FLYING_PETS.map(id => [id, InteractOtherPlayerInteraction.FLYING_PET] as [number, InteractOtherPlayerInteraction]),
-	...PetConstants.AQUATIC_PETS.map(id => [id, InteractOtherPlayerInteraction.AQUATIC_PET] as [number, InteractOtherPlayerInteraction])
-]);
+function getPetTypeInteraction(petTypeId: number): InteractOtherPlayerInteraction | null {
+	const petData = PetDataController.instance.getById(petTypeId);
+	if (petData?.hasTag(PetConstants.TAGS.FLYING)) {
+		return InteractOtherPlayerInteraction.FLYING_PET;
+	}
+	if (petData?.hasTag(PetConstants.TAGS.AQUATIC)) {
+		return InteractOtherPlayerInteraction.AQUATIC_PET;
+	}
+	return null;
+}
 
 function checkPetType(playerPet: PetEntity | null, otherPet: PetEntity | null, interactionsList: InteractOtherPlayerInteraction[]): void {
 	if (!otherPet) {
@@ -366,7 +373,7 @@ function checkPetType(playerPet: PetEntity | null, otherPet: PetEntity | null, i
 			interactionsList.splice(petIndex, 1);
 		}
 	}
-	const petInteraction = PET_TYPE_TO_INTERACTION.get(otherPet.typeId);
+	const petInteraction = getPetTypeInteraction(otherPet.typeId);
 	if (petInteraction) {
 		interactionsList.push(petInteraction);
 	}

--- a/Core/src/data/Pet.ts
+++ b/Core/src/data/Pet.ts
@@ -44,6 +44,13 @@ export class Pet extends Data<number> {
 		}
 		return false;
 	}
+
+	/**
+	 * Returns true if this pet carries the given data tag
+	 */
+	public hasTag(tag: string): boolean {
+		return Boolean(this.tags?.includes(tag));
+	}
 }
 
 export class PetDataController extends DataControllerNumber<Pet> {

--- a/Lib/src/constants/PetConstants.ts
+++ b/Lib/src/constants/PetConstants.ts
@@ -622,41 +622,11 @@ export abstract class PetConstants {
 		5
 	];
 
-	static readonly TAGS = { FIRE: "fire" } as const;
-
-	static readonly FLYING_PETS = [
-		PetConstants.PETS.BIRD,
-		PetConstants.PETS.DUCK,
-		PetConstants.PETS.OWL,
-		PetConstants.PETS.BAT,
-		PetConstants.PETS.SWAN,
-		PetConstants.PETS.FLAMINGO,
-		PetConstants.PETS.PARROT,
-		PetConstants.PETS.EAGLE,
-		PetConstants.PETS.DOVE,
-		PetConstants.PETS.DRAGON,
-		PetConstants.PETS.SCARLET_DUCK,
-		PetConstants.PETS.BLACK_BIRD,
-		PetConstants.PETS.RAVEN,
-		PetConstants.PETS.PHOENIX,
-		PetConstants.PETS.FAIRY
-	];
-
-	static readonly AQUATIC_PETS = [
-		PetConstants.PETS.OCTOPUS,
-		PetConstants.PETS.FISH,
-		PetConstants.PETS.TROPICAL_FISH,
-		PetConstants.PETS.PUFFERFISH,
-		PetConstants.PETS.JELLYFISH,
-		PetConstants.PETS.SHARK,
-		PetConstants.PETS.WHALE,
-		PetConstants.PETS.WHALE_2,
-		PetConstants.PETS.SHRIMP,
-		PetConstants.PETS.LOBSTER,
-		PetConstants.PETS.DOLPHIN,
-		PetConstants.PETS.CRAB,
-		PetConstants.PETS.SNAIL
-	];
+	static readonly TAGS = {
+		FIRE: "fire",
+		FLYING: "flying",
+		AQUATIC: "aquatic"
+	} as const;
 
 	static SEX = {
 		MALE: "m",


### PR DESCRIPTION
Fixes #4366

## Contexte
Suite au système de tags d'affinité des familiers introduit pour #4354 (`PetConstants.TAGS.FIRE`), ce PR applique le même pattern aux catégories de locomotion, conformément au review-checklist « Data tags over hardcoded ID lists ».

## Changements
- `PetConstants.TAGS` étendu avec `FLYING` et `AQUATIC` ; suppression des tableaux `FLYING_PETS` / `AQUATIC_PETS`.
- Nouvelle méthode `Pet.hasTag(tag)` (la logique de tag appartient au modèle).
- Tag `"flying"` sur 15 familiers, `"aquatic"` sur 13 familiers (JSON de données). Dragon et phénix cumulent `["fire", "flying"]`.
- `hammerQuakeAttack` (esquive des familiers volants) et `interactOtherPlayers` (interactions FLYING/AQUATIC) vérifient désormais le tag via `PetDataController` au lieu des listes d'IDs.

## Impact gameplay
Aucun : mêmes familiers volants/aquatiques qu'avant.
