### PR TITLE
Fix campaign mission completed before expedition validation

### DIFF
--- a/Core/__tests__-integration/handlers/expedition-campaign-mission-order.integration.test.ts
+++ b/Core/__tests__-integration/handlers/expedition-campaign-mission-order.integration.test.ts
@@ -1,0 +1,149 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { MissionSlot as MissionSlotType } from "../../src/core/database/game/models/MissionSlot";
+import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
+import type { CrowniclesPacket } from "../../../Lib/src/packets/CrowniclesPacket";
+
+type MissionsControllerModule = typeof import("../../src/core/missions/MissionsController");
+type CampaignDataModule = typeof import("../../src/data/Campaign");
+
+/**
+ * Functional regression test for issue #4379.
+ *
+ * A single game action (finishing one dangerous expedition) fires several
+ * mission updates in a row: `doExpeditions`, `longExpedition`,
+ * `dangerousExpedition` and `expeditionStreak`. When `doExpeditions`
+ * completes the current campaign mission and the next campaign mission is
+ * "complete a dangerous expedition", the SAME expedition used to
+ * retroactively complete that freshly-assigned mission — even though the
+ * player finished the expedition before the mission was handed out.
+ *
+ * The fix routes all of an action's mission updates through
+ * `MissionsController.updateMultiple`, which applies every progress count
+ * to the current mission slots BEFORE advancing the campaign. The newly
+ * assigned `dangerousExpedition` campaign mission must therefore stay at
+ * `numberDone = 0`.
+ */
+describe("Expedition campaign mission ordering (issue #4379)", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let MissionSlot: ModelStatic<MissionSlotType>;
+	let PlayerMissionsInfo: ModelStatic<PlayerMissionsInfoType>;
+	let MissionsController: MissionsControllerModule["MissionsController"];
+	let CampaignData: CampaignDataModule["CampaignData"];
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("expeditioncampaignorder");
+		Player = env.crownicles.gameDatabase.sequelize.models.Player as ModelStatic<PlayerType>;
+		MissionSlot = env.crownicles.gameDatabase.sequelize.models.MissionSlot as ModelStatic<MissionSlotType>;
+		PlayerMissionsInfo = env.crownicles.gameDatabase.sequelize.models.PlayerMissionsInfo as ModelStatic<PlayerMissionsInfoType>;
+		MissionsController = loadProductionModule<MissionsControllerModule>("core/missions/MissionsController").MissionsController;
+		CampaignData = loadProductionModule<CampaignDataModule>("data/Campaign").CampaignData;
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await MissionSlot.destroy({ truncate: true, force: true });
+			await PlayerMissionsInfo.destroy({ truncate: true, force: true });
+			await Player.destroy({ truncate: true, force: true });
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	});
+
+	/**
+	 * Locate a `doExpeditions` campaign mission immediately followed (in
+	 * completion order) by a later `dangerousExpedition` campaign mission.
+	 * Every position in between is marked completed so `dangerousExpedition`
+	 * is the very next mission handed out once `doExpeditions` completes.
+	 */
+	function findExpeditionChain(): { doIndex: number; dangerousIndex: number } {
+		const missions = CampaignData.getMissions();
+		const doIndex = missions.findIndex(mission => mission.missionId === "doExpeditions");
+		const dangerousIndex = missions.findIndex((mission, index) => index > doIndex && mission.missionId === "dangerousExpedition");
+		return {
+			doIndex, dangerousIndex
+		};
+	}
+
+	it("does not complete a freshly assigned dangerousExpedition campaign mission with the same expedition", async () => {
+		const { doIndex, dangerousIndex } = findExpeditionChain();
+		expect(doIndex).toBeGreaterThanOrEqual(0);
+		expect(dangerousIndex).toBeGreaterThan(doIndex);
+
+		const missions = CampaignData.getMissions();
+		const doMission = missions[doIndex];
+		const dangerousMission = missions[dangerousIndex];
+
+		// Every campaign mission is already completed except doExpeditions and
+		// dangerousExpedition, so dangerousExpedition is the next one handed out.
+		const campaignBlobChars = Array.from({ length: missions.length }, () => "1");
+		campaignBlobChars[doIndex] = "0";
+		campaignBlobChars[dangerousIndex] = "0";
+
+		const player = await Player.create({ keycloakId: "expedition-order-player" });
+		await PlayerMissionsInfo.create({
+			playerId: player.id,
+			campaignBlob: campaignBlobChars.join(""),
+			campaignProgression: doIndex + 1
+		});
+
+		// Current campaign mission: one expedition away from completing doExpeditions.
+		await MissionSlot.create({
+			playerId: player.id,
+			missionId: doMission.missionId,
+			missionVariant: doMission.missionVariant,
+			missionObjective: doMission.missionObjective,
+			numberDone: doMission.missionObjective - 1,
+			expiresAt: null,
+			gemsToWin: doMission.gemsToWin,
+			pointsToWin: 0,
+			xpToWin: doMission.xpToWin,
+			moneyToWin: doMission.moneyToWin
+		});
+
+		const lockedPlayer = await Player.findOne({ where: { id: player.id } });
+		const response: CrowniclesPacket[] = [];
+
+		// Same order as PetExpeditionCommand.updateExpeditionMissions.
+		await MissionsController.updateMultiple(lockedPlayer!, response, [
+			{ missionId: "doExpeditions" },
+			{
+				missionId: "longExpedition",
+				params: { durationMinutes: 100_000 }
+			},
+			{
+				missionId: "dangerousExpedition",
+				// Maximum risk: satisfies the mission's risk-category variant.
+				params: { riskRate: 100 }
+			},
+			{ missionId: "expeditionStreak" }
+		]);
+
+		const campaignSlot = await MissionSlot.findOne({ where: { playerId: player.id, expiresAt: null } });
+		expect(campaignSlot).not.toBeNull();
+
+		// The campaign advanced to dangerousExpedition...
+		expect(campaignSlot!.missionId).toBe("dangerousExpedition");
+		expect(campaignSlot!.missionObjective).toBe(dangerousMission.missionObjective);
+
+		// ...but it must NOT be completed by the very expedition that assigned it.
+		expect(campaignSlot!.numberDone).toBe(0);
+		expect(campaignSlot!.numberDone).toBeLessThan(campaignSlot!.missionObjective);
+
+		const missionInfo = await PlayerMissionsInfo.findOne({ where: { playerId: player.id } });
+		expect(missionInfo!.campaignProgression).toBe(dangerousIndex + 1);
+	});
+});

