### PR TITLE
Fix pebble event health malus

### DIFF
--- a/Core/__tests__/core/data/BonusGuildPveIslandData.test.ts
+++ b/Core/__tests__/core/data/BonusGuildPveIslandData.test.ts
@@ -1,0 +1,17 @@
+import {
+	describe, expect, it
+} from "vitest";
+import bonusGuildPveIsland = require("../../../resources/smallEvents/bonusGuildPVEIsland.json");
+
+describe("bonus guild PvE island event data", () => {
+	it("uses the life malus for the pebble injury", () => {
+		const pebbleEvent = bonusGuildPveIsland.properties.events[3];
+
+		expect(pebbleEvent.lose.withGuild).toBe("life");
+		expect(pebbleEvent.lose.solo).toBe("life");
+		expect(bonusGuildPveIsland.properties.ranges.life).toEqual({
+			min: 3,
+			max: 10
+		});
+	});
+});

--- a/Core/resources/smallEvents/bonusGuildPVEIsland.json
+++ b/Core/resources/smallEvents/bonusGuildPVEIsland.json
@@ -55,7 +55,7 @@
           "solo": "experience"
         },
         "lose": {
-          "withGuild": "money",
+          "withGuild": "life",
           "solo": "life"
         }
       },


### PR DESCRIPTION
## Résumé

- corrige la donnée du mini-événement caillou sur l’île
- applique désormais le malus `life` avec guilde, comme le texte et le cas solo
- ramène le montant appliqué et affiché à la plage de vie prévue de 3 à 10 au lieu de la plage d’argent 25 à 50
- ajoute un test ciblé sur l’événement d’index 3

Fixes #4453

## Validation

- Core : ESLint, TypeScript, 1 356 tests réussis