### PR TITLE
Show cart refusal when the collector times out

### DIFF
--- a/Discord/__tests__/smallEvents/CartTimeout.test.ts
+++ b/Discord/__tests__/smallEvents/CartTimeout.test.ts
@@ -1,0 +1,43 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { DiscordCache } from "../../src/bot/DiscordCache";
+import { cartResult } from "../../src/smallEvents/cart";
+
+vi.mock("../../src/bot/DiscordCache");
+
+describe("cartResult timeout", () => {
+	it("edits the original interaction when no button was pressed", async () => {
+		const editReply = vi.fn().mockResolvedValue(undefined);
+		vi.mocked(DiscordCache.getInteraction).mockReturnValue({
+			editReply,
+			user: {
+				displayAvatarURL: () => "https://example.com/avatar.png",
+				displayName: "Tester"
+			}
+		} as never);
+
+		await cartResult({
+			isDisplayed: true,
+			isScam: false,
+			pointsWon: 0,
+			travelDone: {
+				hasEnoughMoney: true,
+				isAccepted: false
+			}
+		} as never, {
+			discord: {
+				channel: "channel",
+				interaction: "command-interaction",
+				language: "fr",
+				shardId: 0,
+				user: "user"
+			},
+			frontEndOrigin: "discord",
+			frontEndSubOrigin: "guild"
+		} as never);
+
+		expect(DiscordCache.getInteraction).toHaveBeenCalledWith("command-interaction");
+		expect(editReply).toHaveBeenCalledOnce();
+	});
+});

--- a/Discord/src/smallEvents/cart.ts
+++ b/Discord/src/smallEvents/cart.ts
@@ -68,7 +68,9 @@ function getGainScoreText(story: CartStory, packet: SmallEventCartPacket, lng: L
 }
 
 export async function cartResult(packet: SmallEventCartPacket, context: PacketContext): Promise<void> {
-	const interaction = DiscordCache.getButtonInteraction(context.discord!.buttonInteraction!);
+	const interaction = context.discord?.buttonInteraction
+		? DiscordCache.getButtonInteraction(context.discord.buttonInteraction)
+		: DiscordCache.getInteraction(context.discord!.interaction);
 	if (!interaction) {
 		return;
 	}


### PR DESCRIPTION
## Résumé

- utilise l’interaction de bouton lorsqu’un choix a été fait
- retombe sur l’interaction slash d’origine lorsque le collecteur expire sans réponse
- affiche alors le récit `travelRefused` déjà produit par Core au lieu de laisser le message silencieux
- ajoute un test de timeout sans interaction de bouton

Fixes #4422

## Validation

- `pnpm eslint` : réussi
- `pnpm test` : 238 tests Discord réussis
- test dédié : réussi
- `pnpm tsc` reste bloqué sur l’erreur préexistante TS2589 dans `Discord/src/translations/i18n.ts:104`