### PR TITLE
Defer fight interactions before backend processing

### DIFF
--- a/Discord/__tests__/utils/FightInteractionUtils.test.ts
+++ b/Discord/__tests__/utils/FightInteractionUtils.test.ts
@@ -1,0 +1,42 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { deferFightInteraction } from "../../src/commands/player/FightInteractionUtils";
+
+describe("deferFightInteraction", () => {
+	it("defers an untouched interaction", async () => {
+		const interaction = {
+			deferred: false,
+			replied: false,
+			deferReply: vi.fn().mockResolvedValue(undefined)
+		};
+
+		await deferFightInteraction(interaction as never);
+
+		expect(interaction.deferReply).toHaveBeenCalledOnce();
+	});
+
+	it("does not defer an already deferred interaction", async () => {
+		const interaction = {
+			deferred: true,
+			replied: false,
+			deferReply: vi.fn()
+		};
+
+		await deferFightInteraction(interaction as never);
+
+		expect(interaction.deferReply).not.toHaveBeenCalled();
+	});
+
+	it("does not defer an already replied interaction", async () => {
+		const interaction = {
+			deferred: false,
+			replied: true,
+			deferReply: vi.fn()
+		};
+
+		await deferFightInteraction(interaction as never);
+
+		expect(interaction.deferReply).not.toHaveBeenCalled();
+	});
+});

--- a/Discord/src/commands/player/FightCommand.ts
+++ b/Discord/src/commands/player/FightCommand.ts
@@ -45,6 +45,7 @@ import { DiscordConstants } from "../../DiscordConstants";
 import { PetUtils } from "../../utils/PetUtils";
 import { SexTypeShort } from "../../../../Lib/src/constants/StringConstants";
 import { ReactionCollectorFightChooseActionPacket } from "../../../../Lib/src/packets/interaction/ReactionCollectorFightChooseAction";
+import { deferFightInteraction } from "./FightInteractionUtils";
 
 const buggedFights = new Set<string>();
 
@@ -69,7 +70,7 @@ function fightBugged(context: PacketContext, fightId: string): void {
  */
 export async function createFightCollector(context: PacketContext, packet: ReactionCollectorFightPacket): Promise<ReactionCollectorReturnTypeOrNull> {
 	const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
-	await interaction.deferReply();
+	await deferFightInteraction(interaction);
 	const lng = interaction.userLanguage;
 	const data = packet.data.data;
 	const subTextKey = RandomUtils.crowniclesRandom.bool(FightConstants.RARE_SUB_TEXT_INTRO) ? "rare" : "common";
@@ -641,6 +642,7 @@ async function getPacket(interaction: CrowniclesInteraction, user: KeycloakUser)
 	if (!player || !player.keycloakId) {
 		return null;
 	}
+	await deferFightInteraction(interaction);
 	return makePacket(CommandFightPacketReq, { playerKeycloakId: player.keycloakId });
 }
 

--- a/Discord/src/commands/player/FightInteractionUtils.ts
+++ b/Discord/src/commands/player/FightInteractionUtils.ts
@@ -1,0 +1,7 @@
+import { CrowniclesInteraction } from "../../messages/CrowniclesInteraction";
+
+export async function deferFightInteraction(interaction: CrowniclesInteraction): Promise<void> {
+	if (!interaction.deferred && !interaction.replied) {
+		await interaction.deferReply();
+	}
+}


### PR DESCRIPTION
## Résumé

- diffère l’interaction `/combat` après validation de la cible mais avant l’aller-retour Core
- empêche le token Discord d’expirer pendant la préparation du combat
- rend le defer idempotent lorsque le collecteur arrive sur une interaction déjà différée
- ajoute des tests pour les interactions intactes, différées et déjà répondues

Fixes #4015

## Validation

- `pnpm eslint` : réussi
- `pnpm test` : 240 tests Discord réussis
- test dédié : 3 tests réussis
- `pnpm tsc` reste bloqué sur l’erreur préexistante TS2589 dans `Discord/src/translations/i18n.ts:104`, hors du périmètre de ce patch