--- a/Core/src/commands/pet/PetExpeditionCommand.ts
+++ b/Core/src/commands/pet/PetExpeditionCommand.ts
@@ -97,16 +97,18 @@ async function updateExpeditionMissions(
 		return;
 	}
 
-	await MissionsController.update(player, response, { missionId: "doExpeditions" });
-	await MissionsController.update(player, response, {
-		missionId: "longExpedition",
-		params: { durationMinutes: expeditionData.durationMinutes }
-	});
-	await MissionsController.update(player, response, {
-		missionId: "dangerousExpedition",
-		params: { riskRate: expeditionData.riskRate }
-	});
-	await MissionsController.update(player, response, { missionId: "expeditionStreak" });
+	await MissionsController.updateMultiple(player, response, [
+		{ missionId: "doExpeditions" },
+		{
+			missionId: "longExpedition",
+			params: { durationMinutes: expeditionData.durationMinutes }
+		},
+		{
+			missionId: "dangerousExpedition",
+			params: { riskRate: expeditionData.riskRate }
+		},
+		{ missionId: "expeditionStreak" }
+	]);
 }
 
 /**

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -234,6 +234,49 @@ export abstract class MissionsController {
 	}
 
 	/**
+	 * Acquire the per-player mission lock (Player + PlayerMissionsInfo rows) and run
+	 * `body` under it, resolving the current daily mission first.
+	 *
+	 * The daily mission is resolved BEFORE acquiring the lock: DailyMissions.getOrGenerate()
+	 * can run a whole-table UPDATE on player_missions_info when the daily mission rolls
+	 * over, which would otherwise execute inside this player's transaction and hold row
+	 * locks on every player_missions_info row until commit — causing cascading
+	 * ER_LOCK_WAIT_TIMEOUT (1205).
+	 *
+	 * A vanished locked row (LockedRowNotFoundError) is warn-and-skipped so fire-and-forget
+	 * callers don't crash on a concurrently-deleted player.
+	 * @param player
+	 * @param caller identifier used in the skip warning
+	 * @param body the work to run once the rows are locked
+	 */
+	private static async runUnderMissionLock(
+		player: Player,
+		caller: string,
+		body: (lockedPlayer: Player, lockedMissionInfo: PlayerMissionsInfo, dailyMission: DailyMission) => Promise<Player>
+	): Promise<Player> {
+		const dailyMission = await DailyMissions.getOrGenerate();
+		await PlayerMissionsInfos.getOfPlayer(player.id);
+		try {
+			return await withLockedEntities(
+				[
+					Player.lockKey(player.id),
+					PlayerMissionsInfo.lockKey(player.id)
+				] as const,
+				([lockedPlayer, lockedMissionInfo]) => body(lockedPlayer, lockedMissionInfo, dailyMission)
+			);
+		}
+		catch (e) {
+			if (e instanceof LockedRowNotFoundError) {
+				CrowniclesLogger.warn(
+					`${caller}: locked row vanished for player ${player.id} — skipping mission update`
+				);
+				return player;
+			}
+			throw e;
+		}
+	}
+
+	/**
 	 * Update all the mission of the user
 	 * @param player
 	 * @param response the response packets
@@ -242,7 +285,7 @@ export abstract class MissionsController {
 	 * @param params
 	 * @param set
 	 */
