### PR TITLE
Restore potion usage counts in inventory

### DIFF
--- a/Core/__tests__/core/commands/player/InventoryPotionUsages.test.ts
+++ b/Core/__tests__/core/commands/player/InventoryPotionUsages.test.ts
@@ -1,0 +1,28 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { buildPotionDisplayPacket } from "../../../../src/commands/player/InventoryPotionUtils";
+import { NO_STAT_COMPARISON } from "../../../../../Lib/src/types/StatValues";
+
+vi.mock("../../../../src/core/utils/CommandUtils", () => ({
+	commandRequires: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => descriptor,
+	CommandUtils: {
+		DISALLOWED_EFFECTS: { NOT_STARTED_OR_DEAD: [] },
+		WHERE: { EVERYWHERE: [] }
+	}
+}));
+
+describe("inventory potion usages", () => {
+	it("forwards the remaining usages to the potion display packet", () => {
+		const getDisplayPacket = vi.fn().mockReturnValue({ usages: 2, maxUsages: 5 });
+		const potionSlot = {
+			getItem: () => ({ getDisplayPacket }),
+			remainingPotionUsages: 2
+		};
+
+		const result = buildPotionDisplayPacket(potionSlot as never);
+
+		expect(getDisplayPacket).toHaveBeenCalledWith(NO_STAT_COMPARISON, 2);
+		expect(result).toEqual({ usages: 2, maxUsages: 5 });
+	});
+});

