### PR TITLE
Run notification hooks safely after commit

### DIFF
--- a/Core/src/core/database/game/models/InventoryInfo.ts
+++ b/Core/src/core/database/game/models/InventoryInfo.ts
@@ -13,6 +13,7 @@ import {
 import { DailyConstants } from "../../../../../../Lib/src/constants/DailyConstants";
 import { CrowniclesLogger } from "../../../../../../Lib/src/logs/CrowniclesLogger";
 import { Players } from "./Player";
+import { scheduleAfterCommit } from "../../../../../../Lib/src/locks/scheduleAfterCommit";
 import {
 	LockKey, withLockedEntities
 } from "../../../../../../Lib/src/locks/withLockedEntities";
@@ -167,7 +168,7 @@ export function initModel(sequelize: Sequelize): void {
 			.toDate();
 	});
 
-	InventoryInfo.afterSave(instance => {
+	InventoryInfo.afterSave((instance, options) => {
 		const handleNotifications = async (): Promise<void> => {
 			// DailyBonus Notification
 			const pendingDailyBonusNotification = await ScheduledDailyBonusNotifications.getPendingNotification(instance.playerId);
@@ -187,11 +188,9 @@ export function initModel(sequelize: Sequelize): void {
 			}
 		};
 
-		handleNotifications()
-			.then()
-			.catch(error => {
-				CrowniclesLogger.errorWithObj("Error while handling notifications", error);
-			});
+		scheduleAfterCommit(handleNotifications, error => {
+			CrowniclesLogger.errorWithObj("Error while handling notifications", error);
+		}, options.transaction);
 	});
 }
 

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -30,6 +30,7 @@ import { PlayerDeathPacket } from "../../../../../../Lib/src/packets/events/Play
 import { PlayerLeavePveIslandPacket } from "../../../../../../Lib/src/packets/events/PlayerLeavePveIslandPacket";
 import { PlayerLevelUpPacket } from "../../../../../../Lib/src/packets/events/PlayerLevelUpPacket";
 import { MapLinkDataController } from "../../../../data/MapLink";
+import { scheduleAfterCommit } from "../../../../../../Lib/src/locks/scheduleAfterCommit";
 import {
 	MapLocation, MapLocationDataController
 } from "../../../../data/MapLocation";
@@ -1965,7 +1966,7 @@ export function initModel(sequelize: Sequelize): void {
 			.toDate();
 	});
 
-	Player.afterSave(instance => {
+	Player.afterSave((instance, options) => {
 		if (!instance.mapLinkId) {
 			return;
 		}
@@ -2003,11 +2004,9 @@ export function initModel(sequelize: Sequelize): void {
 			}
 		};
 
-		handleNotifications()
-			.then()
-			.catch(error => {
-				CrowniclesLogger.errorWithObj("Error while handling notifications", error);
-			});
+		scheduleAfterCommit(handleNotifications, error => {
+			CrowniclesLogger.errorWithObj("Error while handling notifications", error);
+		}, options.transaction);
 	});
 }
 

--- a/Lib/src/locks/scheduleAfterCommit.ts
+++ b/Lib/src/locks/scheduleAfterCommit.ts
@@ -8,8 +8,8 @@ type AsyncTask = () => Promise<void>;
 function runOutsideTransaction(task: AsyncTask, onError: (error: unknown) => void): void {
 	const namespace = getCrowniclesNamespace();
 	namespace.run(() => {
-		namespace.set(CLS_TRANSACTION_KEY, undefined);
-		void task().catch(onError);
+		namespace.set(CLS_TRANSACTION_KEY, null);
+		task().catch(onError);
 	});
 }
 

--- a/Lib/src/locks/scheduleAfterCommit.ts
+++ b/Lib/src/locks/scheduleAfterCommit.ts
@@ -1,0 +1,24 @@
+import {
+	CLS_TRANSACTION_KEY, getCrowniclesNamespace, getCurrentTransaction
+} from "./CLSNamespace";
+import type { Transaction } from "sequelize";
+
+type AsyncTask = () => Promise<void>;
+
+function runOutsideTransaction(task: AsyncTask, onError: (error: unknown) => void): void {
+	const namespace = getCrowniclesNamespace();
+	namespace.run(() => {
+		namespace.set(CLS_TRANSACTION_KEY, undefined);
+		void task().catch(onError);
+	});
+}
+
+export function scheduleAfterCommit(task: AsyncTask, onError: (error: unknown) => void, explicitTransaction?: Transaction | null): void {
+	const transaction = explicitTransaction === undefined ? getCurrentTransaction() : explicitTransaction;
+	if (transaction) {
+		transaction.afterCommit(() => runOutsideTransaction(task, onError));
+		return;
+	}
+
+	runOutsideTransaction(task, onError);
+}

