### PR TITLE
ajoute des conseils cuisine et de localisation des PNJ #4378

### DIFF
--- a/Lang/fr/advices.json
+++ b/Lang/fr/advices.json
@@ -458,6 +458,23 @@
     "Les temps d'attente des services (repas, sommeil, enchantements) sont affichés avec des horaires Discord qui se mettent à jour automatiquement dans votre fuseau horaire.",
     "Le forgeron permet de désenchanter des objets ou d'en améliorer les niveaux, tandis que l'enchanteur leur ajoute de nouvelles propriétés : leurs rôles sont complémentaires.",
     "Certaines missions ou événements vous obligent à rester en ville pour progresser, tandis que d'autres exigent que vous continuiez votre route : lisez les objectifs attentivement.",
-    "Les auberges proposent des repas différents chaque jour selon une sélection rotative, ce qui signifie que certains bonus d'énergie ne sont disponibles qu'à des jours précis."
+    "Les auberges proposent des repas différents chaque jour selon une sélection rotative, ce qui signifie que certains bonus d'énergie ne sont disponibles qu'à des jours précis.",
+    "Allumer ou relancer le fourneau de votre cuisine consomme un matériau de type bois, en priorisant les ressources les plus communes.",
+    "Vous pouvez épingler une recette pour la conserver et la fabriquer plus tard. Une recette dont le résultat est inconnu ne peut pas être épinglée.",
+    "Relancer le fourneau de votre cuisine renouvelle les recettes proposées.",
+    "La cuisine permet de fabriquer diverses recettes, comme de la nourriture pour vos familiers ou des potions, à partir de matériaux et de plantes.",
+    "Améliorer votre maison débloque des emplacements de cuisson supplémentaires, pour accéder à une plus grande variété de recettes.",
+    "Certaines recettes de cuisine doivent d'abord être découvertes au cours de votre aventure avant de pouvoir être fabriquées.",
+    "Les recettes de cuisine les plus difficiles rapportent davantage d'expérience de cuisine.",
+    "Monter en niveau de cuisine vous rend plus efficace dans vos préparations et débloque divers avantages.",
+    "À partir du niveau 11 de cuisine, vous avez de faibles chances de ne pas consommer certains ingrédients lors de vos préparations.",
+    "Un Grand cuisinier royal n'échoue presque aucune recette de cuisine.",
+    "Si vous avez besoin de bois, le bûcheron du Village Coco pourra vous en vendre.",
+    "Les vétérinaires du royaume sont installés à Mergagnan et à Claire de Ville : n'hésitez pas à leur présenter votre familier.",
+    "Le Tanneur de Mergagnan vous permet d'agrandir votre inventaire.",
+    "La Bourse de Claire de Ville offre un service de spéculation.",
+    "Les gemmes peuvent être échangées contre des récompenses uniques au château du roi.",
+    "Si vous cherchez des matériaux, visitez la Ville Forte : un marchand peut vous en vendre.",
+    "Un herboriste s'est installé au Village Coco."
   ]
 }


### PR DESCRIPTION
## Contexte

Implémente l'issue #4378 : ajout de nouveaux conseils (pool `advices`) pour la V6, la cuisine n'en ayant quasiment aucun.

## Conseils cuisine (10)

Faits vérifiés dans le code (`CookingConstants`, `CookingService`) :

- consommation de bois en priorisant les ressources communes,
- épinglage d'une recette (impossible si le résultat est inconnu),
- relance = renouvellement des recettes,
- fabrication de nourriture pour familiers / potions à partir de matériaux et plantes,
- emplacements de cuisson débloqués par le niveau de maison,
- recettes à découvrir en aventure,
- recettes difficiles = plus d'expérience,
- avantages liés au niveau de cuisine,
- économie d'ingrédients à partir du **niveau 11** (grade Marmiton, `materialSaveChance`),
- **Grand cuisinier royal** ≈ jamais d'échec (`royalGrandChef`, `failureRate` 1 %).

## Conseils localisation des PNJ (7)

Localisations vérifiées via `Core/resources/cities/*.json` :

- bûcheron & herboriste → **Village Coco** (`coco_village`),
- vétérinaires → **Mergagnan** (`seawynne`) et **Claire de Ville**,
- Tanneur → **Mergagnan**,
- Bourse (spéculation) → **Claire de Ville**,
- marchand de matériaux → **Ville Forte**,
- gemmes → récompenses uniques au **château du roi** (Marché royal).

## Notes

- Uniquement le fichier FR modifié (les autres langues sont synchronisées via Crowdin).
- Style narratif, aucun discours direct, aucun emoji hardcodé.
- JSON validé, aucun doublon exact dans le pool.
- Le conseil « marchand de jetons » proposé dans l'issue est **déjà couvert** par 2 conseils existants → écarté pour éviter un doublon.

Fixes #4378
