### PR TITLE
Fix weekly reset of expedition cancellation penalties

### DIFF
--- a/Core/__tests__/core/database/LogsExpeditionLogger.test.ts
+++ b/Core/__tests__/core/database/LogsExpeditionLogger.test.ts
@@ -1,0 +1,40 @@
+import {
+	afterAll, beforeEach, describe, expect, it, vi
+} from "vitest";
+import { Op } from "sequelize";
+import { ExpeditionConstants } from "../../../../Lib/src/constants/ExpeditionConstants";
+import { LogsExpeditions } from "../../../src/core/database/logs/models/LogsExpeditions";
+import { LogsExpeditionLogger } from "../../../src/core/database/logs/LogsExpeditionLogger";
+
+vi.mock("../../../src/core/database/logs/models/LogsExpeditions", () => ({
+	LogsExpeditions: { count: vi.fn() }
+}));
+
+vi.mock("../../../src/core/database/logs/LogsPlayerResolver", () => ({
+	findOrCreateLogsPlayer: vi.fn().mockResolvedValue({ id: 42 })
+}));
+
+describe("LogsExpeditionLogger", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 6, 15, 12));
+		vi.mocked(LogsExpeditions.count).mockReset().mockResolvedValue(2);
+	});
+
+	afterAll(() => {
+		vi.useRealTimers();
+	});
+
+	it("counts cancellations and recalls since the latest weekly reset", async () => {
+		const count = await new LogsExpeditionLogger().countExpeditionCancellationsThisWeek("player-keycloak-id");
+
+		expect(count).toBe(2);
+		expect(LogsExpeditions.count).toHaveBeenCalledWith({
+			where: {
+				playerId: 42,
+				action: { [Op.in]: [ExpeditionConstants.LOG_ACTION.CANCEL, ExpeditionConstants.LOG_ACTION.RECALL] },
+				date: { [Op.gt]: Math.floor(new Date(2026, 6, 12, 23, 59, 59, 999).valueOf() / 1000) }
+			}
+		});
+	});
+});

--- a/Core/src/core/database/logs/LogsDatabase.ts
+++ b/Core/src/core/database/logs/LogsDatabase.ts
@@ -1658,10 +1658,10 @@ export class LogsDatabase extends Database {
 	}
 
 	/**
-	 * Count the number of expedition cancellations (cancel + recall) for a player in the last N days
+	 * Count the number of expedition cancellations (cancel + recall) for a player during the current week
 	 */
-	public countRecentExpeditionCancellations(keycloakId: string, days: number): Promise<number> {
-		return this.expeditionLogger.countRecentExpeditionCancellations(keycloakId, days);
+	public countExpeditionCancellationsThisWeek(keycloakId: string): Promise<number> {
+		return this.expeditionLogger.countExpeditionCancellationsThisWeek(keycloakId);
 	}
 
 	/**

--- a/Core/src/core/database/logs/LogsExpeditionLogger.ts
+++ b/Core/src/core/database/logs/LogsExpeditionLogger.ts
@@ -4,9 +4,9 @@ import { findOrCreateLogsPlayer } from "./LogsPlayerResolver";
 import { Op } from "sequelize";
 import { ExpeditionConstants } from "../../../../../Lib/src/constants/ExpeditionConstants";
 import {
-	daysToSeconds, getDateLogs, sDiff
+	getDateLogs, getNextSundayMidnight, millisecondsToSeconds, msDiff
 } from "../../../../../Lib/src/utils/TimeUtils";
-import { asDays } from "../../../../../Lib/src/types/TimeTypes";
+import { TimeConstants } from "../../../../../Lib/src/constants/TimeConstants";
 import {
 	ExpeditionCompleteParams,
 	ExpeditionLogData,
@@ -147,21 +147,24 @@ export class LogsExpeditionLogger {
 	}
 
 	/**
-	 * Count the number of expedition cancellations (cancel + recall) for a player in the last N days
+	 * Count the number of expedition cancellations (cancel + recall) for a player during the current week
 	 * Both cancelling during preparation and recalling during expedition count towards the progressive penalty
 	 */
-	async countRecentExpeditionCancellations(keycloakId: string, days: number): Promise<number> {
+	async countExpeditionCancellationsThisWeek(keycloakId: string): Promise<number> {
 		const logPlayer = await findOrCreateLogsPlayer(keycloakId);
 		if (!logPlayer) {
 			return 0;
 		}
-		const cutoffDate = sDiff(getDateLogs(), daysToSeconds(asDays(days)));
+		const startOfWeek = Math.floor(millisecondsToSeconds(msDiff(
+			getNextSundayMidnight(),
+			TimeConstants.MS_TIME.WEEK
+		)));
 
 		return LogsExpeditions.count({
 			where: {
 				playerId: logPlayer.id,
 				action: { [Op.in]: [ExpeditionConstants.LOG_ACTION.CANCEL, ExpeditionConstants.LOG_ACTION.RECALL] },
-				date: { [Op.gte]: cutoffDate }
+				date: { [Op.gt]: startOfWeek }
 			}
 		});
 	}

--- a/Core/src/core/expeditions/ExpeditionActionHandlers.ts
+++ b/Core/src/core/expeditions/ExpeditionActionHandlers.ts
@@ -309,9 +309,8 @@ export async function handleExpeditionCancel(
 	}
 
 	// Calculate progressive penalty based on recent cancellations
-	const recentCancellations = await crowniclesInstance?.logsDatabase.countRecentExpeditionCancellations(
-		player.keycloakId,
-		ExpeditionConstants.CANCELLATION_PENALTY.LOOKBACK_DAYS
+	const recentCancellations = await crowniclesInstance?.logsDatabase.countExpeditionCancellationsThisWeek(
+		player.keycloakId
 	) ?? 0;
 
 	const loveLost = calculateProgressiveLoveLoss(
@@ -375,9 +374,8 @@ export async function handleExpeditionRecall(
 	}
 
 	// Calculate progressive penalty based on recent cancellations (includes both cancel and recall)
-	const recentCancellations = await crowniclesInstance?.logsDatabase.countRecentExpeditionCancellations(
-		player.keycloakId,
-		ExpeditionConstants.CANCELLATION_PENALTY.LOOKBACK_DAYS
+	const recentCancellations = await crowniclesInstance?.logsDatabase.countExpeditionCancellationsThisWeek(
+		player.keycloakId
 	) ?? 0;
 
 	const loveLost = calculateProgressiveLoveLoss(

--- a/Lib/src/constants/ExpeditionConstants.ts
+++ b/Lib/src/constants/ExpeditionConstants.ts
@@ -257,17 +257,6 @@ export abstract class ExpeditionConstants {
 	};
 
 	/**
-	 * Progressive penalty for cancellation
-	 * Love lost = base * (1 + cancellations in last 7 days)
-	 */
-	static readonly CANCELLATION_PENALTY = {
-		/**
-		 * Number of days to look back for cancellation history
-		 */
-		LOOKBACK_DAYS: 7
-	};
-
-	/**
 	 * Safety caps used during expedition penalty calculations
 	 */
 	static readonly CAPS = {


### PR DESCRIPTION
## Summary

- count expedition cancellations and recalls from the latest weekly reset instead of over a rolling seven-day window
- share the weekly rule between cancellation and recall penalties
- add a regression test for the weekly boundary

## Validation

- Core ESLint and 1336 tests
- Lib ESLint and 569 tests
- Core TypeScript compilation

Fixes #4196