### PR TITLE
Allow gardener encounters in both travel directions

### DIFF
--- a/Lib/src/constants/PlantConstants.ts
+++ b/Lib/src/constants/PlantConstants.ts
@@ -441,14 +441,17 @@ export abstract class PlantConstants {
 
 	/**
 	 * Map link IDs where the gardener NPC can appear.
-	 * Link 8: Plains(3) -> Forest(4)
-	 * Link 46: Village(17) -> Forest(27)
-	 * Link 32: Forest(22) -> Lake(14)
+	 * Links 8/69: Plains(3) <-> Forest(4)
+	 * Links 46/59: Village(17) <-> Forest(27)
+	 * Links 32/56: Forest(22) <-> Lake(14)
 	 */
 	public static readonly GARDENER_MAP_LINKS: readonly number[] = [
 		8,
+		69,
 		46,
-		32
+		59,
+		32,
+		56
 	];
 
 	/**

--- a/Lib/tests/constants/GardenerMapLinks.test.ts
+++ b/Lib/tests/constants/GardenerMapLinks.test.ts
@@ -1,0 +1,14 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { PlantConstants } from "../../src/constants/PlantConstants";
+
+describe("gardener map links", () => {
+	it("allows each configured route in both directions", () => {
+		expect(new Set(PlantConstants.GARDENER_MAP_LINKS)).toEqual(new Set([
+			8, 69,
+			46, 59,
+			32, 56
+		]));
+	});
+});


### PR DESCRIPTION
## Résumé

- ajoute les liens inverses des trois trajets autorisés au mini-événement gardener
- permet au jardinier d’apparaître dans les deux sens entre Plaine/Forêt, Village/Forêt et Forêt/Lac
- ajoute un test sur les six IDs de liens configurés

Fixes #4452

## Validation

- Lib : ESLint, TypeScript, 570 tests réussis