### PR TITLE
fix #4401 use attacker level for alteration damage bonus

### DIFF
--- a/Core/__tests__/core/fights/actions/FightActionController.test.ts
+++ b/Core/__tests__/core/fights/actions/FightActionController.test.ts
@@ -1,17 +1,25 @@
 import {
-	describe, expect, it, vi
+	afterAll, beforeAll, describe, expect, it, vi
 } from "vitest";
 import { RandomUtils } from "../../../../../Lib/src/utils/RandomUtils";
 import { FightActionController } from "../../../../src/core/fights/actions/FightActionController";
 import type { Fighter } from "../../../../src/core/fights/fighter/Fighter";
-
-vi.spyOn(RandomUtils, "variationInt").mockReturnValue(0);
 
 function buildFighter(level: number): Fighter {
 	return { level } as Fighter;
 }
 
 describe("FightActionController.getAttackDamage", () => {
+	let variationIntSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(() => {
+		variationIntSpy = vi.spyOn(RandomUtils, "variationInt").mockReturnValue(0);
+	});
+
+	afterAll(() => {
+		variationIntSpy.mockRestore();
+	});
+
 	const statsInfo = {
 		attackerStats: [100], defenderStats: [100], statsEffect: [1]
 	};

--- a/Core/__tests__/core/fights/actions/FightActionController.test.ts
+++ b/Core/__tests__/core/fights/actions/FightActionController.test.ts
@@ -1,0 +1,33 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { RandomUtils } from "../../../../../Lib/src/utils/RandomUtils";
+import { FightActionController } from "../../../../src/core/fights/actions/FightActionController";
+import type { Fighter } from "../../../../src/core/fights/fighter/Fighter";
+
+vi.spyOn(RandomUtils, "variationInt").mockReturnValue(0);
+
+function buildFighter(level: number): Fighter {
+	return { level } as Fighter;
+}
+
+describe("FightActionController.getAttackDamage", () => {
+	const statsInfo = {
+		attackerStats: [100], defenderStats: [100], statsEffect: [1]
+	};
+	const attackInfo = {
+		minDamage: 10, averageDamage: 50, maxDamage: 100
+	};
+
+	it("applies the level bonus of the fighter passed as attacker, not any other fighter", () => {
+		const lowLevelFighter = buildFighter(1);
+		const highLevelFighter = buildFighter(100);
+
+		const damageWithLowLevelAttacker = FightActionController.getAttackDamage(statsInfo, lowLevelFighter, attackInfo, true);
+		const damageWithHighLevelAttacker = FightActionController.getAttackDamage(statsInfo, highLevelFighter, attackInfo, true);
+
+		// A higher attacker level must yield a strictly higher level bonus (regression test for #4401:
+		// alteration damage was previously computed using the victim's level instead of the original attacker's)
+		expect(damageWithHighLevelAttacker).toBeGreaterThan(damageWithLowLevelAttacker);
+	});
+});

--- a/Core/__tests__/core/fights/actions/alterations/poisoned.test.ts
+++ b/Core/__tests__/core/fights/actions/alterations/poisoned.test.ts
@@ -1,0 +1,55 @@
+import {
+	afterAll, beforeAll, describe, expect, it, vi
+} from "vitest";
+import { RandomUtils } from "../../../../../../Lib/src/utils/RandomUtils";
+import poisonedUse from "../../../../../src/core/fights/actions/interfaces/alterations/poisoned";
+import type { Fighter } from "../../../../../src/core/fights/fighter/Fighter";
+import type { FightAlteration } from "../../../../../src/data/FightAlteration";
+import type { FightController } from "../../../../../src/core/fights/FightController";
+
+const ATTACK = 50;
+
+function buildAffected(): Fighter {
+	// alterationTurn 1 keeps the alteration in its damage branch (the heal branch requires alterationTurn > 3).
+	// A fixed level ensures that, if damage were (wrongly) scaled by the victim, both scenarios would be equal.
+	return {
+		level: 1, alterationTurn: 1
+	} as Fighter;
+}
+
+function buildOpponent(level: number): Fighter {
+	return {
+		level,
+		getAttack: () => ATTACK,
+		getAlterationMultiplier: () => 1
+	} as unknown as Fighter;
+}
+
+/**
+ * Regression test for #4401: the alteration damage must scale with the level of the fighter who
+ * inflicted the alteration (opponent), not the victim (affected). This guards the call-site wiring
+ * that passes `opponent` to defaultDamageFightAlterationResult.
+ */
+describe("poisoned alteration wiring", () => {
+	let variationIntSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(() => {
+		variationIntSpy = vi.spyOn(RandomUtils, "variationInt").mockReturnValue(0);
+	});
+
+	afterAll(() => {
+		variationIntSpy.mockRestore();
+	});
+
+	it("scales poison damage with the inflicting opponent's level, not the victim's", () => {
+		const affected = buildAffected();
+		const noArgs = null as unknown as FightAlteration;
+		const fight = null as unknown as FightController;
+
+		const lowLevelOpponentDamage = poisonedUse(affected, noArgs, buildOpponent(1), 1, fight).damages;
+		const highLevelOpponentDamage = poisonedUse(affected, noArgs, buildOpponent(100), 1, fight).damages;
+
+		expect(lowLevelOpponentDamage).toBeGreaterThan(0);
+		expect(highLevelOpponentDamage).toBeGreaterThan(lowLevelOpponentDamage!);
+	});
+});

--- a/Core/src/core/fights/FightController.ts
+++ b/Core/src/core/fights/FightController.ts
@@ -552,13 +552,13 @@ export function defaultRandomActionFightAlterationResult(affected: Fighter): Fig
 
 /**
  * Default damage fight alteration result
- * @param affected
+ * @param attacker The fighter who inflicted the alteration (used for the level bonus)
  * @param statsInfo
  * @param attackInfo
  */
-export function defaultDamageFightAlterationResult(affected: Fighter, statsInfo: statsInfo, attackInfo: attackInfo): FightAlterationResult {
+export function defaultDamageFightAlterationResult(attacker: Fighter, statsInfo: statsInfo, attackInfo: attackInfo): FightAlterationResult {
 	return {
 		state: FightAlterationState.ACTIVE,
-		damages: FightActionController.getAttackDamage(statsInfo, affected, attackInfo, true)
+		damages: FightActionController.getAttackDamage(statsInfo, attacker, attackInfo, true)
 	};
 }

--- a/Core/src/core/fights/actions/interfaces/alterations/alliesArePresent.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/alliesArePresent.ts
@@ -6,7 +6,7 @@ import { FightAlterationFunc } from "../../../../../data/FightAlteration";
 import { defaultDamageFightAlterationResult } from "../../../FightController";
 
 const use: FightAlterationFunc = (affected, _fightAlteration, opponent) =>
-	defaultDamageFightAlterationResult(affected, getStatsInfo(affected, opponent), getAttackInfo());
+	defaultDamageFightAlterationResult(opponent, getStatsInfo(affected, opponent), getAttackInfo());
 
 export default use;
 

--- a/Core/src/core/fights/actions/interfaces/alterations/blackCorrosion.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/blackCorrosion.ts
@@ -41,7 +41,7 @@ const use: FightAlterationFunc = (affected, fightAlteration, opponent) => {
 		}, affected, fightAlteration);
 	}
 
-	result.damages = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), affected, getAttackInfo(), true);
+	result.damages = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), opponent, getAttackInfo(), true);
 	return result;
 };
 

