### PR TITLE
Fix city shop button freezes

### DIFF
--- a/Core/__tests__/core/report/ReportCityShopHandoff.test.ts
+++ b/Core/__tests__/core/report/ReportCityShopHandoff.test.ts
@@ -1,0 +1,55 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { makePacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+import { ReactionCollectorCreationPacket } from "../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
+import { ReactionCollectorStopPacket } from "../../../../Lib/src/packets/interaction/ReactionCollectorStopPacket";
+import { runWithDeferredCollectorStop } from "../../../src/core/report/ReportCityShopHandoff";
+
+describe("city shop collector handoff", () => {
+	it("places the city stop packet after the shop creation packet", async () => {
+		const stopPacket = makePacket(ReactionCollectorStopPacket, { id: "city-collector" });
+		const shopPacket = makePacket(ReactionCollectorCreationPacket, {} as ReactionCollectorCreationPacket);
+		const response = [stopPacket];
+
+		await runWithDeferredCollectorStop(response, "city-collector", () => {
+			response.push(shopPacket);
+			return Promise.resolve();
+		});
+
+		expect(response).toEqual([shopPacket, stopPacket]);
+	});
+
+	it("restores the stop packet when shop creation fails", async () => {
+		const stopPacket = makePacket(ReactionCollectorStopPacket, { id: "city-collector" });
+		const response = [stopPacket];
+		const error = new Error("shop creation failed");
+
+		await expect(runWithDeferredCollectorStop(response, "city-collector", () => Promise.reject(error))).rejects.toBe(error);
+
+		expect(response).toEqual([stopPacket]);
+	});
+
+	it("runs normally when no stop packet is present", async () => {
+		const response = [];
+		const openShop = vi.fn().mockResolvedValue(undefined);
+
+		await runWithDeferredCollectorStop(response, "city-collector", openShop);
+
+		expect(openShop).toHaveBeenCalledOnce();
+		expect(response).toEqual([]);
+	});
+
+	it("leaves unrelated stop packets in place", async () => {
+		const unrelatedStopPacket = makePacket(ReactionCollectorStopPacket, { id: "other-collector" });
+		const shopPacket = makePacket(ReactionCollectorCreationPacket, {} as ReactionCollectorCreationPacket);
+		const response = [unrelatedStopPacket];
+
+		await runWithDeferredCollectorStop(response, "city-collector", () => {
+			response.push(shopPacket);
+			return Promise.resolve();
+		});
+
+		expect(response).toEqual([unrelatedStopPacket, shopPacket]);
+	});
+});

--- a/Core/__tests__/core/report/ReportCityShopHandoff.test.ts
+++ b/Core/__tests__/core/report/ReportCityShopHandoff.test.ts
@@ -9,7 +9,7 @@ import { runWithDeferredCollectorStop } from "../../../src/core/report/ReportCit
 describe("city shop collector handoff", () => {
 	it("places the city stop packet after the shop creation packet", async () => {
 		const stopPacket = makePacket(ReactionCollectorStopPacket, { id: "city-collector" });
-		const shopPacket = makePacket(ReactionCollectorCreationPacket, {} as ReactionCollectorCreationPacket);
+		const shopPacket = new ReactionCollectorCreationPacket();
 		const response = [stopPacket];
 
 		await runWithDeferredCollectorStop(response, "city-collector", () => {
@@ -42,7 +42,7 @@ describe("city shop collector handoff", () => {
 
 	it("leaves unrelated stop packets in place", async () => {
 		const unrelatedStopPacket = makePacket(ReactionCollectorStopPacket, { id: "other-collector" });
-		const shopPacket = makePacket(ReactionCollectorCreationPacket, {} as ReactionCollectorCreationPacket);
+		const shopPacket = new ReactionCollectorCreationPacket();
 		const response = [unrelatedStopPacket];
 
 		await runWithDeferredCollectorStop(response, "city-collector", () => {

--- a/Core/src/commands/player/ReportCommand.ts
+++ b/Core/src/commands/player/ReportCommand.ts
@@ -95,6 +95,7 @@ import { crowniclesInstance } from "../../app";
 import {
 	CityMenuMask, CityVisitExitReason, CityVisitExitReasonValue
 } from "../../core/database/logs/LogsCityLogger";
+import { runWithDeferredCollectorStop } from "../../core/report/ReportCityShopHandoff";
 
 const CITY_REACTION_MENU_MASK = new Map<string, number>([
 	[ReactionCollectorInnMealReaction.name, CityMenuMask.INN],
@@ -367,7 +368,8 @@ function cityCollectorEndCallback(context: PacketContext, player: Player, forceS
 				city,
 				response,
 				reactionData: firstReaction.reaction.data,
-				collectorData: collector.creationPacket.data.data
+				collectorData: collector.creationPacket.data.data,
+				collectorId: collector.creationPacket.id
 			});
 		}
 	};
@@ -381,7 +383,30 @@ type CityReactionParams = {
 	response: CrowniclesPacket[];
 	reactionData: unknown;
 	collectorData: unknown;
+	collectorId: string;
 };
+
+async function handleCityShopReactionWithDeferredStop(params: CityReactionParams): Promise<void> {
+	await runWithDeferredCollectorStop(params.response, params.collectorId, async () => {
+		await handleCityShopReaction({
+			player: params.player,
+			city: params.city,
+			shopId: (params.reactionData as ReactionCollectorCityShopReaction).shopId,
+			context: params.context,
+			response: params.response,
+			onClose: async (closeResponse): Promise<void> => {
+				await params.player.reload();
+				await sendCityCollector(
+					params.context,
+					closeResponse,
+					params.player,
+					params.city,
+					{ forceSpecificEvent: params.forceSpecificEvent }
+				);
+			}
+		});
+	});
+}
 
 const NOOP_REACTION = (): Promise<void> => Promise.resolve();
 
@@ -431,30 +456,7 @@ const CITY_REACTION_HANDLERS = new Map<string, (params: CityReactionParams) => P
 	],
 	[
 		ReactionCollectorCityShopReaction.name, async (params): Promise<void> => {
-			await handleCityShopReaction({
-				player: params.player,
-				city: params.city,
-				shopId: (params.reactionData as ReactionCollectorCityShopReaction).shopId,
-				context: params.context,
-				response: params.response,
-
-				/*
-				 * Re-open the main city menu when the player closes the
-				 * shop (or it expires without a purchase) so the close
-				 * button brings them back to the city instead of just
-				 * dismissing the shop UI (#4268).
-				 */
-				onClose: async (closeResponse): Promise<void> => {
-					await params.player.reload();
-					await sendCityCollector(
-						params.context,
-						closeResponse,
-						params.player,
-						params.city,
-						{ forceSpecificEvent: params.forceSpecificEvent }
-					);
-				}
-			});
+			await handleCityShopReactionWithDeferredStop(params);
 		}
 	],
 	[ReactionCollectorHomeMenuReaction.name, NOOP_REACTION],

--- a/Core/src/core/report/ReportCityShopHandoff.ts
+++ b/Core/src/core/report/ReportCityShopHandoff.ts
@@ -1,0 +1,19 @@
+import { CrowniclesPacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+import { ReactionCollectorStopPacket } from "../../../../Lib/src/packets/interaction/ReactionCollectorStopPacket";
+
+export async function runWithDeferredCollectorStop(
+	response: CrowniclesPacket[],
+	collectorId: string,
+	openShop: () => Promise<void>
+): Promise<void> {
+	const stopPacketIndex = response.findIndex(packet => packet instanceof ReactionCollectorStopPacket && packet.id === collectorId);
+	const [stopPacket] = stopPacketIndex === -1 ? [] : response.splice(stopPacketIndex, 1);
+	try {
+		await openShop();
+	}
+	finally {
+		if (stopPacket) {
+			response.push(stopPacket);
+		}
+	}
+}

--- a/Discord/__tests__/city/MainMenuShopHandoff.test.ts
+++ b/Discord/__tests__/city/MainMenuShopHandoff.test.ts
@@ -1,0 +1,147 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+import { Message, MessageComponentInteraction } from "discord.js";
+
+vi.mock("../../src/utils/DiscordCollectorUtils", () => ({
+	DiscordCollectorUtils: {
+		sendReaction: vi.fn()
+	},
+	disableRows: vi.fn()
+}));
+
+import { LANGUAGE } from "../../../Lib/src/Language";
+import {
+	ReactionCollectorCityData,
+	ReactionCollectorCityShopReaction
+} from "../../../Lib/src/packets/interaction/ReactionCollectorCity";
+import { ReactionCollectorCreationPacket } from "../../../Lib/src/packets/interaction/ReactionCollectorPacket";
+import { DiscordCollectorUtils } from "../../src/utils/DiscordCollectorUtils";
+import { getMainMenu } from "../../src/commands/player/report/cityMenu/MainMenu";
+import { ReportCityMenuIds } from "../../src/commands/player/report/ReportCityMenuConstants";
+import { CityMenuParams } from "../../src/commands/player/report/ReportCityMenuTypes";
+import {
+	CrowniclesNestedMenu,
+	CrowniclesNestedMenus
+} from "../../src/messages/CrowniclesNestedMenus";
+
+function createPacket(): ReactionCollectorCreationPacket {
+	return {
+		id: "city-collector-id",
+		reactions: [{
+			type: ReactionCollectorCityShopReaction.name,
+			data: { shopId: "generalShop" }
+		}],
+		data: {
+			data: {
+				mapLocationId: 1,
+				mapTypeId: 0,
+				home: {},
+				apartmentNotary: { ownedApartments: [] },
+				shops: [{
+					shopId: "generalShop",
+					isEmpty: false
+				}]
+			} as unknown as ReactionCollectorCityData
+		}
+	} as unknown as ReactionCollectorCreationPacket;
+}
+
+function createMenuParams(packet: ReactionCollectorCreationPacket): CityMenuParams {
+	return {
+		context: {
+			keycloakId: "keycloak-id",
+			discord: { interaction: "interaction-id" }
+		} as never,
+		interaction: {
+			user: { id: "discord-user-id" },
+			userLanguage: LANGUAGE.FRENCH
+		} as never,
+		packet,
+		collectorTime: 1000,
+		pseudo: "Player"
+	};
+}
+
+describe("city shop message handoff", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("hands the city message off after sending the shop reaction", async () => {
+		const packet = createPacket();
+		const menu = getMainMenu(createMenuParams(packet));
+		let collectHandler: ((interaction: MessageComponentInteraction) => Promise<void>) | undefined;
+		const collector = {
+			on: vi.fn((event: string, handler: (interaction: MessageComponentInteraction) => Promise<void>) => {
+				if (event === "collect") {
+					collectHandler = handler;
+				}
+				return collector;
+			})
+		};
+		const message = {
+			createMessageComponentCollector: vi.fn(() => collector)
+		} as unknown as Message;
+		const nestedMenus = { beginMessageHandoff: vi.fn().mockReturnValue(true) };
+		menu.createCollector!(nestedMenus as never, message);
+		const buttonInteraction = {
+			customId: `${ReportCityMenuIds.CITY_SHOP_PREFIX}generalShop`,
+			user: { id: "discord-user-id" },
+			deferUpdate: vi.fn().mockResolvedValue(undefined)
+		} as unknown as MessageComponentInteraction;
+
+		await collectHandler!(buttonInteraction);
+
+		expect(buttonInteraction.deferUpdate).toHaveBeenCalledOnce();
+		expect(DiscordCollectorUtils.sendReaction).toHaveBeenCalledWith(
+			packet,
+			expect.objectContaining({ keycloakId: "keycloak-id" }),
+			"keycloak-id",
+			buttonInteraction,
+			0
+		);
+		expect(nestedMenus.beginMessageHandoff).toHaveBeenCalledOnce();
+	});
+
+	it("does not edit the city message when its collector stops after the handoff", async () => {
+		const collector = { stop: vi.fn() };
+		const message = {
+			edit: vi.fn(),
+			createMessageComponentCollector: vi.fn(() => collector)
+		} as unknown as Message;
+		const menu = {
+			containers: [],
+			createCollector: vi.fn(() => collector)
+		} as CrowniclesNestedMenu;
+		const nestedMenus = new CrowniclesNestedMenus(menu, new Map());
+		await nestedMenus.send({ editReply: vi.fn().mockResolvedValue(message) } as never);
+
+		expect(nestedMenus.beginMessageHandoff()).toBe(true);
+		expect(collector.stop).not.toHaveBeenCalled();
+		nestedMenus.confirmMessageHandoff();
+		await nestedMenus.stopCurrentCollector();
+
+		expect(collector.stop).toHaveBeenCalledOnce();
+		expect(message.edit).not.toHaveBeenCalled();
+	});
+
+	it("disables the city message when an unconfirmed handoff expires", async () => {
+		const collector = { stop: vi.fn() };
+		const message = {
+			edit: vi.fn().mockResolvedValue(undefined),
+			createMessageComponentCollector: vi.fn(() => collector)
+		} as unknown as Message;
+		const menu = {
+			containers: [],
+			createCollector: vi.fn(() => collector)
+		} as CrowniclesNestedMenu;
+		const nestedMenus = new CrowniclesNestedMenus(menu, new Map());
+		await nestedMenus.send({ editReply: vi.fn().mockResolvedValue(message) } as never);
+
+		expect(nestedMenus.beginMessageHandoff()).toBe(true);
+		await nestedMenus.stopCurrentCollector();
+
+		expect(message.edit).toHaveBeenCalledOnce();
+	});
+});

--- a/Discord/src/commands/player/report/CityMessageHandoff.ts
+++ b/Discord/src/commands/player/report/CityMessageHandoff.ts
@@ -1,0 +1,12 @@
+import { CrowniclesInteraction } from "../../../messages/CrowniclesInteraction";
+import { CrowniclesNestedMenus } from "../../../messages/CrowniclesNestedMenus";
+
+const cityMenusByInteraction = new WeakMap<CrowniclesInteraction, CrowniclesNestedMenus>();
+
+export function registerCityMessageOwner(interaction: CrowniclesInteraction, nestedMenus: CrowniclesNestedMenus): void {
+	cityMenusByInteraction.set(interaction, nestedMenus);
+}
+
+export function confirmCityMessageHandoff(interaction: CrowniclesInteraction): void {
+	cityMenusByInteraction.get(interaction)?.confirmMessageHandoff();
+}

--- a/Discord/src/commands/player/report/ReportCityMenu.ts
+++ b/Discord/src/commands/player/report/ReportCityMenu.ts
@@ -44,6 +44,7 @@ import { getMainMenu } from "./cityMenu/MainMenu";
 import { getInnMenu } from "./cityMenu/InnMenu";
 import { getEnchanterMenu } from "./cityMenu/EnchanterMenu";
 import { getManageHomeMenu } from "./cityMenu/NotaryMenu";
+import { registerCityMessageOwner } from "./CityMessageHandoff";
 
 type CityCollectorHandler = (
 	customId: string,
@@ -318,6 +319,7 @@ export class ReportCityMenu {
 				PacketUtils.sendPacketToBackend(context, makePacket(ReactionCollectorResetTimerPacketReq, { reactionCollectorId: packet.id }));
 			}
 		);
+		registerCityMessageOwner(interaction, nestedMenus);
 		const msg = await nestedMenus.send(interaction);
 
 		if (navigateAfterSend) {

--- a/Discord/src/commands/player/report/cityMenu/MainMenu.ts
+++ b/Discord/src/commands/player/report/cityMenu/MainMenu.ts
@@ -350,15 +350,16 @@ async function handleMainMenuSelection(params: CityCollectorHandlerParams): Prom
 	}
 
 	if (selectedValue.startsWith(ReportCityMenuIds.CITY_SHOP_PREFIX)) {
+		if (!nestedMenus.beginMessageHandoff()) {
+			return;
+		}
 		handleShopSelection(selectedValue, componentInteraction, context, packet);
 
 		/*
-		 * The shop packet about to arrive replaces the city message in place
-		 * (see shopCollector, #4337). Stop the city collector now without
-		 * disabling the message — editing it here would race with the shop
-		 * render that is going to take over the same message.
+		 * The shop packet about to arrive takes ownership of the city message.
+		 * The pending handoff keeps this collector responsive during the network
+		 * round trip, then prevents Core's stop packet from overwriting the shop.
 		 */
-		await nestedMenus.stopCurrentCollector({ editMessage: false });
 		return;
 	}
 

--- a/Discord/src/messages/CrowniclesNestedMenus.ts
+++ b/Discord/src/messages/CrowniclesNestedMenus.ts
@@ -118,6 +118,10 @@ export class CrowniclesNestedMenus {
 
 	private _isV2 = false;
 
+	private _messageHandoffPending = false;
+
+	private _messageHandoffConfirmed = false;
+
 	constructor(mainMenu: CrowniclesNestedMenu, menus: Map<string, CrowniclesNestedMenu>, _onChangeMenu: (() => void) | undefined = undefined) {
 		this._menus = menus;
 		this._mainMenu = mainMenu;
@@ -177,6 +181,20 @@ export class CrowniclesNestedMenus {
 		await this.changeToMenu(this._mainMenu);
 	}
 
+	public beginMessageHandoff(): boolean {
+		if (this._messageHandoffPending) {
+			return false;
+		}
+		this._messageHandoffPending = true;
+		return true;
+	}
+
+	public confirmMessageHandoff(): void {
+		if (this._messageHandoffPending) {
+			this._messageHandoffConfirmed = true;
+		}
+	}
+
 	/**
 	 * Stops the current collector and (by default) edits the underlying message to disable its components.
 	 *
@@ -188,6 +206,13 @@ export class CrowniclesNestedMenus {
 		const editMessage = options.editMessage !== false;
 		this._currentCollector?.stop();
 		this._currentCollector = undefined;
+		if (this._messageHandoffConfirmed) {
+			this._messageHandoffPending = false;
+			this._messageHandoffConfirmed = false;
+			this._message = undefined;
+			return;
+		}
+		this._messageHandoffPending = false;
 		if (!editMessage) {
 			return;
 		}

--- a/Discord/src/utils/ShopDisplayUtils.ts
+++ b/Discord/src/utils/ShopDisplayUtils.ts
@@ -48,6 +48,7 @@ import {
 	groupReactionsByItem,
 	parseShopAmountCustomId
 } from "./cityShop/CityShopViews";
+import { confirmCityMessageHandoff } from "../commands/player/report/CityMessageHandoff";
 
 /**
  * discord.js message flag enabling the Components V2 layout (containers,
@@ -522,6 +523,7 @@ export async function shopCollector(context: PacketContext, packet: ReactionColl
 	if (!msg) {
 		return null;
 	}
+	confirmCityMessageHandoff(interaction);
 
 	const controller = new ShopUiController({
 		data, reactionsByItem, pseudo, lng, initialContainer: mainContainer, msg


### PR DESCRIPTION
## Résumé

- conserve le collecteur de ville actif pendant l’aller-retour réseau vers Core
- envoie la création de la boutique avant l’arrêt de l’ancien collecteur de ville
- transfère explicitement la propriété du message une fois la boutique réellement rendue
- empêche l’arrêt tardif du collecteur de ville d’écraser la boutique avec des boutons désactivés
- garde le comportement normal d’expiration si le handoff n’est jamais confirmé

## Cause confirmée

Les logs locaux montraient une réponse `ReactionCollectorStopPacket` suivie de `ReactionCollectorCreationPacket`. Les deux handlers modifiaient alors le même message de façon concurrente, ce qui pouvait laisser la boutique affichée sans collecteur actif.

## Tests

- `cd Discord && pnpm eslint`
- `cd Discord && pnpm tsc --noEmit`
- `cd Discord && pnpm test` (231 tests)
- `cd Core && pnpm eslint`
- `cd Core && pnpm tsc --noEmit`
- `cd Core && pnpm test` (1 339 tests)

Fixes #4418
