### PR TITLE
Fix expedition concurrency races

### DIFF
--- a/Core/__tests__-integration/handlers/pet-expedition.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/pet-expedition.race.integration.test.ts
@@ -1,0 +1,184 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { Guild as GuildType } from "../../src/core/database/game/models/Guild";
+import type { PetEntity as PetEntityType } from "../../src/core/database/game/models/PetEntity";
+import type { PetExpedition as PetExpeditionType } from "../../src/core/database/game/models/PetExpedition";
+import type { PlayerTalismans as PlayerTalismansType } from "../../src/core/database/game/models/PlayerTalismans";
+import type { ScheduledExpeditionNotification as ScheduledExpeditionNotificationType } from "../../src/core/database/game/models/ScheduledExpeditionNotification";
+import { ExpeditionConstants } from "../../../Lib/src/constants/ExpeditionConstants";
+import type { ExpeditionData } from "../../../Lib/src/packets/commands/CommandPetExpeditionPacket";
+
+type ExpeditionActionHandlersModule = typeof import("../../src/core/expeditions/ExpeditionActionHandlers");
+type PendingExpeditionsCacheModule = typeof import("../../src/core/expeditions/PendingExpeditionsCache");
+
+const FOOD_PER_EXPEDITION = 3;
+
+describe("pet expedition races", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let Guild: ModelStatic<GuildType>;
+	let PetEntity: ModelStatic<PetEntityType>;
+	let PetExpedition: ModelStatic<PetExpeditionType>;
+	let PlayerTalismans: ModelStatic<PlayerTalismansType>;
+	let ScheduledExpeditionNotification: ModelStatic<ScheduledExpeditionNotificationType>;
+	let handlers: ExpeditionActionHandlersModule;
+	let pendingCache: PendingExpeditionsCacheModule["PendingExpeditionsCache"];
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("petexpeditionrace");
+		const models = env.crownicles.gameDatabase.sequelize.models;
+		Player = models.Player as ModelStatic<PlayerType>;
+		Guild = models.Guild as ModelStatic<GuildType>;
+		PetEntity = models.PetEntity as ModelStatic<PetEntityType>;
+		PetExpedition = models.PetExpedition as ModelStatic<PetExpeditionType>;
+		PlayerTalismans = models.PlayerTalismans as ModelStatic<PlayerTalismansType>;
+		ScheduledExpeditionNotification = models.ScheduledExpeditionNotification as ModelStatic<ScheduledExpeditionNotificationType>;
+		handlers = loadProductionModule<ExpeditionActionHandlersModule>("core/expeditions/ExpeditionActionHandlers");
+		pendingCache = loadProductionModule<PendingExpeditionsCacheModule>(
+			"core/expeditions/PendingExpeditionsCache"
+		).PendingExpeditionsCache;
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await ScheduledExpeditionNotification.destroy({ truncate: true, force: true });
+			await PetExpedition.destroy({ truncate: true, force: true });
+			await PlayerTalismans.destroy({ truncate: true, force: true });
+			await PetEntity.destroy({ truncate: true, force: true });
+			await Player.destroy({ truncate: true, force: true });
+			await Guild.destroy({ truncate: true, force: true });
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	});
+
+	function expedition(id: string): ExpeditionData {
+		return {
+			id,
+			durationMinutes: 60,
+			displayDurationMinutes: 60,
+			riskRate: 10,
+			difficulty: 10,
+			wealthRate: 1,
+			locationType: ExpeditionConstants.EXPEDITION_LOCATION_TYPES.FOREST,
+			foodCost: FOOD_PER_EXPEDITION,
+			mapLocationId: 1
+		};
+	}
+
+	async function seedPlayer(keycloakId: string, guildId: number): Promise<{ player: PlayerType; pet: PetEntityType }> {
+		const pet = await PetEntity.create({
+			typeId: 1,
+			sex: "m",
+			nickname: keycloakId.slice(0, 16),
+			lovePoints: 50
+		});
+		const player = await Player.create({
+			keycloakId,
+			guildId,
+			petId: pet.id
+		});
+		await PlayerTalismans.create({
+			playerId: player.id,
+			hasTalisman: true
+		});
+		return {
+			player, pet
+		};
+	}
+
+	it("creates one active expedition when two selections race", async () => {
+		const guild = await Guild.create({
+			name: "ExpeditionRaceGuild",
+			chiefId: 1,
+			commonFood: FOOD_PER_EXPEDITION * 2
+		});
+		const {
+			player, pet
+		} = await seedPlayer("expedition-double-start", guild.id);
+		const option = expedition("double-start");
+		pendingCache.set(player.keycloakId, [option]);
+
+		const responses = [[], []];
+		await runAllOrThrow(responses.map(response => handlers.handleExpeditionSelect({
+			player,
+			petEntity: pet,
+			expeditionId: option.id,
+			keycloakId: player.keycloakId
+		}, response)));
+
+		expect(await PetExpedition.count({ where: { playerId: player.id } })).toBe(1);
+		const freshGuild = await Guild.findByPk(guild.id);
+		expect(freshGuild!.commonFood).toBe(FOOD_PER_EXPEDITION);
+	});
+
+	it("preserves every guild food debit when two members start concurrently", async () => {
+		const initialFood = FOOD_PER_EXPEDITION * 2;
+		const guild = await Guild.create({
+			name: "ExpeditionFoodRaceGuild",
+			chiefId: 1,
+			commonFood: initialFood
+		});
+		const members = await Promise.all([
+			seedPlayer("expedition-food-a", guild.id),
+			seedPlayer("expedition-food-b", guild.id)
+		]);
+
+		await runAllOrThrow(members.map(async ({ player, pet }, index) => {
+			const option = expedition(`food-${index}`);
+			pendingCache.set(player.keycloakId, [option]);
+			await handlers.handleExpeditionSelect({
+				player,
+				petEntity: pet,
+				expeditionId: option.id,
+				keycloakId: player.keycloakId
+			}, []);
+		}));
+
+		const freshGuild = await Guild.findByPk(guild.id);
+		expect(freshGuild!.commonFood).toBe(0);
+		expect(await PetExpedition.count()).toBe(2);
+	});
+
+	it("rejects a stale recall after the expedition end date", async () => {
+		const guild = await Guild.create({
+			name: "ExpiredRecallGuild", chiefId: 1
+		});
+		const {
+			player, pet
+		} = await seedPlayer("expedition-expired-recall", guild.id);
+		const activeExpedition = await PetExpedition.create({
+			playerId: player.id,
+			petId: pet.id,
+			startDate: new Date(Date.now() - 120_000),
+			endDate: new Date(Date.now() - 60_000),
+			riskRate: 10,
+			difficulty: 10,
+			wealthRate: 1,
+			locationType: ExpeditionConstants.EXPEDITION_LOCATION_TYPES.FOREST,
+			mapLocationId: 1,
+			status: ExpeditionConstants.STATUS.IN_PROGRESS,
+			foodConsumed: 0,
+			rewardIndex: 0
+		});
+
+		const response = [];
+		await handlers.handleExpeditionRecall(player, response);
+
+		expect(await PetExpedition.findByPk(activeExpedition.id)).toBeTruthy();
+		const freshPet = await PetEntity.findByPk(pet.id);
+		expect(freshPet!.lovePoints).toBe(50);
+	});
+});

