### PR TITLE
Fix weekly score updates under player lock

### DIFF
--- a/Core/__tests__/core/missions/MissionChainStateSync.test.ts
+++ b/Core/__tests__/core/missions/MissionChainStateSync.test.ts
@@ -69,7 +69,6 @@ describe("Mission chain state synchronization", () => {
 			// Mock methods that interact with DB
 			setMoney: vi.fn(),
 			setScore: vi.fn().mockResolvedValue(undefined),
-			addWeeklyScore: vi.fn(),
 			needLevelUp: vi.fn().mockReturnValue(false),
 			save: vi.fn().mockResolvedValue(undefined),
 			toJSON: function() {
@@ -184,6 +183,31 @@ describe("Mission chain state synchronization", () => {
 
 			expect(player.experience).toBe(originalExperience + 15);
 			expect(player.score).toBe(150);
+		});
+
+		it("should persist weekly score gains on the locked player", async () => {
+			const player = createTestPlayer({ score: 100, weeklyScore: 200 });
+			let persistedWeeklyScore = 0;
+
+			vi.spyOn(MissionsController, "update").mockImplementation(async (inputPlayer, _response, opts) => {
+				const lockedPlayer = createTestPlayer({
+					...inputPlayer,
+					score: inputPlayer.score,
+					weeklyScore: inputPlayer.weeklyScore
+				});
+				opts.applyOnLockedPlayer?.(lockedPlayer);
+				persistedWeeklyScore = lockedPlayer.weeklyScore;
+				return lockedPlayer;
+			});
+
+			await player.addScore({
+				amount: 50,
+				response,
+				reason: NumberChangeReason.BIG_EVENT
+			});
+
+			expect(persistedWeeklyScore).toBe(250);
+			expect(player.weeklyScore).toBe(250);
 		});
 	});
 });

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -298,17 +298,18 @@ export class Player extends Model {
 				count: delta,
 				applyOnLockedPlayer: locked => {
 					locked.score += delta;
+					locked.addWeeklyScore(delta);
 				}
 			});
 			Object.assign(this, newPlayer);
 		}
 		else {
 			this.score += delta;
+			this.addWeeklyScore(delta);
 		}
 		await this.setScore(this.score, parameters.response);
 		crowniclesInstance?.logsDatabase.logScoreChange(this.keycloakId, this.score, parameters.reason)
 			.then();
-		this.addWeeklyScore(parameters.amount);
 		return this;
 	}
 


### PR DESCRIPTION
## Summary

- update `score` and `weeklyScore` together on the locked player instance
- preserve the existing lower bound behavior for negative score changes
- add regression coverage proving weekly gains are persisted before later mission updates reload player state

## Context

Positive score gains were persisted under the player/mission lock, while `weeklyScore` was only changed on the caller instance after the transaction. Flows such as big events then awarded money and experience, reloaded the persisted player, and could overwrite the in-memory weekly increment.

Production log reconstruction on 2026-07-17 identified 106 affected players and about 119,693 missing weekly points. Restoring the current leaderboard values from logs is a separate production data operation.

Fixes #4448

## Validation

- `pnpm eslint`
- `pnpm test` (79 files, 1,356 tests)
- `pnpm tsc`
- targeted `MissionChainStateSync.test.ts` regression test