### PR TITLE
Make charged attack final hit physical

### DIFF
--- a/Core/__tests__/core/fightActions/ChargingAttackType.test.ts
+++ b/Core/__tests__/core/fightActions/ChargingAttackType.test.ts
@@ -1,0 +1,16 @@
+import {
+	describe, expect, it
+} from "vitest";
+import chargingAttack = require("../../../resources/fightActions/chargingAttack.json");
+import chargeChargingAttack = require("../../../resources/fightActions/chargeChargingAttack.json");
+import { FightActionType } from "../../../../Lib/src/types/FightActionType";
+
+describe("charged attack action types", () => {
+	it("treats the preparation phase as physical", () => {
+		expect(chargeChargingAttack.type).toBe(FightActionType.PHYSICAL);
+	});
+
+	it("treats the final hit as physical damage", () => {
+		expect(chargingAttack.type).toBe(FightActionType.PHYSICAL);
+	});
+});

--- a/Core/resources/fightActions/chargingAttack.json
+++ b/Core/resources/fightActions/chargingAttack.json
@@ -1,5 +1,5 @@
 {
   "breath": 0,
   "missionVariant": 4,
-  "type": "charge"
+  "type": "physical"
 }


### PR DESCRIPTION
## Résumé

- passe le coup final de l’attaque chargée du type `charge` au type `physical`
- aligne le coup final sur la phase de préparation déjà physique
- permet aux résistances et renvois de dégâts physiques, notamment la solidification de la Tortue Géante, de s’appliquer au coup final
- ajoute un test sur le type des deux phases

Fixes #4270

## Validation

- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` : 1 357 tests Core réussis