--- a/Core/eslint.config.mjs
+++ b/Core/eslint.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig([
 			"src/core/report/ReportCookingService.ts",
 			"src/core/report/ReportCityChestService.ts",
 			"src/core/report/ReportBigEventService.ts",
+			"src/core/expeditions/ExpeditionFoodService.ts",
 			"src/commands/player/FightCommand.ts",
 			"src/commands/player/DailyBonusCommand.ts",
 			"src/core/missions/Campaign.ts",

--- a/Core/src/core/expeditions/ExpeditionActionHandlers.ts
+++ b/Core/src/core/expeditions/ExpeditionActionHandlers.ts
@@ -20,8 +20,8 @@ import {
 	FoodConsumptionDetail
 } from "../../../../Lib/src/packets/commands/CommandPetExpeditionPacket";
 import {
-	calculateFoodConsumptionPlan,
-	applyFoodConsumptionPlan,
+	calculateGuildFoodConsumptionPlan,
+	applyFoodConsumptionPlanUnderLock,
 	type FoodConsumptionPlan
 } from "./ExpeditionFoodService";
 import { calculateRewardIndex } from "./ExpeditionRewardCalculator";
@@ -29,6 +29,10 @@ import { PendingExpeditionsCache } from "./PendingExpeditionsCache";
 import { crowniclesInstance } from "../../app";
 import { ScheduledExpeditionNotifications } from "../database/game/models/ScheduledExpeditionNotification";
 import { PlayerTalismansManager } from "../database/game/models/PlayerTalismans";
+import { Guild } from "../database/game/models/Guild";
+import {
+	LockedRowNotFoundError, withLockedEntities
+} from "../../../../Lib/src/locks/withLockedEntities";
 
 /**
  * Context for handling expedition selection
@@ -138,7 +142,7 @@ interface ExpeditionCreationData {
 /**
  * Create and save expedition to database
  */
-async function createAndSaveExpedition(data: ExpeditionCreationData): Promise<PetExpedition> {
+async function createAndSaveExpeditionUnderLock(data: ExpeditionCreationData): Promise<PetExpedition> {
 	const {
 		player, petEntity, expeditionData, foodPlan, adjustedDurationMinutes, rewardIndex
 	} = data;
@@ -230,9 +234,46 @@ export async function handleExpeditionSelect(
 	ctx: ExpeditionSelectContext,
 	response: CrowniclesPacket[]
 ): Promise<void> {
+	const lockKeys = ctx.player.guildId
+		? [
+			Player.lockKey(ctx.player.id),
+			PetEntity.lockKey(ctx.petEntity.id),
+			Guild.lockKey(ctx.player.guildId)
+		] as const
+		: [Player.lockKey(ctx.player.id), PetEntity.lockKey(ctx.petEntity.id)] as const;
+
+	try {
+		await withLockedEntities(lockKeys, async lockedEntities => {
+			const [player, petEntity] = lockedEntities;
+			const guild = lockedEntities.length === 3 ? lockedEntities[2] : null;
+			await handleExpeditionSelectUnderLock({
+				...ctx,
+				player,
+				petEntity
+			}, response, guild);
+		});
+	}
+	catch (error) {
+		if (error instanceof LockedRowNotFoundError) {
+			response.push(createExpeditionSelectFailure(ExpeditionConstants.ERROR_CODES.INVALID_STATE));
+			return;
+		}
+		throw error;
+	}
+}
+
+async function handleExpeditionSelectUnderLock(
+	ctx: ExpeditionSelectContext,
+	response: CrowniclesPacket[],
+	guild: Guild | null
+): Promise<void> {
 	const {
 		player, petEntity, expeditionId, keycloakId
 	} = ctx;
+	if (player.petId !== petEntity.id || player.guildId !== (guild?.id ?? null)) {
+		response.push(createExpeditionSelectFailure(ExpeditionConstants.ERROR_CODES.INVALID_STATE));
+		return;
+	}
 
 	// Validate prerequisites
 	const validationError = await validateExpeditionSelection(ctx);
@@ -245,12 +286,17 @@ export async function handleExpeditionSelect(
 	const petModel = PetDataController.instance.getById(petEntity.typeId)!;
 	const rationsRequired = expeditionData.foodCost ?? ExpeditionConstants.DEFAULT_FOOD_COST;
 
-	// Calculate optimal food consumption plan
-	const foodPlan = await calculateFoodConsumptionPlan(player, petModel, rationsRequired);
+	// Calculate the plan from the freshly locked guild row.
+	const foodPlan = guild
+		? calculateGuildFoodConsumptionPlan(guild, petModel, rationsRequired)
+		: {
+			totalRations: 0,
+			consumption: []
+		};
 
 	// Apply food consumption to guild storage (even if insufficient, consume what's available)
-	if (player.guildId && foodPlan.consumption.length > 0) {
-		await applyFoodConsumptionPlan(player.guildId, foodPlan);
+	if (guild) {
+		await applyFoodConsumptionPlanUnderLock(guild, foodPlan);
 	}
 
 	// Calculate speed modifier and adjusted duration
@@ -259,7 +305,7 @@ export async function handleExpeditionSelect(
 	const rewardIndex = calculateRewardIndex(expeditionData);
 
 	// Create and save expedition
-	const expedition = await createAndSaveExpedition({
+	const expedition = await createAndSaveExpeditionUnderLock({
 		player,
 		petEntity,
 		expeditionData,
@@ -355,7 +401,6 @@ export async function handleExpeditionRecall(
 	player: Player,
 	response: CrowniclesPacket[]
 ): Promise<void> {
-	// Check for active expedition
 	const activeExpedition = await PetExpeditions.getActiveExpeditionForPlayer(player.id);
 	if (!activeExpedition) {
 		response.push(makePacket(CommandPetExpeditionErrorPacket, { errorCode: ExpeditionConstants.ERROR_CODES.NO_EXPEDITION }));
@@ -367,52 +412,73 @@ export async function handleExpeditionRecall(
 		return;
 	}
 
-	const petEntity = await PetEntities.getById(player.petId);
-	if (!petEntity) {
-		response.push(makePacket(CommandPetExpeditionErrorPacket, { errorCode: ExpeditionConstants.ERROR_CODES.NO_PET }));
-		return;
-	}
+	try {
+		const recallLog = await withLockedEntities(
+			[Player.lockKey(player.id), PetEntity.lockKey(player.petId)] as const,
+			async ([lockedPlayer, lockedPet]) => {
+				const lockedExpedition = await PetExpeditions.getActiveExpeditionForPlayer(lockedPlayer.id);
+				if (!lockedExpedition
+					|| lockedExpedition.id !== activeExpedition.id
+					|| lockedExpedition.hasEnded()
+					|| lockedPlayer.petId !== lockedPet.id) {
+					return null;
+				}
 
-	// Calculate progressive penalty based on recent cancellations (includes both cancel and recall)
-	const recentCancellations = await crowniclesInstance?.logsDatabase.countExpeditionCancellationsThisWeek(
-		player.keycloakId
-	) ?? 0;
+				const recentCancellations = await crowniclesInstance?.logsDatabase.countExpeditionCancellationsThisWeek(
+					lockedPlayer.keycloakId
+				) ?? 0;
+				const loveLost = calculateProgressiveLoveLoss(
+					ExpeditionConstants.LOVE_CHANGES.RECALL_DURING_EXPEDITION,
+					recentCancellations
+				);
+				const loveChange = -loveLost;
 
-	const loveLost = calculateProgressiveLoveLoss(
-		ExpeditionConstants.LOVE_CHANGES.RECALL_DURING_EXPEDITION,
-		recentCancellations
-	);
-	const loveChange = -loveLost;
+				await ScheduledExpeditionNotifications.deleteByExpeditionId(lockedExpedition.id);
+				await PetExpeditions.recallExpedition(lockedExpedition);
+				await lockedPet.changeLovePoints({
+					player: lockedPlayer,
+					amount: loveChange,
+					response,
+					reason: NumberChangeReason.SMALL_EVENT
+				});
+				await lockedPet.save();
 
-	// Log expedition recall to database
-	crowniclesInstance.logsDatabase.logExpeditionRecall(
-		{
-			keycloakId: player.keycloakId, petGameId: petEntity.id
-		},
-		{
-			mapLocationId: activeExpedition.mapLocationId,
-			locationType: activeExpedition.locationType,
-			loveChange
+				response.push(makePacket(CommandPetExpeditionRecallPacketRes, {
+					loveLost,
+					pet: lockedPet.getBasicInfo()
+				}));
+
+				return {
+					keycloakId: lockedPlayer.keycloakId,
+					petGameId: lockedPet.id,
+					mapLocationId: lockedExpedition.mapLocationId,
+					locationType: lockedExpedition.locationType,
+					loveChange
+				};
+			}
+		);
+
+		if (!recallLog) {
+			response.push(makePacket(CommandPetExpeditionErrorPacket, { errorCode: ExpeditionConstants.ERROR_CODES.NO_EXPEDITION }));
+			return;
 		}
-	).then();
 
-	// Cancel the scheduled notification for this expedition
-	await ScheduledExpeditionNotifications.deleteByExpeditionId(activeExpedition.id);
-
-	// Recall expedition
-	await PetExpeditions.recallExpedition(activeExpedition);
-
-	// Apply love loss for recall with progressive penalty
-	await petEntity.changeLovePoints({
-		player,
-		amount: loveChange,
-		response,
-		reason: NumberChangeReason.SMALL_EVENT
-	});
-	await petEntity.save();
-
-	response.push(makePacket(CommandPetExpeditionRecallPacketRes, {
-		loveLost,
-		pet: petEntity.getBasicInfo()
-	}));
+		crowniclesInstance.logsDatabase.logExpeditionRecall(
+			{
+				keycloakId: recallLog.keycloakId, petGameId: recallLog.petGameId
+			},
+			{
+				mapLocationId: recallLog.mapLocationId,
+				locationType: recallLog.locationType,
+				loveChange: recallLog.loveChange
+			}
+		).then();
+	}
+	catch (error) {
+		if (error instanceof LockedRowNotFoundError) {
+			response.push(makePacket(CommandPetExpeditionErrorPacket, { errorCode: ExpeditionConstants.ERROR_CODES.NO_PET }));
+			return;
+		}
+		throw error;
+	}
 }

--- a/Core/src/core/expeditions/ExpeditionFoodService.ts
+++ b/Core/src/core/expeditions/ExpeditionFoodService.ts
@@ -417,6 +417,17 @@ export async function calculateFoodConsumptionPlan(
 		return emptyPlan;
 	}
 
+	return calculateGuildFoodConsumptionPlan(guild, petModel, rationsRequired);
+}
+
+/**
+ * Calculate a food plan from a guild row already locked by the caller.
+ */
+export function calculateGuildFoodConsumptionPlan(
+	guild: Guild,
+	petModel: Pet,
+	rationsRequired: number
+): FoodConsumptionPlan {
 	const slots = getAvailableFoodSlots(guild, petModel);
 	const optimal = findOptimalCombination(slots, rationsRequired);
 
@@ -424,15 +435,10 @@ export async function calculateFoodConsumptionPlan(
 }
 
 /**
- * Apply the food consumption plan to the guild storage
+ * Apply a food plan to the guild row locked by the caller.
  */
-export async function applyFoodConsumptionPlan(guildId: number, plan: FoodConsumptionPlan): Promise<void> {
+export async function applyFoodConsumptionPlanUnderLock(guild: Guild, plan: FoodConsumptionPlan): Promise<void> {
 	if (plan.consumption.length === 0) {
-		return;
-	}
-
-	const guild = await Guilds.getById(guildId);
-	if (!guild) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

- serialize expedition creation per player and revalidate ownership under lock
- calculate and consume guild food from the locked guild row in the same transaction
- serialize recalls with resolution and reject stale recall collectors after expedition completion
- add MariaDB race tests for active expedition uniqueness, exact guild food debits, and expired recalls
- extend the unguarded-save ESLint protection to expedition food consumption

## Validation

- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` (1336 tests)
- `pnpm test:integration` (31 tests)

Relates to #4416