### PR TITLE
Restrict time potions only inside cities

### DIFF
--- a/Core/__tests__/core/commands/player/DrinkCommand.test.ts
+++ b/Core/__tests__/core/commands/player/DrinkCommand.test.ts
@@ -3,7 +3,6 @@ import {
 } from "vitest";
 import DrinkCommand from "../../../../src/commands/player/DrinkCommand";
 import { InventorySlots } from "../../../../src/core/database/game/models/InventorySlot";
-import { Maps } from "../../../../src/core/maps/Maps";
 import { toItemWithDetails } from "../../../../src/core/utils/ItemUtils";
 import { ItemCategory, ItemNature } from "../../../../../Lib/src/constants/ItemConstants";
 
@@ -16,14 +15,13 @@ vi.mock("../../../../src/core/utils/CommandUtils", () => ({
 	}
 }));
 vi.mock("../../../../src/core/database/game/models/InventorySlot");
-vi.mock("../../../../src/core/maps/Maps");
 vi.mock("../../../../src/core/utils/ItemUtils");
 
 describe("DrinkCommand", () => {
 	const player = {
 		id: 42,
 		keycloakId: "player-keycloak-id",
-		effectRemainingTime: vi.fn()
+		insideCity: false
 	};
 	const timePotionSlot = {
 		itemId: 1,
@@ -37,12 +35,20 @@ describe("DrinkCommand", () => {
 			isFightPotion: () => false
 		})
 	};
+	const healthPotionSlot = {
+		...timePotionSlot,
+		getItem: () => ({
+			id: 2,
+			nature: ItemNature.HEALTH,
+			isFightPotion: () => false
+		})
+	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.mocked(InventorySlots.getOfPlayer).mockResolvedValue([timePotionSlot as never]);
 		vi.mocked(toItemWithDetails).mockReturnValue({ id: 1 } as never);
-		player.effectRemainingTime.mockReturnValue(0);
+		player.insideCity = false;
 	});
 
 	async function executeCommand(): Promise<unknown[]> {
@@ -51,28 +57,26 @@ describe("DrinkCommand", () => {
 		return response;
 	}
 
-	it("offers time potions during a normal journey without an active effect", async () => {
-		vi.mocked(Maps.isArrived).mockReturnValue(false);
-
+	it("offers time potions whenever the player is outside a city", async () => {
 		const response = await executeCommand();
 
 		expect(response[0]?.constructor.name).toBe("ReactionCollectorCreationPacket");
 	});
 
-	it("offers time potions while an effect is active", async () => {
-		vi.mocked(Maps.isArrived).mockReturnValue(true);
-		player.effectRemainingTime.mockReturnValue(1);
-
-		const response = await executeCommand();
-
-		expect(response[0]?.constructor.name).toBe("ReactionCollectorCreationPacket");
-	});
-
-	it("hides time potions after arrival without an active effect", async () => {
-		vi.mocked(Maps.isArrived).mockReturnValue(true);
+	it("hides time potions while the player is inside a city", async () => {
+		player.insideCity = true;
 
 		const response = await executeCommand();
 
 		expect(response[0]?.constructor.name).toBe("CommandDrinkNoAvailablePotion");
+	});
+
+	it("keeps regular potions available inside a city", async () => {
+		player.insideCity = true;
+		vi.mocked(InventorySlots.getOfPlayer).mockResolvedValue([healthPotionSlot as never]);
+
+		const response = await executeCommand();
+
+		expect(response[0]?.constructor.name).toBe("ReactionCollectorCreationPacket");
 	});
 });

--- a/Core/__tests__/core/commands/player/DrinkCommand.test.ts
+++ b/Core/__tests__/core/commands/player/DrinkCommand.test.ts
@@ -1,0 +1,78 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+import DrinkCommand from "../../../../src/commands/player/DrinkCommand";
+import { InventorySlots } from "../../../../src/core/database/game/models/InventorySlot";
+import { Maps } from "../../../../src/core/maps/Maps";
+import { toItemWithDetails } from "../../../../src/core/utils/ItemUtils";
+import { ItemCategory, ItemNature } from "../../../../../Lib/src/constants/ItemConstants";
+
+vi.mock("../../../../src/core/utils/CommandUtils", () => ({
+	commandRequires: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => descriptor,
+	CommandUtils: {
+		DISALLOWED_EFFECTS: {
+			NOT_STARTED_OR_DEAD_OR_JAILED: []
+		}
+	}
+}));
+vi.mock("../../../../src/core/database/game/models/InventorySlot");
+vi.mock("../../../../src/core/maps/Maps");
+vi.mock("../../../../src/core/utils/ItemUtils");
+
+describe("DrinkCommand", () => {
+	const player = {
+		id: 42,
+		keycloakId: "player-keycloak-id",
+		effectRemainingTime: vi.fn()
+	};
+	const timePotionSlot = {
+		itemId: 1,
+		itemCategory: ItemCategory.POTION,
+		itemLevel: 0,
+		itemEnchantmentId: null,
+		isPotion: () => true,
+		getItem: () => ({
+			id: 1,
+			nature: ItemNature.TIME_SPEEDUP,
+			isFightPotion: () => false
+		})
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(InventorySlots.getOfPlayer).mockResolvedValue([timePotionSlot as never]);
+		vi.mocked(toItemWithDetails).mockReturnValue({ id: 1 } as never);
+		player.effectRemainingTime.mockReturnValue(0);
+	});
+
+	async function executeCommand(): Promise<unknown[]> {
+		const response: unknown[] = [];
+		await new DrinkCommand().execute(response as never, player as never, {} as never, {} as never);
+		return response;
+	}
+
+	it("offers time potions during a normal journey without an active effect", async () => {
+		vi.mocked(Maps.isArrived).mockReturnValue(false);
+
+		const response = await executeCommand();
+
+		expect(response[0]?.constructor.name).toBe("ReactionCollectorCreationPacket");
+	});
+
+	it("offers time potions while an effect is active", async () => {
+		vi.mocked(Maps.isArrived).mockReturnValue(true);
+		player.effectRemainingTime.mockReturnValue(1);
+
+		const response = await executeCommand();
+
+		expect(response[0]?.constructor.name).toBe("ReactionCollectorCreationPacket");
+	});
+
+	it("hides time potions after arrival without an active effect", async () => {
+		vi.mocked(Maps.isArrived).mockReturnValue(true);
+
+		const response = await executeCommand();
+
+		expect(response[0]?.constructor.name).toBe("CommandDrinkNoAvailablePotion");
+	});
+});

--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "6.0.0.a",
+  "version": "6.0.0.b",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/main.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Core/src/commands/player/DrinkCommand.ts
+++ b/Core/src/commands/player/DrinkCommand.ts
@@ -29,16 +29,14 @@ import {
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorDrink";
 import { WhereAllowed } from "../../../../Lib/src/types/WhereAllowed";
 import { ItemNature } from "../../../../Lib/src/constants/ItemConstants";
-import { Maps } from "../../core/maps/Maps";
 
 async function getDrinkablePotions(player: Player): Promise<InventorySlot[]> {
-	const canSpeedUpTime = player.effectRemainingTime() > 0 || !Maps.isArrived(player, new Date());
 	return (await InventorySlots.getOfPlayer(player.id)).filter(item => {
 		const potion = item.getItem() as Potion;
 		return item.itemId !== 0
 			&& item.isPotion()
 			&& !potion.isFightPotion()
-			&& (potion.nature !== ItemNature.TIME_SPEEDUP || canSpeedUpTime);
+			&& (potion.nature !== ItemNature.TIME_SPEEDUP || !player.insideCity);
 	});
 }
 

--- a/Core/src/commands/player/DrinkCommand.ts
+++ b/Core/src/commands/player/DrinkCommand.ts
@@ -29,15 +29,16 @@ import {
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorDrink";
 import { WhereAllowed } from "../../../../Lib/src/types/WhereAllowed";
 import { ItemNature } from "../../../../Lib/src/constants/ItemConstants";
+import { Maps } from "../../core/maps/Maps";
 
 async function getDrinkablePotions(player: Player): Promise<InventorySlot[]> {
-	const hasActiveEffect = player.effectRemainingTime() > 0;
+	const canSpeedUpTime = player.effectRemainingTime() > 0 || !Maps.isArrived(player, new Date());
 	return (await InventorySlots.getOfPlayer(player.id)).filter(item => {
 		const potion = item.getItem() as Potion;
 		return item.itemId !== 0
 			&& item.isPotion()
 			&& !potion.isFightPotion()
-			&& (potion.nature !== ItemNature.TIME_SPEEDUP || hasActiveEffect);
+			&& (potion.nature !== ItemNature.TIME_SPEEDUP || canSpeedUpTime);
 	});
 }
 

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "6.0.0.a",
+  "version": "6.0.0.b",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "6.0.0.a",
+  "version": "6.0.0.b",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "6.0.0.a",
+  "version": "6.0.0.b",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
## Résumé

- autorise les potions de temps partout hors des villes, y compris quand le trajet est déjà terminé afin de conserver leur gain de points
- masque uniquement les potions de temps lorsque `player.insideCity` est actif
- laisse les autres potions disponibles en ville
- ajoute trois tests de régression sur ces situations
- passe Core, Discord, Lib et RestWs en version `6.0.0.b`

Fixes #4437

## Validation

- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` : 1 349 tests réussis