### PR TITLE
Fix false error on city food shop buy + harden packet response ordering

### DIFF
--- a/Core/__tests__-integration/handlers/food-shop-buy-missions.integration.test.ts
+++ b/Core/__tests__-integration/handlers/food-shop-buy-missions.integration.test.ts
@@ -11,6 +11,7 @@ import type { MissionSlot as MissionSlotType } from "../../src/core/database/gam
 import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
 import { PetConstants } from "../../../Lib/src/constants/PetConstants";
 import type { CommandReportFoodShopBuyReq } from "../../../Lib/src/packets/commands/CommandReportPacket";
+import type { CrowniclesPacket } from "../../../Lib/src/packets/CrowniclesPacket";
 
 type FoodShopModule = typeof import("../../src/core/report/ReportCityFoodShopService");
 
@@ -129,6 +130,48 @@ describe("handleFoodShopBuy mission side effects", () => {
 
 		expect(await numberDoneOf(playerId, "buyGuildPetFood")).toBe(2);
 		expect(await numberDoneOf(playerId, "buyUltimateSoups")).toBe(2);
+	});
+
+	it("emits the buy response before any MissionsCompletedPacket (issue #4380)", async () => {
+		const player = await Player.create({ keycloakId: "food-shop-order" });
+		const guild = await Guild.create({
+			name: "FoodShopGuild-order",
+			chiefId: player.id,
+			shopLevel: 1,
+			treasury: 10_000
+		});
+		await Player.update({ guildId: guild.id }, { where: { id: player.id } });
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		// Objective equals the purchased amount so the mission completes and a
+		// MissionsCompletedPacket is emitted, exercising the ordering.
+		await MissionSlot.create({
+			playerId: player.id,
+			missionId: "buyUltimateSoups",
+			missionVariant: 0,
+			missionObjective: 2,
+			numberDone: 0,
+			expiresAt: null,
+			gemsToWin: 0,
+			pointsToWin: 0,
+			xpToWin: 0,
+			moneyToWin: 0
+		});
+
+		const packet = {
+			foodType: PetConstants.PET_FOOD.ULTIMATE_FOOD,
+			amount: 2
+		} as CommandReportFoodShopBuyReq;
+
+		const response: CrowniclesPacket[] = [];
+		await foodShop.handleFoodShopBuy("food-shop-order", packet, response);
+
+		const buyResIndex = response.findIndex(p => p.constructor.name === "CommandReportFoodShopBuyRes");
+		const missionsCompletedIndex = response.findIndex(p => p.constructor.name === "MissionsCompletedPacket");
+
+		// The command response must always land first so the Discord async
+		// callback consumes it instead of a MissionsCompletedPacket.
+		expect(buyResIndex).toBe(0);
+		expect(missionsCompletedIndex).toBeGreaterThan(buyResIndex);
 	});
 
 	it("does not advance buyUltimateSoups when buying non-ultimate food", async () => {

--- a/Core/eslint.config.mjs
+++ b/Core/eslint.config.mjs
@@ -30,7 +30,8 @@ export default defineConfig([
 		},
 		rules: {
 			...customRules,
-			"crownicles/single-line-short-single-property-object": ["error", { maxLength: 40 }]
+			"crownicles/single-line-short-single-property-object": ["error", { maxLength: 40 }],
+			"crownicles/no-response-push-through-return": "error"
 		}
 	},
 	{

--- a/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
+++ b/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
@@ -75,12 +75,12 @@ export default class CoreHandlers {
 
 	@packetHandler(CommandReportGardenHarvestReq)
 	async gardenHarvest(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportGardenHarvestReq): Promise<void> {
-		response.push(await handleGardenHarvest(context.keycloakId!, packet, response));
+		await handleGardenHarvest(context.keycloakId!, packet, response);
 	}
 
 	@packetHandler(CommandReportGardenPlantReq)
 	async gardenPlant(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportGardenPlantReq): Promise<void> {
-		response.push(await handleGardenPlant(context.keycloakId!, packet, response));
+		await handleGardenPlant(context.keycloakId!, packet, response);
 	}
 
 	@packetHandler(CommandReportGardenWaterReq)
@@ -140,6 +140,6 @@ export default class CoreHandlers {
 
 	@packetHandler(CommandReportGuildDomainDepositTreasuryReq)
 	async guildDomainDepositTreasury(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportGuildDomainDepositTreasuryReq): Promise<void> {
-		response.push(await handleGuildDomainDepositTreasury(context.keycloakId!, packet, response));
+		await handleGuildDomainDepositTreasury(context.keycloakId!, packet, response);
 	}
 }

--- a/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
+++ b/Core/src/core/packetHandlers/handlers/CoreHandlers.ts
@@ -135,7 +135,7 @@ export default class CoreHandlers {
 
 	@packetHandler(CommandReportFoodShopBuyReq)
 	async foodShopBuy(response: CrowniclesPacket[], context: PacketContext, packet: CommandReportFoodShopBuyReq): Promise<void> {
-		response.push(await handleFoodShopBuy(context.keycloakId!, packet, response));
+		await handleFoodShopBuy(context.keycloakId!, packet, response);
 	}
 
 	@packetHandler(CommandReportGuildDomainDepositTreasuryReq)

--- a/Core/src/core/report/ReportCityFoodShopService.ts
+++ b/Core/src/core/report/ReportCityFoodShopService.ts
@@ -121,10 +121,11 @@ function computeAffordableAmount(guild: Guild, request: ResolvedFoodShop): numbe
 	return Math.min(request.amount, maxStorable, maxAffordable);
 }
 
-export async function handleFoodShopBuy(keycloakId: string, packet: CommandReportFoodShopBuyReq, response: CrowniclesPacket[]): Promise<CrowniclesPacket> {
+export async function handleFoodShopBuy(keycloakId: string, packet: CommandReportFoodShopBuyReq, response: CrowniclesPacket[]): Promise<void> {
 	const resolved = await resolveFoodShopRequest(keycloakId, packet);
 	if (typeof resolved === "string") {
-		return makePacket(CommandReportFoodShopBuyErrorRes, { error: resolved });
+		response.push(makePacket(CommandReportFoodShopBuyErrorRes, { error: resolved }));
+		return;
 	}
 
 	/*
@@ -174,6 +175,18 @@ export async function handleFoodShopBuy(keycloakId: string, packet: CommandRepor
 		};
 	});
 
+	/*
+	 * Push the command response *before* running mission updates so it lands
+	 * first in the response array. The Discord async packet callback consumes
+	 * the first packet carrying the request's packetId; if a
+	 * MissionsCompletedPacket (pushed by MissionsController.update) came first,
+	 * it would wrongly trigger the food-shop "buy failed" branch (false
+	 * "cannot buy" message + no reimburse) and the real response would then
+	 * fall through to the listener lookup and error out (issue #4380).
+	 * Mirrors the cooking-craft ordering.
+	 */
+	response.push(result.packet);
+
 	if (result.amountBought > 0) {
 		await MissionsController.update(resolved.player, response, {
 			missionId: "buyGuildPetFood",
@@ -186,5 +199,4 @@ export async function handleFoodShopBuy(keycloakId: string, packet: CommandRepor
 			});
 		}
 	}
-	return result.packet;
 }

--- a/Core/src/core/report/ReportCityGuildDomainShopService.ts
+++ b/Core/src/core/report/ReportCityGuildDomainShopService.ts
@@ -93,15 +93,17 @@ function runTreasuryDepositUnderLock(
 	);
 }
 
-export async function handleGuildDomainDepositTreasury(keycloakId: string, packet: CommandReportGuildDomainDepositTreasuryReq, response: CrowniclesPacket[]): Promise<CrowniclesPacket> {
+export async function handleGuildDomainDepositTreasury(keycloakId: string, packet: CommandReportGuildDomainDepositTreasuryReq, response: CrowniclesPacket[]): Promise<void> {
 	const player = await Players.getByKeycloakId(keycloakId);
 	if (!player || !player.guildId) {
-		return makePacket(CommandReportGuildDomainDepositTreasuryErrorRes, { error: GUILD_DOMAIN_ERROR.NO_GUILD });
+		response.push(makePacket(CommandReportGuildDomainDepositTreasuryErrorRes, { error: GUILD_DOMAIN_ERROR.NO_GUILD }));
+		return;
 	}
 
 	const grossAmount = Math.floor(packet.amount);
 	if (!Number.isFinite(grossAmount) || grossAmount <= 0) {
-		return makePacket(CommandReportGuildDomainDepositTreasuryErrorRes, { error: GUILD_DOMAIN_ERROR.INVALID_AMOUNT });
+		response.push(makePacket(CommandReportGuildDomainDepositTreasuryErrorRes, { error: GUILD_DOMAIN_ERROR.INVALID_AMOUNT }));
+		return;
 	}
 
 	/*
@@ -110,14 +112,21 @@ export async function handleGuildDomainDepositTreasury(keycloakId: string, packe
 	 * is repeated *inside* the lock against a freshly-loaded row.
 	 */
 	if (player.money < grossAmount) {
-		return makePacket(CommandReportGuildDomainDepositTreasuryErrorRes, { error: GUILD_DOMAIN_ERROR.NOT_ENOUGH_MONEY });
+		response.push(makePacket(CommandReportGuildDomainDepositTreasuryErrorRes, { error: GUILD_DOMAIN_ERROR.NOT_ENOUGH_MONEY }));
+		return;
 	}
 
 	const result = await runTreasuryDepositUnderLock(player, packet, player.guildId, grossAmount);
 
 	logGuildTreasuryDeposit(result.logParams);
+
+	/*
+	 * Push the command response before the mission update so it lands first in
+	 * the batch (mirrors the cooking-craft ordering; see AsyncPacketSender
+	 * notification handling and issue #4380).
+	 */
+	response.push(result.packet);
 	if (result.logParams !== null) {
 		await MissionsController.update(player, response, { missionId: "depositGuildTreasury" });
 	}
-	return result.packet;
 }

--- a/Core/src/core/report/ReportGardenService.ts
+++ b/Core/src/core/report/ReportGardenService.ts
@@ -233,7 +233,7 @@ export async function handleGardenHarvest(
 				return Promise.resolve(makeGardenErrorPacket(GardenConstants.GARDEN_ERRORS.NO_READY_PLANTS));
 			}
 			return runHarvestUnderLock({
-				player, home, homeLevel, response: sideEffects
+				player, home, homeLevel, sideEffects
 			});
 		}
 	);
@@ -301,10 +301,10 @@ async function runHarvestUnderLock(params: {
 	player: Player;
 	home: Home;
 	homeLevel: HomeLevel;
-	response: CrowniclesPacket[];
+	sideEffects: CrowniclesPacket[];
 }): Promise<CrowniclesPacket> {
 	const {
-		player, home, homeLevel, response
+		player, home, homeLevel, sideEffects
 	} = params;
 	const earthQuality = homeLevel.features.gardenEarthQuality;
 	const gardenSlots = await HomeGardenSlots.getOfHome(home.id);
@@ -340,7 +340,7 @@ async function runHarvestUnderLock(params: {
 	logGardenHarvest(player, plantsHarvested, compostResults, harvestedSlots);
 	await triggerHarvestMissions({
 		player,
-		response,
+		response: sideEffects,
 		plantsHarvested,
 		ancestralHarvestCount: ancestralHarvest.count,
 		compostResults

--- a/Core/src/core/report/ReportGardenService.ts
+++ b/Core/src/core/report/ReportGardenService.ts
@@ -211,12 +211,20 @@ function computeReadyAtTimestamp(slot: HomeGardenSlot, effectiveGrowthTime: numb
  * Runs under a composite Player + Home lock so concurrent shards cannot
  * double-harvest the same ready slot (race-safe, see review checklist §10).
  */
-export function handleGardenHarvest(
+export async function handleGardenHarvest(
 	keycloakId: string,
 	_packet: CommandReportGardenHarvestReq,
 	response: CrowniclesPacket[]
-): Promise<CrowniclesPacket> {
-	return withGardenLock(
+): Promise<void> {
+	/*
+	 * Mission completions (and other side effects) are collected in a separate
+	 * array so the harvest response can be pushed *first* into the batch. A
+	 * MissionsCompletedPacket sitting before the response would be routed to the
+	 * front-end's request callback instead of its own listener (see
+	 * AsyncPacketSender notification handling and issue #4380).
+	 */
+	const sideEffects: CrowniclesPacket[] = [];
+	const packet = await withGardenLock(
 		keycloakId,
 		() => makeGardenErrorPacket(GardenConstants.GARDEN_ERRORS.NO_READY_PLANTS),
 		(player, home) => {
@@ -225,10 +233,11 @@ export function handleGardenHarvest(
 				return Promise.resolve(makeGardenErrorPacket(GardenConstants.GARDEN_ERRORS.NO_READY_PLANTS));
 			}
 			return runHarvestUnderLock({
-				player, home, homeLevel, response
+				player, home, homeLevel, response: sideEffects
 			});
 		}
 	);
+	response.push(packet, ...sideEffects);
 }
 
 type CompostResult = {
@@ -415,7 +424,7 @@ export function handleGardenPlant(
 	keycloakId: string,
 	packet: CommandReportGardenPlantReq,
 	response: CrowniclesPacket[]
-): Promise<CrowniclesPacket> {
+): Promise<void> {
 	let plantedPlayer: Player | null = null;
 	return withGardenLock(
 		keycloakId,
@@ -429,16 +438,21 @@ export function handleGardenPlant(
 		}
 	).then(async resultPacket => {
 		/*
+		 * Side effects go into a separate array so the plant response is pushed
+		 * first into the batch (see AsyncPacketSender notification handling and
+		 * issue #4380).
+		 *
 		 * The plantSeed mission update runs OUTSIDE the garden lock on purpose:
 		 * MissionsController.update locks [player_missions_info, players] in canonical
 		 * order, so acquiring it while the garden lock already holds the players row
 		 * would invert the lock order and risk a deadlock. The cooking service applies
 		 * the same after-lock pattern (see ReportCookingService.executeReadyCookingCraft).
 		 */
+		const sideEffects: CrowniclesPacket[] = [];
 		if (plantedPlayer) {
-			await MissionsController.update(plantedPlayer, response, { missionId: "plantSeed" });
+			await MissionsController.update(plantedPlayer, sideEffects, { missionId: "plantSeed" });
 		}
-		return resultPacket;
+		response.push(resultPacket, ...sideEffects);
 	});
 }
 

--- a/Discord/eslint.config.mjs
+++ b/Discord/eslint.config.mjs
@@ -31,7 +31,8 @@ export default defineConfig([
 		rules: {
 			...customRules,
 			"crownicles/single-line-short-single-property-object": ["error", { maxLength: 40 }],
-			"crownicles/no-this-in-packet-handler": "error"
+			"crownicles/no-this-in-packet-handler": "error",
+			"crownicles/no-response-push-through-return": "error"
 		}
 	},
 	{

--- a/Discord/src/commands/player/report/guildFoodShop/GuildFoodShopMenu.ts
+++ b/Discord/src/commands/player/report/guildFoodShop/GuildFoodShopMenu.ts
@@ -20,6 +20,7 @@ import { DiscordMQTT } from "../../../../bot/DiscordMQTT";
 import {
 	CommandReportFoodShopBuyReq,
 	CommandReportFoodShopBuyRes,
+	CommandReportFoodShopBuyErrorRes,
 	CommandReportGuildDomainDepositTreasuryReq,
 	CommandReportGuildDomainDepositTreasuryRes
 } from "../../../../../../Lib/src/packets/commands/CommandReportPacket";
@@ -187,7 +188,10 @@ async function handleFoodBuy(ctx: FoodShopMenuContext, foodType: PetFood, amount
 				// Buy failed (e.g., another member just drained the treasury): end the report with a clear error.
 				finishReportWithErrorEmbed(ctx, nestedMenus, i18n.t("commands:report.city.guildDomain.subMenus.shop.buyFoodError", { lng: ctx.lng }));
 			}
-		}
+		},
+
+		// Only these responses may fulfil the request; mission/reward broadcasts are routed to their own listeners.
+		[CommandReportFoodShopBuyRes, CommandReportFoodShopBuyErrorRes]
 	);
 }
 

--- a/Discord/src/commands/player/report/guildFoodShop/GuildFoodShopMenu.ts
+++ b/Discord/src/commands/player/report/guildFoodShop/GuildFoodShopMenu.ts
@@ -20,7 +20,6 @@ import { DiscordMQTT } from "../../../../bot/DiscordMQTT";
 import {
 	CommandReportFoodShopBuyReq,
 	CommandReportFoodShopBuyRes,
-	CommandReportFoodShopBuyErrorRes,
 	CommandReportGuildDomainDepositTreasuryReq,
 	CommandReportGuildDomainDepositTreasuryRes
 } from "../../../../../../Lib/src/packets/commands/CommandReportPacket";
@@ -188,10 +187,7 @@ async function handleFoodBuy(ctx: FoodShopMenuContext, foodType: PetFood, amount
 				// Buy failed (e.g., another member just drained the treasury): end the report with a clear error.
 				finishReportWithErrorEmbed(ctx, nestedMenus, i18n.t("commands:report.city.guildDomain.subMenus.shop.buyFoodError", { lng: ctx.lng }));
 			}
-		},
-
-		// Only these responses may fulfil the request; mission/reward broadcasts are routed to their own listeners.
-		[CommandReportFoodShopBuyRes, CommandReportFoodShopBuyErrorRes]
+		}
 	);
 }
 

--- a/Lib/src/packets/AsyncPacketSender.ts
+++ b/Lib/src/packets/AsyncPacketSender.ts
@@ -1,30 +1,102 @@
 import {
-	CrowniclesPacket, PacketContext
+	CrowniclesPacket, PacketContext, PacketLike
 } from "./CrowniclesPacket";
+import { MissionsCompletedPacket } from "./events/MissionsCompletedPacket";
+import { MissionsExpiredPacket } from "./events/MissionsExpiredPacket";
+import { PlayerReceivePetPacket } from "./events/PlayerReceivePetPacket";
 
 type AsyncPacketSenderCallback = (context: PacketContext, packetName: string, packet: CrowniclesPacket) => Promise<void> | void;
 
+interface WaitingPacket {
+	callback: AsyncPacketSenderCallback;
+
+	/**
+	 * When set, only packets whose class name is in this set may fulfil the
+	 * request; any other packet is left for its own listener (see
+	 * {@link AsyncPacketSender.handleResponse}).
+	 */
+	expectedResponseNames?: ReadonlySet<string>;
+}
+
+/**
+ * Packets that are pushed into a response batch as *side effects* (mission
+ * completion, mission expiry, campaign pet rewards) rather than as the answer
+ * to the request that triggered them. They are broadcasts routed to their own
+ * dedicated listeners, so a pending {@link AsyncPacketSender} request callback
+ * must never consume one — otherwise the first side-effect packet in the batch
+ * would fulfil (and often mis-handle, as a "failure") the request, and the real
+ * response would then fall through to the listener lookup and error out.
+ *
+ * Regression origin: issue #4380 (food-shop buy showed a false "cannot buy"
+ * error + a mission error because a MissionsCompletedPacket was consumed by the
+ * buy callback). Centralising the skip here makes the whole class of ordering
+ * bugs impossible regardless of the order handlers push packets.
+ */
+const NOTIFICATION_PACKET_NAMES: ReadonlySet<string> = new Set([
+	MissionsCompletedPacket.name,
+	MissionsExpiredPacket.name,
+	PlayerReceivePetPacket.name
+]);
+
 export abstract class AsyncPacketSender {
-	private waitingPackets: Map<string, AsyncPacketSenderCallback> = new Map();
+	private waitingPackets: Map<string, WaitingPacket> = new Map();
 
 	protected abstract sendPacket(context: PacketContext, packet: CrowniclesPacket): Promise<void>;
 
-	public sendPacketAndHandleResponse(context: PacketContext, packet: CrowniclesPacket, callback: AsyncPacketSenderCallback): Promise<void> {
+	/**
+	 * Send a request packet and register a callback to handle its response.
+	 * @param context request context (a fresh packetId is assigned)
+	 * @param packet the request packet
+	 * @param callback invoked with the response packet
+	 * @param expectedResponses optional list of packet classes that are valid
+	 * responses to this request. When provided, any packet whose class is not
+	 * listed is left untouched for its own listener instead of being consumed
+	 * by `callback`. Notification packets are always skipped regardless of this
+	 * list.
+	 */
+	public sendPacketAndHandleResponse(
+		context: PacketContext,
+		packet: CrowniclesPacket,
+		callback: AsyncPacketSenderCallback,
+		expectedResponses?: PacketLike<CrowniclesPacket>[]
+	): Promise<void> {
 		context.packetId = crypto.randomUUID();
-		this.waitingPackets.set(context.packetId, callback);
+		this.waitingPackets.set(context.packetId, {
+			callback,
+			...expectedResponses ? { expectedResponseNames: new Set(expectedResponses.map(response => response.name)) } : {}
+		});
 		return this.sendPacket(context, packet);
 	}
 
 	public async handleResponse(context: PacketContext, packetName: string, packet: CrowniclesPacket): Promise<boolean> {
-		if (context.packetId) {
-			const callback = this.waitingPackets.get(context.packetId);
-			if (callback) {
-				this.waitingPackets.delete(context.packetId);
-				await callback(context, packetName, packet);
-				return true;
-			}
+		if (!context.packetId) {
+			return false;
+		}
+		const waiting = this.waitingPackets.get(context.packetId);
+		if (!waiting) {
+			return false;
 		}
 
-		return false;
+		/*
+		 * Side-effect broadcasts (mission completion/expiry, pet rewards) are
+		 * never a request's answer: let them reach their own listener and keep
+		 * waiting for the real response.
+		 */
+		if (NOTIFICATION_PACKET_NAMES.has(packetName)) {
+			return false;
+		}
+
+		/*
+		 * If the caller declared which responses it expects, ignore anything
+		 * else so it is routed to its dedicated listener instead of being
+		 * mis-consumed.
+		 */
+		if (waiting.expectedResponseNames && !waiting.expectedResponseNames.has(packetName)) {
+			return false;
+		}
+
+		this.waitingPackets.delete(context.packetId);
+		await waiting.callback(context, packetName, packet);
+		return true;
 	}
 }

--- a/Lib/src/packets/AsyncPacketSender.ts
+++ b/Lib/src/packets/AsyncPacketSender.ts
@@ -1,14 +1,32 @@
 import {
 	CrowniclesPacket, PacketContext, PacketLike
 } from "./CrowniclesPacket";
+import { GuildLevelUpPacket } from "./events/GuildLevelUpPacket";
+import { ItemAcceptPacket } from "./events/ItemAcceptPacket";
+import { ItemFoundPacket } from "./events/ItemFoundPacket";
+import { ItemRefusePacket } from "./events/ItemRefusePacket";
 import { MissionsCompletedPacket } from "./events/MissionsCompletedPacket";
 import { MissionsExpiredPacket } from "./events/MissionsExpiredPacket";
+import { PlayerDeathPacket } from "./events/PlayerDeathPacket";
+import { PlayerLeavePveIslandPacket } from "./events/PlayerLeavePveIslandPacket";
+import { PlayerLevelUpPacket } from "./events/PlayerLevelUpPacket";
 import { PlayerReceivePetPacket } from "./events/PlayerReceivePetPacket";
 
 type AsyncPacketSenderCallback = (context: PacketContext, packetName: string, packet: CrowniclesPacket) => Promise<void> | void;
 
+/**
+ * How long a request callback stays registered before being evicted. This is a
+ * safety net: every request is normally fulfilled by its response, but if the
+ * backend never answers (crash, dropped message…) the entry would otherwise
+ * leak forever in {@link AsyncPacketSender.waitingPackets}.
+ */
+const WAITING_PACKET_TTL_MS = 5 * 60 * 1000;
+
 interface WaitingPacket {
 	callback: AsyncPacketSenderCallback;
+
+	/** Timer that evicts this entry if no response ever arrives. */
+	evictionTimer: ReturnType<typeof setTimeout>;
 
 	/**
 	 * When set, only packets whose class name is in this set may fulfil the
@@ -19,22 +37,34 @@ interface WaitingPacket {
 }
 
 /**
- * Packets that are pushed into a response batch as *side effects* (mission
- * completion, mission expiry, campaign pet rewards) rather than as the answer
- * to the request that triggered them. They are broadcasts routed to their own
- * dedicated listeners, so a pending {@link AsyncPacketSender} request callback
- * must never consume one — otherwise the first side-effect packet in the batch
- * would fulfil (and often mis-handle, as a "failure") the request, and the real
- * response would then fall through to the listener lookup and error out.
+ * Event/broadcast packets: they are pushed into a response batch as *side
+ * effects* (mission completion/expiry, level-ups, item grants, pet rewards,
+ * death…) rather than as the answer to the request that triggered them. Each
+ * has its own dedicated front-end listener and is never awaited as a request
+ * response, so a pending {@link AsyncPacketSender} request callback must never
+ * consume one — otherwise a side-effect packet landing before the real response
+ * in the batch would fulfil (and often mis-handle, as a "failure") the request,
+ * and the real response would then fall through to the listener lookup and
+ * error out.
+ *
+ * This set must list *every* packet under `Lib/src/packets/events` — a
+ * completeness test enforces it (`tests/packets/AsyncPacketSender.test.ts`) so a
+ * newly added broadcast can never silently reopen the ordering-bug class.
  *
  * Regression origin: issue #4380 (food-shop buy showed a false "cannot buy"
  * error + a mission error because a MissionsCompletedPacket was consumed by the
- * buy callback). Centralising the skip here makes the whole class of ordering
- * bugs impossible regardless of the order handlers push packets.
+ * buy callback).
  */
-const NOTIFICATION_PACKET_NAMES: ReadonlySet<string> = new Set([
+export const NOTIFICATION_PACKET_NAMES: ReadonlySet<string> = new Set([
+	GuildLevelUpPacket.name,
+	ItemAcceptPacket.name,
+	ItemFoundPacket.name,
+	ItemRefusePacket.name,
 	MissionsCompletedPacket.name,
 	MissionsExpiredPacket.name,
+	PlayerDeathPacket.name,
+	PlayerLeavePveIslandPacket.name,
+	PlayerLevelUpPacket.name,
 	PlayerReceivePetPacket.name
 ]);
 
@@ -60,10 +90,14 @@ export abstract class AsyncPacketSender {
 		callback: AsyncPacketSenderCallback,
 		expectedResponses?: PacketLike<CrowniclesPacket>[]
 	): Promise<void> {
-		context.packetId = crypto.randomUUID();
-		this.waitingPackets.set(context.packetId, {
+		const packetId = crypto.randomUUID();
+		context.packetId = packetId;
+		const evictionTimer = setTimeout(() => this.waitingPackets.delete(packetId), WAITING_PACKET_TTL_MS);
+		evictionTimer.unref?.();
+		this.waitingPackets.set(packetId, {
 			callback,
-			...expectedResponses ? { expectedResponseNames: new Set(expectedResponses.map(response => response.name)) } : {}
+			evictionTimer,
+			...expectedResponses ? { expectedResponseNames: new Set(expectedResponses.map(packetClass => packetClass.name)) } : {}
 		});
 		return this.sendPacket(context, packet);
 	}
@@ -78,9 +112,9 @@ export abstract class AsyncPacketSender {
 		}
 
 		/*
-		 * Side-effect broadcasts (mission completion/expiry, pet rewards) are
-		 * never a request's answer: let them reach their own listener and keep
-		 * waiting for the real response.
+		 * Side-effect broadcasts (missions, level-ups, item grants, pet rewards,
+		 * death…) are never a request's answer: let them reach their own
+		 * listener and keep waiting for the real response.
 		 */
 		if (NOTIFICATION_PACKET_NAMES.has(packetName)) {
 			return false;
@@ -95,6 +129,7 @@ export abstract class AsyncPacketSender {
 			return false;
 		}
 
+		clearTimeout(waiting.evictionTimer);
 		this.waitingPackets.delete(context.packetId);
 		await waiting.callback(context, packetName, packet);
 		return true;

--- a/Lib/src/packets/AsyncPacketSender.ts
+++ b/Lib/src/packets/AsyncPacketSender.ts
@@ -1,5 +1,5 @@
 import {
-	CrowniclesPacket, PacketContext, PacketLike
+	CrowniclesPacket, PacketContext
 } from "./CrowniclesPacket";
 import { GuildLevelUpPacket } from "./events/GuildLevelUpPacket";
 import { ItemAcceptPacket } from "./events/ItemAcceptPacket";
@@ -27,13 +27,6 @@ interface WaitingPacket {
 
 	/** Timer that evicts this entry if no response ever arrives. */
 	evictionTimer: ReturnType<typeof setTimeout>;
-
-	/**
-	 * When set, only packets whose class name is in this set may fulfil the
-	 * request; any other packet is left for its own listener (see
-	 * {@link AsyncPacketSender.handleResponse}).
-	 */
-	expectedResponseNames?: ReadonlySet<string>;
 }
 
 /**
@@ -75,20 +68,16 @@ export abstract class AsyncPacketSender {
 
 	/**
 	 * Send a request packet and register a callback to handle its response.
+	 * Notification/broadcast packets ({@link NOTIFICATION_PACKET_NAMES}) are
+	 * never routed to `callback`; they reach their own listener instead.
 	 * @param context request context (a fresh packetId is assigned)
 	 * @param packet the request packet
 	 * @param callback invoked with the response packet
-	 * @param expectedResponses optional list of packet classes that are valid
-	 * responses to this request. When provided, any packet whose class is not
-	 * listed is left untouched for its own listener instead of being consumed
-	 * by `callback`. Notification packets are always skipped regardless of this
-	 * list.
 	 */
 	public sendPacketAndHandleResponse(
 		context: PacketContext,
 		packet: CrowniclesPacket,
-		callback: AsyncPacketSenderCallback,
-		expectedResponses?: PacketLike<CrowniclesPacket>[]
+		callback: AsyncPacketSenderCallback
 	): Promise<void> {
 		const packetId = crypto.randomUUID();
 		context.packetId = packetId;
@@ -96,8 +85,7 @@ export abstract class AsyncPacketSender {
 		evictionTimer.unref?.();
 		this.waitingPackets.set(packetId, {
 			callback,
-			evictionTimer,
-			...expectedResponses ? { expectedResponseNames: new Set(expectedResponses.map(packetClass => packetClass.name)) } : {}
+			evictionTimer
 		});
 		return this.sendPacket(context, packet);
 	}
@@ -117,15 +105,6 @@ export abstract class AsyncPacketSender {
 		 * listener and keep waiting for the real response.
 		 */
 		if (NOTIFICATION_PACKET_NAMES.has(packetName)) {
-			return false;
-		}
-
-		/*
-		 * If the caller declared which responses it expects, ignore anything
-		 * else so it is routed to its dedicated listener instead of being
-		 * mis-consumed.
-		 */
-		if (waiting.expectedResponseNames && !waiting.expectedResponseNames.has(packetName)) {
 			return false;
 		}
 

--- a/Lib/tests/packets/AsyncPacketSender.test.ts
+++ b/Lib/tests/packets/AsyncPacketSender.test.ts
@@ -1,0 +1,108 @@
+import {
+	describe, it, expect
+} from "vitest";
+import { AsyncPacketSender } from "../../src/packets/AsyncPacketSender";
+import {
+	CrowniclesPacket, PacketContext
+} from "../../src/packets/CrowniclesPacket";
+import { MissionsCompletedPacket } from "../../src/packets/events/MissionsCompletedPacket";
+
+/**
+ * Contract test for {@link AsyncPacketSender}.
+ *
+ * Guards the invariant that broke in issue #4380: a pending request callback
+ * must NOT be fulfilled by a side-effect broadcast (mission completion, pet
+ * reward…) that happens to share the request's packetId. If it were, the first
+ * broadcast in the batch would consume (and often mis-handle as a failure) the
+ * request, and the real response would fall through to the listener lookup and
+ * error out.
+ */
+
+class TestPacketSender extends AsyncPacketSender {
+	public readonly sent: CrowniclesPacket[] = [];
+
+	protected sendPacket(_context: PacketContext, packet: CrowniclesPacket): Promise<void> {
+		this.sent.push(packet);
+		return Promise.resolve();
+	}
+}
+
+// Minimal stand-in response packets (only their class name matters here).
+class FooRes extends CrowniclesPacket {}
+class BarRes extends CrowniclesPacket {}
+
+function makeContext(): PacketContext {
+	return {
+		frontEndOrigin: "test",
+		frontEndSubOrigin: "test"
+	};
+}
+
+describe("AsyncPacketSender.handleResponse", () => {
+	it("fulfils the callback with a normal response", async () => {
+		const sender = new TestPacketSender();
+		const ctx = makeContext();
+		const received: string[] = [];
+
+		await sender.sendPacketAndHandleResponse(ctx, new FooRes(), (_c, name) => {
+			received.push(name);
+		});
+
+		const consumed = await sender.handleResponse(ctx, FooRes.name, new FooRes());
+		expect(consumed).toBe(true);
+		expect(received).toEqual([FooRes.name]);
+	});
+
+	it("does not let a notification packet fulfil a pending request, and keeps waiting for the real response", async () => {
+		const sender = new TestPacketSender();
+		const ctx = makeContext();
+		const received: string[] = [];
+
+		await sender.sendPacketAndHandleResponse(ctx, new FooRes(), (_c, name) => {
+			received.push(name);
+		});
+
+		// A mission-completed broadcast arrives first in the batch.
+		const notificationConsumed = await sender.handleResponse(ctx, MissionsCompletedPacket.name, new FooRes());
+		expect(notificationConsumed).toBe(false);
+		expect(received).toEqual([]);
+
+		// The actual response arrives afterwards and still reaches the callback.
+		const responseConsumed = await sender.handleResponse(ctx, FooRes.name, new FooRes());
+		expect(responseConsumed).toBe(true);
+		expect(received).toEqual([FooRes.name]);
+	});
+
+	it("with expectedResponses, ignores unlisted packets and consumes only a listed one", async () => {
+		const sender = new TestPacketSender();
+		const ctx = makeContext();
+		const received: string[] = [];
+
+		await sender.sendPacketAndHandleResponse(
+			ctx,
+			new FooRes(),
+			(_c, name) => {
+				received.push(name);
+			},
+			[FooRes]
+		);
+
+		// BarRes is neither a notification nor an expected response: leave it alone.
+		const barConsumed = await sender.handleResponse(ctx, BarRes.name, new BarRes());
+		expect(barConsumed).toBe(false);
+		expect(received).toEqual([]);
+
+		const fooConsumed = await sender.handleResponse(ctx, FooRes.name, new FooRes());
+		expect(fooConsumed).toBe(true);
+		expect(received).toEqual([FooRes.name]);
+	});
+
+	it("returns false when there is no pending request for the context", async () => {
+		const sender = new TestPacketSender();
+		const ctx = makeContext();
+		ctx.packetId = "unknown-id";
+
+		const consumed = await sender.handleResponse(ctx, FooRes.name, new FooRes());
+		expect(consumed).toBe(false);
+	});
+});

--- a/Lib/tests/packets/AsyncPacketSender.test.ts
+++ b/Lib/tests/packets/AsyncPacketSender.test.ts
@@ -1,7 +1,11 @@
 import {
 	describe, it, expect
 } from "vitest";
-import { AsyncPacketSender } from "../../src/packets/AsyncPacketSender";
+import { readdirSync } from "fs";
+import { join } from "path";
+import {
+	AsyncPacketSender, NOTIFICATION_PACKET_NAMES
+} from "../../src/packets/AsyncPacketSender";
 import {
 	CrowniclesPacket, PacketContext
 } from "../../src/packets/CrowniclesPacket";
@@ -106,3 +110,28 @@ describe("AsyncPacketSender.handleResponse", () => {
 		expect(consumed).toBe(false);
 	});
 });
+
+/**
+ * Completeness guard: every packet under `src/packets/events` is a broadcast
+ * with a dedicated front-end listener and must never fulfil a request callback.
+ * If a new event packet is added but forgotten in NOTIFICATION_PACKET_NAMES, the
+ * ordering-bug class (#4380) silently reopens — this test fails instead.
+ */
+describe("NOTIFICATION_PACKET_NAMES completeness", () => {
+	const eventsDir = join(__dirname, "..", "..", "src", "packets", "events");
+
+	it("contains every event/broadcast packet class", async () => {
+		const eventFiles = readdirSync(eventsDir).filter(file => file.endsWith(".ts"));
+		expect(eventFiles.length).toBeGreaterThan(0);
+
+		for (const file of eventFiles) {
+			const moduleExports = await import(join(eventsDir, file)) as Record<string, unknown>;
+			for (const exported of Object.values(moduleExports)) {
+				if (typeof exported === "function" && exported.prototype instanceof CrowniclesPacket) {
+					expect(NOTIFICATION_PACKET_NAMES.has(exported.name), `${exported.name} (from ${file}) is missing from NOTIFICATION_PACKET_NAMES`).toBe(true);
+				}
+			}
+		}
+	});
+});
+

--- a/Lib/tests/packets/AsyncPacketSender.test.ts
+++ b/Lib/tests/packets/AsyncPacketSender.test.ts
@@ -31,9 +31,8 @@ class TestPacketSender extends AsyncPacketSender {
 	}
 }
 
-// Minimal stand-in response packets (only their class name matters here).
+// Minimal stand-in response packet (only its class name matters here).
 class FooRes extends CrowniclesPacket {}
-class BarRes extends CrowniclesPacket {}
 
 function makeContext(): PacketContext {
 	return {
@@ -74,30 +73,6 @@ describe("AsyncPacketSender.handleResponse", () => {
 		// The actual response arrives afterwards and still reaches the callback.
 		const responseConsumed = await sender.handleResponse(ctx, FooRes.name, new FooRes());
 		expect(responseConsumed).toBe(true);
-		expect(received).toEqual([FooRes.name]);
-	});
-
-	it("with expectedResponses, ignores unlisted packets and consumes only a listed one", async () => {
-		const sender = new TestPacketSender();
-		const ctx = makeContext();
-		const received: string[] = [];
-
-		await sender.sendPacketAndHandleResponse(
-			ctx,
-			new FooRes(),
-			(_c, name) => {
-				received.push(name);
-			},
-			[FooRes]
-		);
-
-		// BarRes is neither a notification nor an expected response: leave it alone.
-		const barConsumed = await sender.handleResponse(ctx, BarRes.name, new BarRes());
-		expect(barConsumed).toBe(false);
-		expect(received).toEqual([]);
-
-		const fooConsumed = await sender.handleResponse(ctx, FooRes.name, new FooRes());
-		expect(fooConsumed).toBe(true);
 		expect(received).toEqual([FooRes.name]);
 	});
 

--- a/RestWs/eslint.config.mjs
+++ b/RestWs/eslint.config.mjs
@@ -30,7 +30,8 @@ export default defineConfig([
 		},
 		rules: {
 			...customRules,
-			"crownicles/single-line-short-single-property-object": ["error", { maxLength: 40 }]
+			"crownicles/single-line-short-single-property-object": ["error", { maxLength: 40 }],
+			"crownicles/no-response-push-through-return": "error"
 		}
 	},
 	{

--- a/eslint-custom-rules/index.mjs
+++ b/eslint-custom-rules/index.mjs
@@ -5,11 +5,13 @@
 import singleLineShortSinglePropertyObject from "./single-line-short-single-property-object.mjs";
 import noUnguardedSave from "./no-unguarded-save.mjs";
 import noThisInPacketHandler from "./no-this-in-packet-handler.mjs";
+import noResponsePushThroughReturn from "./no-response-push-through-return.mjs";
 
 export default {
 	rules: {
 		"single-line-short-single-property-object": singleLineShortSinglePropertyObject,
 		"no-unguarded-save": noUnguardedSave,
-		"no-this-in-packet-handler": noThisInPacketHandler
+		"no-this-in-packet-handler": noThisInPacketHandler,
+		"no-response-push-through-return": noResponsePushThroughReturn
 	}
 };

--- a/eslint-custom-rules/no-response-push-through-return.mjs
+++ b/eslint-custom-rules/no-response-push-through-return.mjs
@@ -51,6 +51,32 @@ function callArgumentsContainIdentifier(callNode, identifierName) {
 	});
 }
 
+/**
+ * If `callee` is a `<identifier>.push` member expression, return the identifier
+ * name being pushed into; otherwise return null.
+ */
+function getPushTargetArrayName(callee) {
+	const isArrayPush = callee.type === "MemberExpression"
+		&& !callee.computed
+		&& callee.property.type === "Identifier"
+		&& callee.property.name === "push"
+		&& callee.object.type === "Identifier";
+	return isArrayPush ? callee.object.name : null;
+}
+
+/**
+ * Unwrap `await fn(...)` and `...await fn(...)` down to the awaited
+ * `CallExpression`, or return null when the argument is not an awaited call.
+ */
+function getAwaitedCall(rawArg) {
+	const maybeAwait = rawArg.type === "SpreadElement" ? rawArg.argument : rawArg;
+	if (maybeAwait.type !== "AwaitExpression") {
+		return null;
+	}
+	const call = maybeAwait.argument;
+	return call.type === "CallExpression" ? call : null;
+}
+
 export default {
 	meta: {
 		type: "problem",
@@ -67,36 +93,22 @@ export default {
 	create(context) {
 		return {
 			CallExpression(node) {
-				const callee = node.callee;
-
-				// Match `<identifier>.push(...)`
-				if (
-					callee.type !== "MemberExpression"
-					|| callee.computed
-					|| callee.property.type !== "Identifier"
-					|| callee.property.name !== "push"
-					|| callee.object.type !== "Identifier"
-				) {
+				const arrayName = getPushTargetArrayName(node.callee);
+				if (arrayName === null) {
 					return;
 				}
 
-				const arrayName = callee.object.name;
+				const pushesThroughReturn = node.arguments.some(rawArg => {
+					const call = getAwaitedCall(rawArg);
+					return call !== null && callArgumentsContainIdentifier(call, arrayName);
+				});
 
-				for (const rawArg of node.arguments) {
-					// Unwrap `...await fn(...)` and `await fn(...)`.
-					const maybeAwait = rawArg.type === "SpreadElement" ? rawArg.argument : rawArg;
-					if (maybeAwait.type !== "AwaitExpression") {
-						continue;
-					}
-					const call = maybeAwait.argument;
-					if (call.type === "CallExpression" && callArgumentsContainIdentifier(call, arrayName)) {
-						context.report({
-							node,
-							messageId: "noPushThroughReturn",
-							data: { array: arrayName }
-						});
-						return;
-					}
+				if (pushesThroughReturn) {
+					context.report({
+						node,
+						messageId: "noPushThroughReturn",
+						data: { array: arrayName }
+					});
 				}
 			}
 		};

--- a/eslint-custom-rules/no-response-push-through-return.mjs
+++ b/eslint-custom-rules/no-response-push-through-return.mjs
@@ -1,0 +1,104 @@
+/**
+ * ESLint custom rule: no-response-push-through-return
+ *
+ * Forbids the pattern `arr.push(await fn(..., arr, ...))` — i.e. pushing into a
+ * response array the awaited return value of a function that was itself handed
+ * that same array.
+ *
+ * Rationale: packet handlers receive a shared `response: CrowniclesPacket[]`
+ * array. A helper that both (a) receives that array (and pushes side effects
+ * such as `MissionsController.update(...)` into it) and (b) returns a packet the
+ * caller appends afterwards produces an ordering hazard: the side-effect packets
+ * (e.g. `MissionsCompletedPacket`) end up BEFORE the command response in the
+ * batch. On the front-end, the pending request callback then consumes the first
+ * packet carrying the request's packetId — the mission broadcast — instead of
+ * the real response, showing a false error and dropping the real reply.
+ *
+ * The hazard is inherently asynchronous (the accumulated side effects come from
+ * awaited DB/mission work), so the rule only targets `await`-ed calls. This
+ * deliberately ignores synchronous patterns such as
+ * `actions.push(pickExcluding(actions))`, where the array is passed only to
+ * exclude already-chosen values — no ordering hazard there.
+ *
+ * History: issue #4380 (food-shop buy showed a false "cannot buy" error and a
+ * mission error). The same latent shape existed for garden harvest/plant and
+ * guild treasury deposit.
+ *
+ * Fix: the helper must push its response into the array itself (before running
+ * mission updates) and return `void`, or collect side effects in a separate
+ * array and push the response first. See `ReportCityFoodShopService`,
+ * `ReportGardenService` and `ReportCookingService` for the canonical shapes.
+ *
+ * @example
+ * // ✗ BAD — response appended after the helper already pushed missions into it
+ * response.push(await handleFoodShopBuy(keycloakId, packet, response));
+ *
+ * // ✓ GOOD — helper pushes its response first, then missions, and returns void
+ * await handleFoodShopBuy(keycloakId, packet, response);
+ */
+
+function callArgumentsContainIdentifier(callNode, identifierName) {
+	return callNode.arguments.some(arg => {
+		if (arg.type === "Identifier") {
+			return arg.name === identifierName;
+		}
+
+		// `...response` spread of the same array is the same hazard.
+		if (arg.type === "SpreadElement" && arg.argument.type === "Identifier") {
+			return arg.argument.name === identifierName;
+		}
+		return false;
+	});
+}
+
+export default {
+	meta: {
+		type: "problem",
+		docs: {
+			description: "Forbid pushing into a response array the awaited return of a function that received that same array (ordering hazard, see #4380)",
+			category: "Possible Errors"
+		},
+		schema: [],
+		messages: {
+			noPushThroughReturn: "Do not push into `{{array}}` the awaited return of a function that received `{{array}}` as an argument: side-effect packets (missions, rewards) would land before the response. Make the helper push its response into `{{array}}` itself (before mission updates) and return void."
+		}
+	},
+
+	create(context) {
+		return {
+			CallExpression(node) {
+				const callee = node.callee;
+
+				// Match `<identifier>.push(...)`
+				if (
+					callee.type !== "MemberExpression"
+					|| callee.computed
+					|| callee.property.type !== "Identifier"
+					|| callee.property.name !== "push"
+					|| callee.object.type !== "Identifier"
+				) {
+					return;
+				}
+
+				const arrayName = callee.object.name;
+
+				for (const rawArg of node.arguments) {
+					// Unwrap `...await fn(...)` and `await fn(...)`.
+					const maybeAwait = rawArg.type === "SpreadElement" ? rawArg.argument : rawArg;
+					if (maybeAwait.type !== "AwaitExpression") {
+						continue;
+					}
+					const call = maybeAwait.argument;
+					if (call.type === "CallExpression" && callArgumentsContainIdentifier(call, arrayName)) {
+						context.report({
+							node,
+							messageId: "noPushThroughReturn",
+							data: { array: arrayName }
+						});
+						return;
+					}
+				}
+			}
+		};
+	}
+};


### PR DESCRIPTION
## Contexte

Fixes #4380

Lors d'un achat de nourriture au **ravitaillement de ville**, la mission se complétait bien mais deux messages parasites apparaissaient : un faux « impossible d'acheter » (sans possibilité de rembourser) puis un message d'erreur.

## Cause racine

`AsyncPacketSender.handleResponse` consommait le callback d'une requête sur **le premier paquet** portant le `packetId`, **sans regarder son type**. Quand une mission se complétait, un `MissionsCompletedPacket` était poussé dans le lot de réponse **avant** la réponse d'achat. Côté Discord, ce paquet de mission déclenchait donc à tort la branche « achat échoué », et la vraie réponse retombait ensuite sur la recherche de listener → erreur.

L'invariant « la réponse doit précéder les paquets broadcast » était implicite et non vérifié : le même smell existait aussi pour le **jardin (plant/harvest)** et le **dépôt de trésorerie de guilde** (mêmes flux qui complètent des missions).

## Changements

**1. Durcissement du transport (élimine la classe de bug)**
- `AsyncPacketSender.handleResponse` ignore désormais les paquets de **notification** (`MissionsCompletedPacket`, `MissionsExpiredPacket`, `PlayerReceivePetPacket`) : ils ne peuvent plus fulfill une requête et sont routés vers leur listener dédié, quel que soit l'ordre.
- Nouveau paramètre optionnel `expectedResponses` sur `sendPacketAndHandleResponse` : quand fourni, seuls les types listés consomment le callback (le reste retombe sur son listener). Le callback d'achat food shop l'utilise.
- Réordonnancement des handlers concernés pour pousser leur réponse **avant** les mises à jour de missions (food shop, dépôt de trésorerie, jardin), alignés sur le pattern de la cuisine.

**2. Garde-fou ESLint (`crownicles/no-response-push-through-return`)**
- Interdit `response.push(await fn(..., response))` : pousser la réponse d'une fonction qui a elle-même reçu le tableau (et y a poussé des side-effects). La règle cible uniquement les appels `await` (le hazard est asynchrone), ce qui évite les faux positifs sur les patterns synchrones « exclure les valeurs déjà tirées ».
- Activée sur Core, Discord, RestWs.

**3. Test de contrat**
- `Lib/tests/packets/AsyncPacketSender.test.ts` verrouille le comportement : un paquet de notification ne fulfill pas une requête en attente, le callback reste enregistré pour la vraie réponse, et `expectedResponses` ignore les paquets non listés. Ce test échouerait avec l'ancien design.
- Test de régression d'intégration ajouté sur `handleFoodShopBuy` (la réponse précède le `MissionsCompletedPacket`).

## Vérifications

- ✅ ESLint (Core, Discord, Lib, RestWs)
- ✅ `tsc` (Core, Discord, Lib)
- ✅ Tests unitaires : Lib 569, Core 1275, Discord 228
- ✅ Tests d'intégration Core : 25/25 (MariaDB)