--- a/Lib/tests/locks/scheduleAfterCommit.test.ts
+++ b/Lib/tests/locks/scheduleAfterCommit.test.ts
@@ -37,7 +37,7 @@ describe("scheduleAfterCommit", () => {
 			await Promise.resolve();
 		});
 
-		expect(observedTransaction).toHaveBeenCalledWith(undefined);
+		expect(observedTransaction).toHaveBeenCalledWith(null);
 	});
 
 	it("does not run when the transaction never commits", async () => {

--- a/Lib/tests/locks/scheduleAfterCommit.test.ts
+++ b/Lib/tests/locks/scheduleAfterCommit.test.ts
@@ -1,0 +1,83 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import {
+	CLS_TRANSACTION_KEY, getCrowniclesNamespace
+} from "../../src/locks/CLSNamespace";
+import { scheduleAfterCommit } from "../../src/locks/scheduleAfterCommit";
+
+describe("scheduleAfterCommit", () => {
+	it("runs immediately outside a transaction", async () => {
+		const task = vi.fn().mockResolvedValue(undefined);
+
+		scheduleAfterCommit(task, vi.fn());
+		await Promise.resolve();
+
+		expect(task).toHaveBeenCalledOnce();
+	});
+
+	it("waits for commit and clears the transaction context", async () => {
+		const namespace = getCrowniclesNamespace();
+		let afterCommit: (() => void) | undefined;
+		const transaction = {
+			afterCommit: vi.fn(callback => {
+				afterCommit = callback;
+			})
+		};
+		const observedTransaction = vi.fn();
+
+		await namespace.runPromise(async () => {
+			namespace.set(CLS_TRANSACTION_KEY, transaction);
+			scheduleAfterCommit(async () => {
+				observedTransaction(namespace.get(CLS_TRANSACTION_KEY));
+			}, vi.fn());
+
+			expect(observedTransaction).not.toHaveBeenCalled();
+			afterCommit?.();
+			await Promise.resolve();
+		});
+
+		expect(observedTransaction).toHaveBeenCalledWith(undefined);
+	});
+
+	it("does not run when the transaction never commits", async () => {
+		const namespace = getCrowniclesNamespace();
+		const task = vi.fn().mockResolvedValue(undefined);
+		const transaction = { afterCommit: vi.fn() };
+
+		await namespace.runPromise(async () => {
+			namespace.set(CLS_TRANSACTION_KEY, transaction);
+			scheduleAfterCommit(task, vi.fn());
+		});
+
+		expect(task).not.toHaveBeenCalled();
+	});
+
+	it("uses an explicit transaction outside CLS", async () => {
+		let afterCommit: (() => void) | undefined;
+		const transaction = {
+			afterCommit: vi.fn(callback => {
+				afterCommit = callback;
+			})
+		};
+		const task = vi.fn().mockResolvedValue(undefined);
+
+		scheduleAfterCommit(task, vi.fn(), transaction as never);
+		expect(task).not.toHaveBeenCalled();
+
+		afterCommit?.();
+		await Promise.resolve();
+		expect(task).toHaveBeenCalledOnce();
+	});
+
+	it("reports task errors without rejecting the transaction callback", async () => {
+		const error = new Error("notification failed");
+		const onError = vi.fn();
+
+		scheduleAfterCommit(() => Promise.reject(error), onError);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onError).toHaveBeenCalledWith(error);
+	});
+});


### PR DESCRIPTION
## Résumé

- ajoute `scheduleAfterCommit` pour différer les effets secondaires jusqu’au commit effectif
- exécute les callbacks dans un nouveau contexte CLS sans transaction terminée
- prend en charge les transactions explicites des hooks Sequelize et le repli sur la transaction CLS
- exécute immédiatement les tâches hors transaction
- isole les erreurs de notification de la transaction métier
- applique ce contrat aux notifications de rapport et de bonus quotidien

Fixes #4442

## Preuve production

Loki a enregistré 163 erreurs `commit has been called on this transaction` sur quatre heures : 159 notifications de rapport, 2 chemins DailyBonus et 2 tentatives de SAVEPOINT après commit.

## Validation

- Lib : ESLint, TypeScript, 574 tests réussis
- Core : ESLint, TypeScript, 1 355 tests réussis
- tests dédiés : exécution hors transaction, attente du commit, absence après rollback, transaction explicite et erreurs isolées