--- a/Core/src/core/fights/actions/interfaces/alterations/bleeding.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/bleeding.ts
@@ -34,7 +34,7 @@ const use: FightAlterationFunc = (affected, _fightAlteration, opponent) => {
 	if (affected.alterationTurn > turnsToHeal || (affected.alterationTurn > 1 && affected.getLastFightActionUsed()?.id === FightConstants.FIGHT_ACTIONS.PLAYER.RESTING)) {
 		return defaultHealFightAlterationResult(affected);
 	}
-	return defaultDamageFightAlterationResult(affected, getStatsInfo(affected, opponent), getAttackInfo(affected.alterationTurn));
+	return defaultDamageFightAlterationResult(opponent, getStatsInfo(affected, opponent), getAttackInfo(affected.alterationTurn));
 };
 
 export default use;

--- a/Core/src/core/fights/actions/interfaces/alterations/burned.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/burned.ts
@@ -22,7 +22,7 @@ const use: FightAlterationFunc = (affected, _fightAlteration, opponent) => {
 		return defaultHealFightAlterationResult(affected);
 	}
 
-	const burn = defaultDamageFightAlterationResult(affected, getStatsInfo(affected, opponent), getAttackInfo());
+	const burn = defaultDamageFightAlterationResult(opponent, getStatsInfo(affected, opponent), getAttackInfo());
 	if (burn.damages) {
 		burn.damages *= opponent.getAlterationMultiplier(FightAlterations.BURNED); // Apply alteration multiplier
 	}