--- a/Core/__tests__/core/commands/player/InventoryPotionUsages.test.ts
+++ b/Core/__tests__/core/commands/player/InventoryPotionUsages.test.ts
@@ -4,14 +4,6 @@ import {
 import { buildPotionDisplayPacket } from "../../../../src/commands/player/InventoryPotionUtils";
 import { NO_STAT_COMPARISON } from "../../../../../Lib/src/types/StatValues";
 
-vi.mock("../../../../src/core/utils/CommandUtils", () => ({
-	commandRequires: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => descriptor,
-	CommandUtils: {
-		DISALLOWED_EFFECTS: { NOT_STARTED_OR_DEAD: [] },
-		WHERE: { EVERYWHERE: [] }
-	}
-}));
-
 describe("inventory potion usages", () => {
 	it("forwards the remaining usages to the potion display packet", () => {
 		const getDisplayPacket = vi.fn().mockReturnValue({ usages: 2, maxUsages: 5 });

--- a/Core/__tests__/core/data/PotionData.test.ts
+++ b/Core/__tests__/core/data/PotionData.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { readdirSync, readFileSync } from "fs";
 import { resolve } from "path";
 import { CrowniclesIcons } from "../../../../Lib/src/CrowniclesIcons";
+import { Potion } from "../../../src/data/Potion";
+import { ItemNature } from "../../../../Lib/src/constants/ItemConstants";
 
 /**
  * ItemNature enum values for reference:
@@ -16,6 +18,16 @@ interface PotionData {
 	nature: number;
 	usages?: number;
 	fallbackEmote?: string;
+}
+
+function createPotion(nature: ItemNature, usages?: number): Potion {
+	return Object.assign(new Potion(), {
+		id: 1,
+		rarity: 1,
+		power: 10,
+		nature,
+		...(usages === undefined ? {} : { usages })
+	});
 }
 
 describe("Potion Data Validation", () => {
@@ -84,5 +96,25 @@ describe("Potion Data Validation", () => {
 
 			expect(invalidUsages, errorMessage).toHaveLength(0);
 		}
+	});
+
+	it("includes current and maximum usages in combat potion display packets", () => {
+		const potion = createPotion(ItemNature.ATTACK, 4);
+
+		expect(potion.getDisplayPacket(undefined, 2)).toMatchObject({
+			usages: 2,
+			maxUsages: 4
+		});
+		expect(potion.getDisplayPacket()).toMatchObject({
+			usages: 4,
+			maxUsages: 4
+		});
+	});
+
+	it("omits usages from non-combat potion display packets", () => {
+		const displayPacket = createPotion(ItemNature.HEALTH).getDisplayPacket();
+
+		expect(displayPacket).not.toHaveProperty("usages");
+		expect(displayPacket).not.toHaveProperty("maxUsages");
 	});
 });

--- a/Core/src/commands/player/InventoryCommand.ts
+++ b/Core/src/commands/player/InventoryCommand.ts
@@ -27,6 +27,7 @@ import {
 import {
 	PlantId, PLANT_SLOT_TYPE
 } from "../../../../Lib/src/constants/PlantConstants";
+import { buildPotionDisplayPacket } from "./InventoryPotionUtils";
 
 function buildMainItemBackups(
 	items: InventorySlot[],
@@ -48,7 +49,7 @@ function buildPotionBackups(
 	slot: number;
 }[] {
 	return items.map(item => ({
-		display: (item.getItem() as Potion).getDisplayPacket(),
+		display: buildPotionDisplayPacket(item),
 		slot: item.slot
 	}));
 }
@@ -135,7 +136,7 @@ async function buildInventoryData(toCheckPlayer: Player): Promise<CommandInvento
 		data: {
 			weapon: (weapon.getItem() as MainItem).getDisplayPacket(weapon.itemLevel, weapon.itemEnchantmentId ?? undefined, maxStatsValues),
 			armor: (armor.getItem() as MainItem).getDisplayPacket(armor.itemLevel, armor.itemEnchantmentId ?? undefined, maxStatsValues),
-			potion: (potion.getItem() as Potion).getDisplayPacket(),
+			potion: buildPotionDisplayPacket(potion),
 			object: (object.getItem() as ObjectItem).getDisplayPacket(maxStatsValues),
 			backupWeapons: buildMainItemBackups(getBackupItems(items, item => item.isWeapon()), maxStatsValues),
 			backupArmors: buildMainItemBackups(getBackupItems(items, item => item.isArmor()), maxStatsValues),

--- a/Core/src/commands/player/InventoryPotionUtils.ts
+++ b/Core/src/commands/player/InventoryPotionUtils.ts
@@ -5,4 +5,3 @@ import { NO_STAT_COMPARISON } from "../../../../Lib/src/types/StatValues";
 export function buildPotionDisplayPacket(item: InventorySlot): ReturnType<Potion["getDisplayPacket"]> {
 	return (item.getItem() as Potion).getDisplayPacket(NO_STAT_COMPARISON, item.remainingPotionUsages);
 }
-

--- a/Core/src/commands/player/InventoryPotionUtils.ts
+++ b/Core/src/commands/player/InventoryPotionUtils.ts
@@ -1,0 +1,8 @@
+import InventorySlot from "../../core/database/game/models/InventorySlot";
+import { Potion } from "../../data/Potion";
+import { NO_STAT_COMPARISON } from "../../../../Lib/src/types/StatValues";
+
+export function buildPotionDisplayPacket(item: InventorySlot): ReturnType<Potion["getDisplayPacket"]> {
+	return (item.getItem() as Potion).getDisplayPacket(NO_STAT_COMPARISON, item.remainingPotionUsages);
+}
+

--- a/Core/src/data/Potion.ts
+++ b/Core/src/data/Potion.ts
@@ -5,6 +5,9 @@ import { ItemDataController } from "./DataController";
 import { SupportItem } from "./SupportItem";
 import { RandomUtils } from "../../../Lib/src/utils/RandomUtils";
 import { SupportItemDetails } from "../../../Lib/src/types/SupportItemDetails";
+import {
+	NO_STAT_COMPARISON, StatValues
+} from "../../../Lib/src/types/StatValues";
 
 export class Potion extends SupportItem {
 	categoryName = "potions";
@@ -24,14 +27,21 @@ export class Potion extends SupportItem {
 		return this.power;
 	}
 
-	public getDisplayPacket(): SupportItemDetails {
+	public getDisplayPacket(_maxStatsValue: StatValues = NO_STAT_COMPARISON, itemUsages?: number): SupportItemDetails {
+		const maxUsages = this.isFightPotion() ? this.usages || 1 : undefined;
 		return {
 			itemCategory: this.getCategory(),
 			maxPower: this.power,
 			nature: this.nature,
 			power: this.power,
 			rarity: this.rarity,
-			id: this.id
+			id: this.id,
+			...maxUsages === undefined
+				? {}
+				: {
+					usages: itemUsages ?? maxUsages,
+					maxUsages
+				}
 		};
 	}
 }

--- a/Core/src/data/SupportItem.ts
+++ b/Core/src/data/SupportItem.ts
@@ -20,5 +20,5 @@ export abstract class SupportItem extends GenericItem {
 		return this.nature === ItemNature.SPEED ? this.power : 0;
 	}
 
-	public abstract getDisplayPacket(maxStatsValue: StatValues): SupportItemDetails;
+	public abstract getDisplayPacket(maxStatsValue: StatValues, itemUsages?: number): SupportItemDetails;
 }

--- a/Discord/__tests__/utils/DisplayUtils.test.ts
+++ b/Discord/__tests__/utils/DisplayUtils.test.ts
@@ -1,0 +1,19 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { formatPotionUsagesPrefix } from "../../src/utils/PotionDisplayUtils";
+
+describe("formatPotionUsagesPrefix", () => {
+	it("displays remaining and maximum usages for multi-use potions", () => {
+		expect(formatPotionUsagesPrefix(2, 4)).toBe("**2/4** | ");
+	});
+
+	it("defaults remaining usages to the maximum", () => {
+		expect(formatPotionUsagesPrefix(undefined, 4)).toBe("**4/4** | ");
+	});
+
+	it("hides usages for single-use and non-fight potions", () => {
+		expect(formatPotionUsagesPrefix(1, 1)).toBe("");
+		expect(formatPotionUsagesPrefix(undefined, undefined)).toBe("");
+	});
+});

--- a/Discord/src/utils/DiscordItemUtils.ts
+++ b/Discord/src/utils/DiscordItemUtils.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../Lib/src/constants/ItemConstants";
 import { minutesDisplayIntl } from "../../../Lib/src/utils/TimeUtils";
 import { DisplayUtils } from "./DisplayUtils";
+import { formatPotionUsagesPrefix } from "./PotionDisplayUtils";
 import { ItemEnchantment } from "../../../Lib/src/types/ItemEnchantment";
 import { CrowniclesIcons } from "../../../Lib/src/CrowniclesIcons";
 import { MainItemDetails } from "../../../Lib/src/types/MainItemDetails";
@@ -86,15 +87,16 @@ export class DiscordItemUtils {
 	}
 
 	static getPotionField(displayPacket: SupportItemDetails, lng: Language): EmbedField {
+		const natureValue = i18n.t(`items:potionsNatures.${displayPacket.nature}`, {
+			lng,
+			power: displayPacket.nature === ItemNature.TIME_SPEEDUP ? minutesDisplayIntl(displayPacket.power, lng) : displayPacket.power
+		});
 		return DiscordItemUtils.getClassicItemField(
 			"potions",
 			DisplayUtils.getItemIcon({
 				id: displayPacket.id, category: displayPacket.itemCategory
 			}),
-			i18n.t(`items:potionsNatures.${displayPacket.nature}`, {
-				lng,
-				power: displayPacket.nature === ItemNature.TIME_SPEEDUP ? minutesDisplayIntl(displayPacket.power, lng) : displayPacket.power
-			}),
+			`${formatPotionUsagesPrefix(displayPacket.usages, displayPacket.maxUsages)}${natureValue}`,
 			displayPacket,
 			lng
 		);

--- a/Discord/src/utils/PotionDisplayUtils.ts
+++ b/Discord/src/utils/PotionDisplayUtils.ts
@@ -1,0 +1,7 @@
+export function formatPotionUsagesPrefix(usages: number | undefined, maxUsages: number | undefined): string {
+	if (!maxUsages || maxUsages <= 1) {
+		return "";
+	}
+	return `**${usages ?? maxUsages}/${maxUsages}** | `;
+}
+

--- a/Discord/src/utils/PotionDisplayUtils.ts
+++ b/Discord/src/utils/PotionDisplayUtils.ts
@@ -4,4 +4,3 @@ export function formatPotionUsagesPrefix(usages: number | undefined, maxUsages: 
 	}
 	return `**${usages ?? maxUsages}/${maxUsages}** | `;
 }
-

--- a/Lib/src/types/SupportItemDetails.ts
+++ b/Lib/src/types/SupportItemDetails.ts
@@ -7,4 +7,6 @@ export interface SupportItemDetails {
 	power: number;
 	maxPower: number;
 	itemCategory: number;
+	usages?: number;
+	maxUsages?: number;
 }


### PR DESCRIPTION
## Résumé

- ajoute les usages restants et maximum au paquet d’affichage des potions de combat
- transmet `remainingPotionUsages` pour la potion équipée et les potions de réserve
- affiche le compteur sous la forme `restant/total` dans l’inventaire Discord
- masque ce compteur pour les potions à usage unique et hors combat
- ajoute des tests Core et Discord sur le paquet et le rendu

Fixes #4445

## Validation

- Core : ESLint, TypeScript, 1 358 tests réussis
- Lib : ESLint, TypeScript, 569 tests réussis
- Discord : ESLint, 240 tests réussis
- Discord TypeScript reste bloqué sur l’erreur préexistante TS2589 dans `Discord/src/translations/i18n.ts:104`