### PR TITLE
Fix completed V5 campaign migration

### DIFF
--- a/Core/__tests__/core/database/FixV5CompletedCampaignSlotMigration.test.ts
+++ b/Core/__tests__/core/database/FixV5CompletedCampaignSlotMigration.test.ts
@@ -1,0 +1,26 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { QueryInterface } from "sequelize";
+import { up } from "../../../src/core/database/game/migrations/065-fix-v5-completed-campaign-slot";
+
+describe("065-fix-v5-completed-campaign-slot migration", () => {
+	it("resynchronizes only the stale completed V5 campaign slot", async () => {
+		const query = vi.fn().mockResolvedValue(undefined);
+		const context = {
+			sequelize: { query }
+		} as unknown as QueryInterface;
+
+		await up({ context });
+
+		expect(query).toHaveBeenCalledOnce();
+		const sql = query.mock.calls[0][0] as string;
+		expect(sql).toContain("SET pmi.campaignProgression = 10");
+		expect(sql).toContain("ms.missionId = 'commandMap'");
+		expect(sql).toContain("ms.numberDone = 0");
+		expect(sql).toContain("pmi.campaignProgression = 12");
+		expect(sql).toContain("SUBSTRING(pmi.campaignBlob, 10, 3) = '010'");
+		expect(sql).toContain("ms.missionId = 'depositPetInShelter'");
+		expect(sql).toContain("ms.numberDone = 1");
+	});
+});

--- a/Core/src/core/database/game/migrations/065-fix-v5-completed-campaign-slot.ts
+++ b/Core/src/core/database/game/migrations/065-fix-v5-completed-campaign-slot.ts
@@ -1,0 +1,34 @@
+import { QueryInterface } from "sequelize";
+
+export async function up({ context }: { context: QueryInterface }): Promise<void> {
+	/*
+	 * Completed V5 players kept their finished depositPetInShelter MissionSlot
+	 * when migrations 063 and 064 reopened the campaign. Their blob points to
+	 * commandMap at position 10, while campaignProgression and the slot remained
+	 * out of sync at position 12.
+	 */
+	await context.sequelize.query(`
+		UPDATE player_missions_info pmi
+		JOIN mission_slots ms ON ms.playerId = pmi.playerId
+		SET pmi.campaignProgression = 10,
+		    ms.missionId = 'commandMap',
+		    ms.missionVariant = 0,
+		    ms.missionObjective = 1,
+		    ms.numberDone = 0,
+		    ms.gemsToWin = 1,
+		    ms.xpToWin = 40,
+		    ms.moneyToWin = 0,
+		    ms.saveBlob = NULL
+		WHERE pmi.campaignProgression = 12
+		  AND LENGTH(pmi.campaignBlob) = 149
+		  AND SUBSTRING(pmi.campaignBlob, 10, 3) = '010'
+		  AND ms.expiresAt IS NULL
+		  AND ms.missionId = 'depositPetInShelter'
+		  AND ms.missionObjective = 1
+		  AND ms.numberDone = 1
+	`);
+}
+
+export async function down(): Promise<void> {
+	// No rollback: restoring the stale completed slot would recreate the bug.
+}


### PR DESCRIPTION
## Résumé

- resynchronise les joueurs ayant terminé la campagne V5 dont la progression V6 pointe en position 12 mais dont le slot affiche encore `depositPetInShelter` terminé
- les replace sur la première mission V6 réellement incomplète, `commandMap` en position 10
- cible uniquement la signature de migration observée sur les 8 joueurs affectés et préserve le joueur légitimement arrivé à la mission 149
- ajoute un test de régression pour les gardes et les valeurs restaurées

Fixes #4434

## Validation

- prédicat vérifié en lecture seule sur la production : 8 joueurs ciblés, première position incomplète 10
- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` : 1 346 tests réussis