--- a/Core/src/core/fights/actions/interfaces/alterations/confused.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/confused.ts
@@ -21,7 +21,7 @@ const use: FightAlterationFunc = (affected, _fightAlteration, opponent) => {
 
 	if (RandomUtils.crowniclesRandom.bool(0.5)) {
 		affected.nextFightAction = FightActionDataController.instance.getNone();
-		return defaultDamageFightAlterationResult(affected, getStatsInfo(affected, opponent), getAttackInfo());
+		return defaultDamageFightAlterationResult(opponent, getStatsInfo(affected, opponent), getAttackInfo());
 	}
 
 	return defaultFightAlterationResult();

--- a/Core/src/core/fights/actions/interfaces/alterations/cursed.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/cursed.ts
@@ -13,7 +13,7 @@ const use: FightAlterationFunc = (affected, _fightAlteration, opponent, turn) =>
 	// 50 % chance to be healed from the cursed (except for the first two turns) and 100 % on 5th turn of being cursed
 	if ((Math.random() < 0.5 && affected.alterationTurn > 2) || affected.alterationTurn > 4) {
 		const result = defaultHealFightAlterationResult(affected);
-		let damageDealt = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), affected, getAttackInfo(), true);
+		let damageDealt = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), opponent, getAttackInfo(), true);
 		damageDealt += MathUtils.getIntervalValue(0, damageDealt * 2, (affected.alterationTurn - 2) / 3);
 		damageDealt += MathUtils.getIntervalValue(0, damageDealt, Math.min(turn, FightConstants.MAX_TURNS) / FightConstants.MAX_TURNS);
 		result.damages = Math.round(damageDealt);

--- a/Core/src/core/fights/actions/interfaces/alterations/cursedByTheSea.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/cursedByTheSea.ts
@@ -16,7 +16,7 @@ import { FightAlterations } from "../../FightAlterations";
 const use: FightAlterationFunc = (affected, _fightAlteration, opponent, turn) => {
 	if ((Math.random() < 0.4 && affected.alterationTurn > 2) || affected.alterationTurn > 4) {
 		const result = defaultHealFightAlterationResult(affected);
-		let damageDealt = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), affected, getAttackInfo(), true);
+		let damageDealt = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), opponent, getAttackInfo(), true);
 		damageDealt += MathUtils.getIntervalValue(0, damageDealt * 2, (affected.alterationTurn - 2) / 3);
 		damageDealt += MathUtils.getIntervalValue(0, damageDealt, Math.min(turn, FightConstants.MAX_TURNS) / FightConstants.MAX_TURNS);
 		result.damages = Math.round(damageDealt);

--- a/Core/src/core/fights/actions/interfaces/alterations/frozen.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/frozen.ts
@@ -37,7 +37,7 @@ const use: FightAlterationFunc = (affected, fightAlteration, opponent) => {
 			value: 0.4
 		}, affected, fightAlteration);
 	}
-	result.damages = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), affected, getAttackInfo(), true);
+	result.damages = FightActionController.getAttackDamage(getStatsInfo(affected, opponent), opponent, getAttackInfo(), true);
 
 	if (result.damages) {
 		result.damages *= opponent.getAlterationMultiplier(FightAlterations.FROZEN); // Apply alteration multiplier

--- a/Core/src/core/fights/actions/interfaces/alterations/poisoned.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/poisoned.ts
@@ -14,7 +14,7 @@ const use: FightAlterationFunc = (affected, _fightAlteration, opponent) => {
 		return defaultHealFightAlterationResult(affected);
 	}
 
-	const poison = defaultDamageFightAlterationResult(affected, getStatsInfo(affected, opponent), getAttackInfo());
+	const poison = defaultDamageFightAlterationResult(opponent, getStatsInfo(affected, opponent), getAttackInfo());
 	if (poison.damages) {
 		poison.damages *= opponent.getAlterationMultiplier(FightAlterations.POISONED); // Apply alteration multiplier
 	}

--- a/Core/src/core/fights/actions/interfaces/alterations/targeted.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/targeted.ts
@@ -22,7 +22,7 @@ const use: FightAlterationFunc = (affected, _fightAlteration, opponent) => {
 		return defaultHealFightAlterationResult(affected);
 	}
 
-	return defaultDamageFightAlterationResult(affected, getStatsInfo(affected, opponent), getAttackInfo());
+	return defaultDamageFightAlterationResult(opponent, getStatsInfo(affected, opponent), getAttackInfo());
 };
 
 export default use;


### PR DESCRIPTION
Fixes #4401

Le bonus/malus de niveau appliqué aux dégâts d'altération (poison, brûlure, gel, saignement, confusion, ciblé, alliés présents) utilisait le niveau de la victime (`affected`) au lieu du niveau de celui qui a infligé l'altération (`opponent`).

Résultat : un lvl 120 empoisonnant un lvl 20-30 infligeait les dégâts d'un lvl 30, et inversement.

## Changements
- `FightController.defaultDamageFightAlterationResult` prend désormais explicitement `attacker` (au lieu de `affected`) pour le calcul du bonus de niveau.
- Tous les call sites (`burned`, `poisoned`, `frozen`, `bleeding`, `confused`, `targeted`, `alliesArePresent`) passent désormais `opponent` (le vrai attaquant) au lieu de `affected`.
- Ajout d'un test de régression sur `FightActionController.getAttackDamage` vérifiant que le bonus de niveau dépend du fighter passé en `attacker`.

## Tests
- `pnpm eslint` : OK
- `pnpm test` : 1308 tests passent (68 fichiers)