-	static async update(
+	static update(
 		player: Player,
 		response: CrowniclesPacket[],
 		{
@@ -253,45 +296,19 @@ export abstract class MissionsController {
 			applyOnLockedPlayer
 		}: MissionInformations
 	): Promise<Player> {
-		/*
-		 * Resolve the current daily mission BEFORE acquiring the per-player lock.
-		 * DailyMissions.getOrGenerate() can run a whole-table UPDATE on player_missions_info
-		 * when the daily mission rolls over, which would otherwise be executed inside this
-		 * player's transaction and hold row locks on every player_missions_info row
-		 * until the transaction commits — causing cascading ER_LOCK_WAIT_TIMEOUT (1205).
-		 */
-		const dailyMission = await DailyMissions.getOrGenerate();
-		await PlayerMissionsInfos.getOfPlayer(player.id);
-		try {
-			return await withLockedEntities(
-				[
-					Player.lockKey(player.id),
-					PlayerMissionsInfo.lockKey(player.id)
-				] as const,
-				([lockedPlayer, lockedMissionInfo]) => {
-					/*
-					 * Apply the caller-supplied mutation on the locked instance so
-					 * the change is persisted under the same row lock as the mission
-					 * progression — see `applyOnLockedPlayer` JSDoc and #4207.
-					 */
-					applyOnLockedPlayer?.(lockedPlayer);
-					const resolvedCount = typeof count === "function" ? count(lockedPlayer) : count;
-					const info: ResolvedMissionInformations = {
-						missionId, count: resolvedCount, params, set, applyOnLockedPlayer
-					};
-					return MissionsController.runUpdateUnderLock(lockedPlayer, lockedMissionInfo, response, info, dailyMission);
-				}
-			);
-		}
-		catch (e) {
-			if (e instanceof LockedRowNotFoundError) {
-				CrowniclesLogger.warn(
-					`MissionsController.update: locked row vanished for player ${player.id} — skipping mission update`
-				);
-				return player;
-			}
-			throw e;
-		}
+		return MissionsController.runUnderMissionLock(player, "MissionsController.update", (lockedPlayer, lockedMissionInfo, dailyMission) => {
+			/*
+			 * Apply the caller-supplied mutation on the locked instance so
+			 * the change is persisted under the same row lock as the mission
+			 * progression — see `applyOnLockedPlayer` JSDoc and #4207.
+			 */
+			applyOnLockedPlayer?.(lockedPlayer);
+			const resolvedCount = typeof count === "function" ? count(lockedPlayer) : count;
+			const info: ResolvedMissionInformations = {
+				missionId, count: resolvedCount, params, set, applyOnLockedPlayer
+			};
+			return MissionsController.runUpdateUnderLock(lockedPlayer, lockedMissionInfo, response, info, dailyMission);
+		});
 	}
 
 	private static async runUpdateUnderLock(
@@ -309,6 +326,81 @@ export abstract class MissionsController {
 		);
 		const updated = await MissionsController.checkCompletedMissionsUnderLock(
 			player, missionSlots, missionInfo, response, specialMissionCompletion, dailyMission
+		);
+
+		await updated.save();
+		return updated;
+	}
+
+	/**
+	 * Update several missions triggered by a single game action in one atomic pass.
+	 *
+	 * All progress counts are applied to the player's CURRENT mission slots BEFORE
+	 * any campaign progression happens: campaign completion is evaluated only once,
+	 * after every count has been consumed. This guarantees that a campaign mission
+	 * freshly assigned by completing a previous one cannot be retroactively completed
+	 * by another mission update belonging to the same action.
+	 *
+	 * Example: finishing a dangerous expedition triggers `doExpeditions`,
+	 * `longExpedition`, `dangerousExpedition` and `expeditionStreak`. If
+	 * `doExpeditions` completes the current campaign mission and the next one is
+	 * "complete a dangerous expedition", that new mission must NOT be completed by
+	 * the very expedition that assigned it.
+	 *
+	 * @see https://github.com/Crownicles/Crownicles/issues/4379
+	 * @param player
+	 * @param response the response packets
+	 * @param missionInformationsList the mission updates to apply together
+	 */
+	static updateMultiple(
+		player: Player,
+		response: CrowniclesPacket[],
+		missionInformationsList: MissionInformations[]
+	): Promise<Player> {
+		return MissionsController.runUnderMissionLock(
+			player,
+			"MissionsController.updateMultiple",
+			(lockedPlayer, lockedMissionInfo, dailyMission) =>
+				MissionsController.runBatchUpdateUnderLock(lockedPlayer, lockedMissionInfo, response, missionInformationsList, dailyMission)
+		);
+	}
+
+	private static async runBatchUpdateUnderLock(
+		player: Player,
+		missionInfo: PlayerMissionsInfo,
+		response: CrowniclesPacket[],
+		missionInformationsList: MissionInformations[],
+		dailyMission: DailyMission
+	): Promise<Player> {
+		const missionSlots = await MissionSlots.getOfPlayer(player.id);
+
+		await MissionsController.handleExpiredMissionsUnderLock(player, missionSlots, response);
+
+		const aggregatedCompletion: SpecialMissionCompletion = {
+			daily: false,
+			campaign: false
+		};
+		for (const missionInformations of missionInformationsList) {
+			missionInformations.applyOnLockedPlayer?.(player);
+			const resolvedCount = typeof missionInformations.count === "function"
+				? missionInformations.count(player)
+				: missionInformations.count ?? 1;
+			const info: ResolvedMissionInformations = {
+				missionId: missionInformations.missionId,
+				count: resolvedCount,
+				params: missionInformations.params ?? {},
+				set: missionInformations.set ?? false,
+				applyOnLockedPlayer: missionInformations.applyOnLockedPlayer
+			};
+			const completion = await MissionsController.updateMissionsCountsUnderLock(
+				info, missionSlots, missionInfo, player, response, dailyMission
+			);
+			aggregatedCompletion.daily = aggregatedCompletion.daily || completion.daily;
+			aggregatedCompletion.campaign = aggregatedCompletion.campaign || completion.campaign;
+		}
+
+		const updated = await MissionsController.checkCompletedMissionsUnderLock(
+			player, missionSlots, missionInfo, response, aggregatedCompletion, dailyMission
 		);
 
 		await updated.save();


### PR DESCRIPTION
## Problème (Fixes #4379)

Une seule expédition réussie déclenche **4 appels séquentiels** à `MissionsController.update` (`doExpeditions`, `longExpedition`, `dangerousExpedition`, `expeditionStreak`).

Le 1er appel (`doExpeditions`) complète la mission de campagne « 25 expéditions », fait avancer la campagne (auto-complétion de « arbre ancestral » via l'état déjà acquis) puis **assigne** la mission suivante « expédition hasardeuse ». Le 3e appel (`dangerousExpedition`) de la **même** expédition complétait alors immédiatement cette mission fraîchement assignée — alors que le joueur a techniquement terminé l'expédition *avant* de recevoir la mission.

## Correction

Ajout de `MissionsController.updateMultiple`, qui applique **tous les compteurs d'une même action sur les slots de mission courants AVANT** toute progression de campagne (évaluée une seule fois, à la fin). Ainsi une mission de campagne assignée par l'action ne peut plus être complétée rétroactivement par cette même action.

Le comportement légitime (chaîne d'auto-complétion basée sur un état déjà acquis, ex. arbre ancestral) reste intact.

`PetExpeditionCommand` route désormais ses 4 updates via `updateMultiple`.

Le boilerplate de verrou partagé entre `update` et `updateMultiple` a été extrait dans un helper commun `runUnderMissionLock` pour éviter la duplication.

## Tests

- Test d'intégration de régression ajouté (`expedition-campaign-mission-order.integration.test.ts`).
- 826 tests unitaires missions/expéditions ✅
- Tests d'intégration de course (`mission-money`, `mission-thousand-points`, `daily-bonus`) ✅
- `pnpm eslint` (règles custom incluses) et `pnpm tsc` ✅
