### PR TITLE
fix #4357 stabilise la recette epinglee du fourneau (swap sans perte)

### DIFF
--- a/Core/__tests__/core/cooking/CookingService.test.ts
+++ b/Core/__tests__/core/cooking/CookingService.test.ts
@@ -183,6 +183,15 @@ describe("CookingService - pure functions", () => {
 				cookingSlots: 3
 			});
 
+		// Resolve the deterministic anchor slot for a recipe by injecting it into empty slots.
+		const computeAnchorIndex = (pinnedCookingRecipeId: string): number => {
+			const emptySlots: Array<CookingRecipe | null> = [null, null, null];
+			injectPotion(emptySlots, pinnedCookingRecipeId);
+			const anchorIndex = emptySlots.findIndex(r => r?.id === pinnedCookingRecipeId);
+			expect(anchorIndex).not.toBe(-1);
+			return anchorIndex;
+		};
+
 		it("should inject a pinned potion into an eligible slot when not already present", () => {
 			const slots: Array<CookingRecipe | null> = [null, null, null];
 			injectPotion(slots, "potion_health_1");
@@ -191,11 +200,7 @@ describe("CookingService - pure functions", () => {
 		});
 
 		it("should anchor the pinned recipe to a stable slot regardless of any pre-existing occurrence", () => {
-			// Reference placement on empty slots gives the deterministic anchor slot.
-			const emptySlots: Array<CookingRecipe | null> = [null, null, null];
-			injectPotion(emptySlots, "potion_health_1");
-			const anchorIndex = emptySlots.findIndex(r => r?.id === "potion_health_1");
-			expect(anchorIndex).not.toBe(-1);
+			const anchorIndex = computeAnchorIndex("potion_health_1");
 
 			// A natural occurrence in another slot must be moved to the anchor, appearing exactly once.
 			const existing = { id: "potion_health_1" } as CookingRecipe;
@@ -206,6 +211,61 @@ describe("CookingService - pure functions", () => {
 
 			expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
 			expect(slots.findIndex(r => r?.id === "potion_health_1")).toBe(anchorIndex);
+		});
+
+		it("should swap the displaced recipe into the vacated slot instead of leaving a hole", () => {
+			const anchorIndex = computeAnchorIndex("potion_health_1");
+
+			// Full rotation: a different recipe sits on the anchor, the pinned one elsewhere.
+			const otherIndex = anchorIndex === 0 ? 1 : 0;
+			const displaced = createTestRecipe({ id: "displaced_recipe" });
+			const slots: Array<CookingRecipe | null> = [null, null, null];
+			slots[anchorIndex] = displaced;
+			slots[otherIndex] = { id: "potion_health_1" } as CookingRecipe;
+			injectPotion(slots, "potion_health_1");
+
+			// Pinned recipe reaches its anchor slot exactly once...
+			expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
+			expect(slots[anchorIndex]?.id).toBe("potion_health_1");
+			// ...and the displaced recipe keeps its place in the vacated slot (no empty station).
+			expect(slots[otherIndex]?.id).toBe("displaced_recipe");
+		});
+
+		it("should keep the pinned recipe on the same anchor slot across re-rolls without ever emptying a slot", () => {
+			const anchorIndex = computeAnchorIndex("potion_health_1");
+
+			// Simulate several furnace re-rolls: the pinned recipe lands in a different
+			// natural slot each time, the two other slots hold distinct filler recipes.
+			for (let naturalIndex = 0; naturalIndex < 3; naturalIndex++) {
+				const slots: Array<CookingRecipe | null> = [
+					createTestRecipe({ id: "filler_0" }),
+					createTestRecipe({ id: "filler_1" }),
+					createTestRecipe({ id: "filler_2" })
+				];
+				slots[naturalIndex] = { id: "potion_health_1" } as CookingRecipe;
+				injectPotion(slots, "potion_health_1");
+
+				// Always exactly one occurrence, always on the same stable anchor slot.
+				expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
+				expect(slots[anchorIndex]?.id).toBe("potion_health_1");
+				// No station is ever emptied by the anchoring (slot count preserved).
+				expect(slots.every(r => r !== null)).toBe(true);
+			}
+		});
+
+		it("should be a no-op when the pinned recipe already sits on its anchor slot", () => {
+			const anchorIndex = computeAnchorIndex("potion_health_1");
+
+			const otherIndex = anchorIndex === 0 ? 1 : 0;
+			const slots: Array<CookingRecipe | null> = [null, null, null];
+			slots[anchorIndex] = { id: "potion_health_1" } as CookingRecipe;
+			slots[otherIndex] = createTestRecipe({ id: "untouched_recipe" });
+			injectPotion(slots, "potion_health_1");
+
+			// The pinned recipe stays put and the neighbour slot is left untouched.
+			expect(slots.filter(r => r?.id === "potion_health_1")).toHaveLength(1);
+			expect(slots[anchorIndex]?.id).toBe("potion_health_1");
+			expect(slots[otherIndex]?.id).toBe("untouched_recipe");
 		});
 
 		it("should be a no-op when player has no pinned recipe", () => {

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -547,27 +547,40 @@ export class CookingService {
 
 	/**
 	 * Anchor the pinned recipe to a deterministic slot so its position stays
-	 * stable across furnace re-rolls, dropping any natural occurrence the
-	 * rotation placed in another slot so it never appears twice. No-op when no
-	 * available slot can host the recipe.
+	 * stable across furnace re-rolls. When the rotation already placed the recipe
+	 * in another slot, the two slots are swapped instead of overwriting the anchor:
+	 * the pinned recipe reaches its stable anchor slot while the recipe it displaces
+	 * keeps a slot rather than vanishing and leaving an empty station. The recipe
+	 * never appears twice. No-op when no available slot can host the recipe.
 	 */
 	private static anchorPinnedRecipe({
 		slotRecipes, cookingSlots
 	}: PinnedRecipeInjection, pinnedRecipe: CookingRecipe): void {
-		const compatibleSlotIndex = SLOT_CONFIGS.findIndex((config, idx) =>
+		const anchorSlotIndex = SLOT_CONFIGS.findIndex((config, idx) =>
 			idx < cookingSlots
 			&& pinnedRecipe.level >= config.minLevel
 			&& pinnedRecipe.level <= config.maxLevel
 			&& config.eligibleTypes.includes(pinnedRecipe.recipeType));
-		if (compatibleSlotIndex === -1) {
+		if (anchorSlotIndex === -1) {
 			return;
 		}
-		for (let i = 0; i < slotRecipes.length; i++) {
-			if (i !== compatibleSlotIndex && slotRecipes[i]?.id === pinnedRecipe.id) {
-				slotRecipes[i] = null;
-			}
+
+		const naturalSlotIndex = slotRecipes.findIndex(recipe => recipe?.id === pinnedRecipe.id);
+
+		// Already sitting in its anchor slot: nothing to move.
+		if (naturalSlotIndex === anchorSlotIndex) {
+			return;
 		}
-		slotRecipes[compatibleSlotIndex] = pinnedRecipe;
+
+		if (naturalSlotIndex === -1) {
+			// Absent from the current rotation: inject it into its anchor slot.
+			slotRecipes[anchorSlotIndex] = pinnedRecipe;
+			return;
+		}
+
+		// Present elsewhere: swap so the displaced recipe keeps a slot instead of vanishing.
+		slotRecipes[naturalSlotIndex] = slotRecipes[anchorSlotIndex];
+		slotRecipes[anchorSlotIndex] = pinnedRecipe;
 	}
 
 	/**


### PR DESCRIPTION
## Contexte

Corrige l'issue #4357. Le fix précédent (#4363) ancrait la recette épinglée sur un slot déterministe (stable entre les relances), mais de façon **destructive** :

- il **écrasait** la recette présente sur le slot d'ancrage (recette perdue → « prend la place d'une autre »),
- il **vidait** le slot d'origine de la recette épinglée (station vide / « cafouillages » / duplication perçue).

## Changement

`anchorPinnedRecipe` réalise désormais un **échange (swap)** au lieu d'un déplacement destructif :

- déjà sur son slot d'ancrage → no-op ;
- absente de la rotation → injectée sur son slot d'ancrage ;
- présente ailleurs → **swap** des deux slots : la recette épinglée rejoint son slot d'ancrage stable, et la recette déplacée garde une place au lieu de disparaître.

Résultat : la recette épinglée apparaît **exactement une fois**, **aucun slot n'est vidé**, **aucune recette n'est perdue**, et la position reste **stable entre les relances**.

## Tests

5 tests unitaires sur `injectPinnedRecipeIfEligible` couvrant les invariants :
- occurrence unique (pas de doublon),
- swap qui préserve la recette déplacée (pas de trou),
- stabilité du slot d'ancrage à travers plusieurs relances,
- no-op si déjà ancrée / si aucune recette épinglée.

`pnpm eslint` vert sur Core, suite Core complète verte (1276 tests).

Fixes #4357
