### PR TITLE
Fix /boire unbound command handler

### DIFF
--- a/Core/eslint.config.mjs
+++ b/Core/eslint.config.mjs
@@ -31,6 +31,7 @@ export default defineConfig([
 		rules: {
 			...customRules,
 			"crownicles/single-line-short-single-property-object": ["error", { maxLength: 40 }],
+			"crownicles/no-this-in-packet-handler": "error",
 			"crownicles/no-response-push-through-return": "error"
 		}
 	},

--- a/Core/src/commands/player/DrinkCommand.ts
+++ b/Core/src/commands/player/DrinkCommand.ts
@@ -30,25 +30,25 @@ import {
 import { WhereAllowed } from "../../../../Lib/src/types/WhereAllowed";
 import { ItemNature } from "../../../../Lib/src/constants/ItemConstants";
 
-export default class DrinkCommand {
-	private async getDrinkablePotions(player: Player): Promise<InventorySlot[]> {
-		const hasActiveEffect = player.effectRemainingTime() > 0;
-		return (await InventorySlots.getOfPlayer(player.id)).filter(item => {
-			const potion = item.getItem() as Potion;
-			return item.itemId !== 0
-				&& item.isPotion()
-				&& !potion.isFightPotion()
-				&& (potion.nature !== ItemNature.TIME_SPEEDUP || hasActiveEffect);
-		});
-	}
+async function getDrinkablePotions(player: Player): Promise<InventorySlot[]> {
+	const hasActiveEffect = player.effectRemainingTime() > 0;
+	return (await InventorySlots.getOfPlayer(player.id)).filter(item => {
+		const potion = item.getItem() as Potion;
+		return item.itemId !== 0
+			&& item.isPotion()
+			&& !potion.isFightPotion()
+			&& (potion.nature !== ItemNature.TIME_SPEEDUP || hasActiveEffect);
+	});
+}
 
+export default class DrinkCommand {
 	@commandRequires(CommandDrinkPacketReq, {
 		notBlocked: true,
 		disallowedEffects: CommandUtils.DISALLOWED_EFFECTS.NOT_STARTED_OR_DEAD_OR_JAILED,
 		whereAllowed: [WhereAllowed.CONTINENT]
 	})
 	async execute(response: CrowniclesPacket[], player: Player, _packet: CommandDrinkPacketReq, context: PacketContext): Promise<void> {
-		const potions = await this.getDrinkablePotions(player);
+		const potions = await getDrinkablePotions(player);
 
 		if (potions.length === 0) {
 			response.push(makePacket(CommandDrinkNoAvailablePotion, {}));

--- a/eslint-custom-rules/no-this-in-packet-handler.mjs
+++ b/eslint-custom-rules/no-this-in-packet-handler.mjs
@@ -1,13 +1,14 @@
 /**
  * ESLint custom rule: no-this-in-packet-handler
  *
- * Forbids using `this` inside any method decorated with `@packetHandler(...)`.
+ * Forbids using `this` inside methods whose decorator registers an unbound
+ * prototype method.
  *
- * Rationale: the `@packetHandler` decorator (see `Discord/src/packetHandlers/PacketHandler.ts`)
- * registers the raw `descriptor.value` (the unbound prototype method) directly on the global
- * `packetListener`. The handler class is never instantiated, so at call time `this` is
- * `undefined`. Any use of `this.<x>` therefore crashes at runtime with
- * "Cannot read properties of undefined".
+ * Rationale: `@packetHandler`, `@commandRequires` and `@adminCommand` register
+ * the raw `descriptor.value` (the unbound prototype method). The handler class
+ * is never instantiated, so at call time `this` is `undefined`. Any use of
+ * `this.<x>` therefore crashes at runtime with "Cannot read properties of
+ * undefined".
  *
  * History: #4246 (blockedHandler crash on `this.helper(...)`), #4257 (latent pitfall).
  *
@@ -35,7 +36,11 @@
  * }
  */
 
-const DECORATOR_NAME = "packetHandler";
+const UNBOUND_HANDLER_DECORATORS = new Set([
+	"adminCommand",
+	"commandRequires",
+	"packetHandler"
+]);
 
 function isPacketHandlerCall(expr) {
 	if (!expr || expr.type !== "CallExpression") {
@@ -45,7 +50,7 @@ function isPacketHandlerCall(expr) {
 	if (!callee || callee.type !== "Identifier") {
 		return false;
 	}
-	return callee.name === DECORATOR_NAME;
+	return UNBOUND_HANDLER_DECORATORS.has(callee.name);
 }
 
 function hasPacketHandlerDecorator(node) {
@@ -57,12 +62,12 @@ export default {
 	meta: {
 		type: "problem",
 		docs: {
-			description: "Forbid `this` inside methods decorated with @packetHandler (decorator does not bind this)",
+			description: "Forbid `this` inside handlers whose decorators do not bind this",
 			category: "Possible Errors"
 		},
 		schema: [],
 		messages: {
-			noThis: "`this` is unbound inside @packetHandler methods (the decorator registers the raw prototype function). Use `ClassName.staticMethod(...)` or a module-level function instead."
+			noThis: "`this` is unbound inside this decorated handler (the decorator registers the raw prototype function). Use `ClassName.staticMethod(...)` or a module-level function instead."
 		}
 	},
 


### PR DESCRIPTION
## Résumé

- corrige le crash de `/boire` causé par l’utilisation de `this` dans un handler `@commandRequires` enregistré sans instance
- déplace la recherche des potions buvables dans une fonction de module
- étend la règle ESLint existante à `@commandRequires` et `@adminCommand` pour empêcher la réintroduction du défaut

Fixes #4432

## Validation

- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` : 1 345 tests réussis