### PR TITLE
Clarify forge exit buttons

### DIFF
--- a/Discord/__tests__/utils/CommandDiscoveryUtils.test.ts
+++ b/Discord/__tests__/utils/CommandDiscoveryUtils.test.ts
@@ -1,0 +1,18 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { isCommandModuleFile } from "../../src/commands/CommandDiscoveryUtils";
+
+describe("isCommandModuleFile", () => {
+	it("accepts compiled command modules", () => {
+		expect(isCommandModuleFile("MissionShopCommand.js")).toBe(true);
+	});
+
+	it("rejects JavaScript helper modules", () => {
+		expect(isCommandModuleFile("MissionShopUtils.js")).toBe(false);
+	});
+
+	it("rejects source maps", () => {
+		expect(isCommandModuleFile("MissionShopCommand.js.map")).toBe(false);
+	});
+});

--- a/Discord/src/commands/CommandDiscoveryUtils.ts
+++ b/Discord/src/commands/CommandDiscoveryUtils.ts
@@ -1,0 +1,3 @@
+export function isCommandModuleFile(fileName: string): boolean {
+	return fileName.endsWith("Command.js");
+}

--- a/Discord/src/commands/CommandsManager.ts
+++ b/Discord/src/commands/CommandsManager.ts
@@ -60,6 +60,7 @@ import {
 	setPendingDeletion,
 	verifyDeletionCode
 } from "../utils/AccountDeletionUtils";
+import { isCommandModuleFile } from "./CommandDiscoveryUtils";
 
 export class CommandsManager {
 	static commands = new Map<string, ICommand>();
@@ -327,7 +328,7 @@ export class CommandsManager {
 		guildsCommandsToRegister: RESTPostAPIChatInputApplicationCommandsJSONBody[]
 	): Promise<void> {
 		let commandsFiles = readdirSync(`dist/Discord/src/commands/${category}`)
-			.filter(command => command.endsWith(".js"));
+			.filter(isCommandModuleFile);
 		if (!discordConfig.TEST_MODE) {
 			commandsFiles = commandsFiles.filter(command => !command.startsWith("Test"));
 		}

--- a/Discord/src/commands/player/report/blacksmith/BlacksmithMenu.ts
+++ b/Discord/src/commands/player/report/blacksmith/BlacksmithMenu.ts
@@ -199,7 +199,7 @@ export function getBlacksmithMenu(params: BlacksmithMenuParams): CrowniclesNeste
 		new ActionRowBuilder<ButtonBuilder>().addComponents(
 			new ButtonBuilder()
 				.setCustomId(BlacksmithMenuIds.BACK_TO_CITY)
-				.setLabel(i18n.t("commands:report.city.buttons.backToCity", { lng }))
+				.setLabel(i18n.t("commands:report.city.blacksmith.backToCity", { lng }))
 				.setEmoji(CrowniclesIcons.city.exit)
 				.setStyle(ButtonStyle.Secondary),
 			createStayInCityButton(lng)

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -1033,7 +1033,7 @@
         "upgradeDescription": "Améliorez le niveau de vos armes et armures contre de l'argent et des matériaux.",
         "disenchantLabel": "Désenchanter un équipement",
         "disenchantDescription": "Retirez l'enchantement d'un de vos équipements.",
-        "backToCity": "Retourner en ville",
+        "backToCity": "Sortir de la forge",
         "descriptionBoth": "{emote:city.blacksmith.menu} La chaleur du brasier vous enveloppe alors que vous pénétrez dans la forge. Le forgeron, un colosse aux bras marqués par des années de labeur, lève les yeux de son enclume et vous salue d'un hochement de tête. Il peut renforcer vos équipements ou retirer les enchantements qui vous encombrent.",
         "descriptionUpgradeOnly": "{emote:city.blacksmith.menu} La chaleur du brasier vous enveloppe alors que vous pénétrez dans la forge. Le forgeron, un colosse aux bras marqués par des années de labeur, examine vos équipements d'un œil expert. Ses services ne sont pas donnés, mais la qualité de son travail parle d'elle-même.",
         "descriptionDisenchantOnly": "{emote:city.blacksmith.menu} La chaleur du brasier vous enveloppe alors que vous pénétrez dans la forge. Le forgeron remarque les lueurs magiques émanant de vos équipements enchantés. Il peut les retirer proprement, sans abîmer l'équipement.",


### PR DESCRIPTION
## Résumé

- utilise la clé dédiée du forgeron pour le bouton qui ferme la forge
- renomme ce bouton en « Sortir de la forge »
- conserve « Rester en ville » pour l’action qui ferme entièrement le menu de ville
- limite la découverte des slash commands aux fichiers compilés `*Command.js`
- ajoute un test qui rejette les helpers JavaScript et les source maps

Fixes #4436

## Validation

- `pnpm eslint` : réussi
- `pnpm test` : 237 tests Discord réussis
- test de découverte : 3 tests réussis
- JSON français validé avec `jq`
- `pnpm tsc` reste bloqué sur l’erreur préexistante TS2589 dans `Discord/src/translations/i18n.ts:104`, hors du périmètre de ce patch