### PR TITLE
Unlock tokens from the start of the game

### DIFF
--- a/Core/__tests__/core/commands/report/TokensUsage.test.ts
+++ b/Core/__tests__/core/commands/report/TokensUsage.test.ts
@@ -528,22 +528,13 @@ describe("Tokens Usage", () => {
 			vi.spyOn(Maps, "isOnPveIsland").mockReturnValue(false);
 		});
 
-		it("should allow tokens on the main continent at level 5 or above", () => {
+		it("should allow tokens on the main continent from the starting level", () => {
 			const player = createMockPlayer({ mapLinkId: 1, level: TokensConstants.LEVEL_TO_UNLOCK });
 			vi.spyOn(Maps, "isOnContinent").mockReturnValue(true);
 			vi.spyOn(Maps, "isOnBoat").mockReturnValue(false);
 			vi.spyOn(Maps, "isOnPveIsland").mockReturnValue(false);
 
 			expect(canUseTokensAtLocation(player as unknown as Parameters<typeof canUseTokensAtLocation>[0])).toBe(true);
-		});
-
-		it("should deny tokens when player level is below unlock threshold", () => {
-			const player = createMockPlayer({ mapLinkId: 1, level: TokensConstants.LEVEL_TO_UNLOCK - 1 });
-			vi.spyOn(Maps, "isOnContinent").mockReturnValue(true);
-			vi.spyOn(Maps, "isOnBoat").mockReturnValue(false);
-			vi.spyOn(Maps, "isOnPveIsland").mockReturnValue(false);
-
-			expect(canUseTokensAtLocation(player as unknown as Parameters<typeof canUseTokensAtLocation>[0])).toBe(false);
 		});
 
 		it("should deny tokens when not on continent", () => {

--- a/Core/__tests__/core/commands/report/TokensUsage.test.ts
+++ b/Core/__tests__/core/commands/report/TokensUsage.test.ts
@@ -10,6 +10,7 @@ import {Constants} from "../../../../../Lib/src/constants/Constants";
 import {NumberChangeReason} from "../../../../../Lib/src/constants/LogsConstants";
 import {canUseTokensAtLocation} from "../../../../src/core/report/ReportTravelService";
 import {asMilliseconds} from "../../../../../Lib/src/utils/TimeUtils";
+import {PlayersConstants} from "../../../../../Lib/src/constants/PlayersConstants";
 
 // Use fake timers so that `Date.now()` and `new Date()` both return our controlled `now`
 vi.useFakeTimers();
@@ -529,7 +530,7 @@ describe("Tokens Usage", () => {
 		});
 
 		it("should allow tokens on the main continent from the starting level", () => {
-			const player = createMockPlayer({ mapLinkId: 1, level: TokensConstants.LEVEL_TO_UNLOCK });
+			const player = createMockPlayer({ mapLinkId: 1, level: PlayersConstants.PLAYER_DEFAULT_VALUES.LEVEL });
 			vi.spyOn(Maps, "isOnContinent").mockReturnValue(true);
 			vi.spyOn(Maps, "isOnBoat").mockReturnValue(false);
 			vi.spyOn(Maps, "isOnPveIsland").mockReturnValue(false);

--- a/Core/src/commands/player/ProfileCommand.ts
+++ b/Core/src/commands/player/ProfileCommand.ts
@@ -222,12 +222,9 @@ interface ProfileTokenData {
 }
 
 /**
- * Build token data for profile (only if player level is high enough)
+ * Build token data for profile
  */
-function buildTokenData(player: Player): ProfileTokenData | undefined {
-	if (player.level < TokensConstants.LEVEL_TO_UNLOCK) {
-		return undefined;
-	}
+function buildTokenData(player: Player): ProfileTokenData {
 	return {
 		value: player.tokens,
 		max: TokensConstants.MAX

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -474,7 +474,6 @@ export class Player extends Model {
 			classesTier5Unlocked: newLevel === ClassConstants.GROUP4LEVEL,
 			missionSlotUnlocked: Player.isMissionSlotUnlockedAtLevel(newLevel),
 			pveUnlocked: newLevel === PVEConstants.MIN_LEVEL,
-			tokensUnlocked: newLevel === TokensConstants.LEVEL_TO_UNLOCK,
 			statsIncreased: true
 		});
 

--- a/Core/src/core/report/ReportTravelService.ts
+++ b/Core/src/core/report/ReportTravelService.ts
@@ -148,11 +148,6 @@ interface TokenButtonData {
  * @param player - The player to check
  */
 export function canUseTokensAtLocation(player: Player): boolean {
-	// Tokens are unlocked at a specific level
-	if (player.level < TokensConstants.LEVEL_TO_UNLOCK) {
-		return false;
-	}
-
 	// Tokens can only be used on the main continent
 	if (!Maps.isOnContinent(player)) {
 		return false;

--- a/Core/src/core/smallEvents/expeditionAdvice.ts
+++ b/Core/src/core/smallEvents/expeditionAdvice.ts
@@ -33,11 +33,10 @@ import { BlessingManager } from "../blessings/BlessingManager";
 
 /**
  * Check if the small event can be executed for this player
- * Requires: player level >= tokens unlock level and on continent
+ * Requires the player to be on the continent
  */
 function canBeExecuted(player: Player): boolean {
-	return Maps.isOnContinent(player)
-		&& player.level >= TokensConstants.LEVEL_TO_UNLOCK;
+	return Maps.isOnContinent(player);
 }
 
 /**

--- a/Core/src/core/smallEvents/interactOtherPlayers.ts
+++ b/Core/src/core/smallEvents/interactOtherPlayers.ts
@@ -41,7 +41,6 @@ import { LogsDatabase } from "../database/logs/LogsDatabase";
 import { LogsPveFightsResults } from "../database/logs/models/LogsPveFightsResults";
 import { SmallEventConstants } from "../../../../Lib/src/constants/SmallEventConstants";
 import { FightConstants } from "../../../../Lib/src/constants/FightConstants";
-import { TokensConstants } from "../../../../Lib/src/constants/TokensConstants";
 import {
 	LockedRowNotFoundError, withLockedEntities
 } from "../../../../Lib/src/locks/withLockedEntities";
@@ -317,12 +316,12 @@ function checkGems(gems: number, interactionsList: InteractOtherPlayerInteractio
 }
 
 /**
- * Check token interactions, interaction not permitted if player is below level 5.
+ * Check token interactions
  * @param otherPlayer
  * @param interactionsList
  */
 function checkTokens(otherPlayer: Player, interactionsList: InteractOtherPlayerInteraction[]): void {
-	if (otherPlayer.level >= TokensConstants.LEVEL_TO_UNLOCK && otherPlayer.tokens >= SmallEventConstants.INTERACT_OTHER_PLAYERS.MANY_TOKENS_MIN) {
+	if (otherPlayer.tokens >= SmallEventConstants.INTERACT_OTHER_PLAYERS.MANY_TOKENS_MIN) {
 		interactionsList.push(InteractOtherPlayerInteraction.MANY_TOKENS);
 	}
 }

--- a/Core/src/core/smallEvents/petDropToken.ts
+++ b/Core/src/core/smallEvents/petDropToken.ts
@@ -30,7 +30,7 @@ async function findPetsOnSamePath(startMapId: number, endMapId: number, playerId
 
 export const smallEventFuncs: SmallEventFuncs = {
 	canBeExecuted: async player => {
-		if (!Maps.isOnContinent(player) || player.level < TokensConstants.LEVEL_TO_UNLOCK || player.tokens >= TokensConstants.MAX) {
+		if (!Maps.isOnContinent(player) || player.tokens >= TokensConstants.MAX) {
 			return false;
 		}
 		const link = MapLinkDataController.instance.getById(player.mapLinkId);

--- a/Discord/src/packetHandlers/handlers/EventsHandlers.ts
+++ b/Discord/src/packetHandlers/handlers/EventsHandlers.ts
@@ -379,7 +379,6 @@ export default class EventsHandlers {
 			},
 			missionSlotUnlocked: { tr: "newMissionSlot" },
 			pveUnlocked: { tr: "pveUnlocked" },
-			tokensUnlocked: { tr: "tokensUnlocked" },
 			statsIncreased: { tr: "statsIncreased" }
 		};
 

--- a/Lang/fr/advices.json
+++ b/Lang/fr/advices.json
@@ -268,7 +268,7 @@
     "Croiser Velanna quand votre familier est en expédition peut vous rapporter des points bonus et parfois d'autres surprises.",
     "Les jetons permettent d'avancer plus vite sur la carte en utilisant la commande {command:report}.",
     "Vous pouvez obtenir des jetons grâce aux expéditions de familier, ou en les achetant auprès du marchand de jetons qui surgit lorsque vous tentez d'avancer avec {command:report} sans en avoir assez. Vous en recevez également 3 gratuitement chaque jour.",
-    "Les jetons sont débloqués à partir du niveau 5.",
+    "Les jetons permettent d'avancer plus vite dès le début de l'aventure.",
     "Un jeton permet de sauter directement à la prochaine étape de votre voyage.",
     "Plus vous êtes occupé longtemps, plus le coût en jetons pour avancer sera élevé.",
     "Méfiez-vous de Moltiar, le frère de Talvar : contrairement à ce dernier, il déteste les animaux et pourrait s'en prendre à votre familier.",

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -2327,7 +2327,6 @@
         "classTier": "{emote:commands.classes} | Classes de palier {{tier}} débloquées ! Pour plus d'informations sur les classes, utilisez les commandes {command:classesinfo} et {command:help}.",
         "newMissionSlot": "{emote:missions.sideMission} | Nouvel emplacement de mission débloqué ! Pour plus d'informations sur vos missions, utilisez la commande {command:missions}.",
         "pveUnlocked": "{emote:other.island} | Accès aux îles lointaines débloquées ! Rendez-vous près d'un point d'eau pour de nouvelles aventures !",
-        "tokensUnlocked": "{emote:unitValues.token} | Jetons débloqués ! Vous pouvez désormais utiliser vos jetons pour avancer plus vite avec la commande {command:report}.",
         "statsIncreased": "{emote:other.increase} | Statistiques améliorées."
       }
     }

--- a/Lib/src/constants/TokensConstants.ts
+++ b/Lib/src/constants/TokensConstants.ts
@@ -1,8 +1,6 @@
 export abstract class TokensConstants {
 	static readonly MAX = 20;
 
-	static readonly LEVEL_TO_UNLOCK = 0;
-
 	static readonly DAILY = {
 		FREE_PER_DAY: 3
 	};

--- a/Lib/src/constants/TokensConstants.ts
+++ b/Lib/src/constants/TokensConstants.ts
@@ -1,7 +1,7 @@
 export abstract class TokensConstants {
 	static readonly MAX = 20;
 
-	static readonly LEVEL_TO_UNLOCK = 5;
+	static readonly LEVEL_TO_UNLOCK = 0;
 
 	static readonly DAILY = {
 		FREE_PER_DAY: 3

--- a/Lib/src/packets/events/PlayerLevelUpPacket.ts
+++ b/Lib/src/packets/events/PlayerLevelUpPacket.ts
@@ -28,7 +28,5 @@ export class PlayerLevelUpPacket extends CrowniclesPacket {
 
 	pveUnlocked!: boolean;
 
-	tokensUnlocked!: boolean;
-
 	statsIncreased!: boolean;
 }


### PR DESCRIPTION
## Summary
- make tokens, profile data and the advance action available from the initial player level
- remove the obsolete token unlock level constant and its redundant guards
- remove the obsolete token-unlock level-up packet field and message
- update the French gameplay advice and regression test

## Validation
- Core: pnpm eslint, pnpm tsc, pnpm test
- Lib: pnpm eslint, pnpm tsc, pnpm test
- Discord: pnpm eslint
- Discord local tsc still hits the pre-existing TS2589 in src/translations/i18n.ts
- Discord local tests: 103 pass; 10 suites cannot load without the ignored config/config.toml

Fixes #4458