### PR TITLE
Fix lost enchantments when replacing inventory items

### DIFF
--- a/Core/__tests__/core/utils/ItemUtils.test.ts
+++ b/Core/__tests__/core/utils/ItemUtils.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	generateRandomLootEnchantment, giveItemToPlayer, toItemWithDetails
 } from '../../../src/core/utils/ItemUtils';
-import { InventorySlots } from '../../../src/core/database/game/models/InventorySlot';
+import InventorySlot, { InventorySlots } from '../../../src/core/database/game/models/InventorySlot';
 import { InventoryInfos } from '../../../src/core/database/game/models/InventoryInfo';
 import { MissionsController } from '../../../src/core/missions/MissionsController';
 import { BlockingUtils } from '../../../src/core/utils/BlockingUtils';
@@ -13,6 +13,18 @@ import { CrowniclesPacket, PacketContext } from '../../../../Lib/src/packets/Cro
 import { ItemFoundPacket } from '../../../../Lib/src/packets/events/ItemFoundPacket';
 import { ReactionCollectorInstance } from '../../../src/core/utils/ReactionsCollector';
 import { RandomUtils } from '../../../../Lib/src/utils/RandomUtils';
+import { ReactionCollectorItemChoiceItemReaction } from '../../../../Lib/src/packets/interaction/ReactionCollectorItemChoice';
+
+let capturedCollectorCallback: ((collector: {
+	getFirstReaction: () => {
+		reaction: {
+			type: string;
+			data: {
+				slot: number;
+			};
+		};
+	};
+}, response: CrowniclesPacket[]) => Promise<void>) | undefined;
 
 // Mock all external dependencies
 vi.mock('../../../src/core/database/game/models/InventorySlot');
@@ -28,7 +40,7 @@ vi.mock('../../../src/core/utils/BlockingUtils');
 vi.mock('../../../src/core/utils/ReactionsCollector', () => ({
 	ReactionCollectorInstance: class {
 		constructor(collector: any, context: any, options: any, callback: any) {
-			// Mock properties
+			capturedCollectorCallback = callback;
 		}
 		block() {
 			return this;
@@ -116,6 +128,7 @@ describe('ItemUtils - giveItemToPlayer', () => {
 	beforeEach(() => {
 		// Clear all mocks
 		vi.clearAllMocks();
+		capturedCollectorCallback = undefined;
 
 		// Mock player
 		mockPlayer = {
@@ -284,6 +297,55 @@ describe('ItemUtils - giveItemToPlayer', () => {
 			// Assert
 			expect(mockResponse).toHaveLength(2); // ItemFoundPacket + ReactionCollectorInstance
 			expect(mockResponse[1]).toBeInstanceOf(ReactionCollectorInstance);
+		});
+
+		it('should preserve item level and enchantment when replacing a multi-slot item', async () => {
+			mockInventoryInfo.slotLimitForCategory.mockReturnValue(2);
+			mockInventorySlots.push({
+				playerId: 1,
+				slot: 1,
+				itemCategory: ItemCategory.WEAPON,
+				itemId: 60,
+				itemLevel: 2,
+				itemEnchantmentId: null,
+				isEquipped: vi.fn().mockReturnValue(false),
+				isPotion: vi.fn().mockReturnValue(false),
+				getItem: vi.fn().mockReturnValue({
+					id: 60,
+					rarity: ItemRarity.COMMON,
+					getCategory: vi.fn().mockReturnValue(ItemCategory.WEAPON),
+					getItemAddedValue: vi.fn().mockReturnValue(5),
+					getDisplayPacket: vi.fn().mockReturnValue({ id: 60, name: 'Second Weapon' })
+				})
+			});
+
+			await giveItemToPlayer(mockResponse, mockContext, mockPlayer, mockItem, {
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1'
+			});
+			expect(capturedCollectorCallback).toBeDefined();
+
+			const callbackResponse: CrowniclesPacket[] = [];
+			await capturedCollectorCallback!({
+				getFirstReaction: () => ({
+					reaction: {
+						type: ReactionCollectorItemChoiceItemReaction.name,
+						data: { slot: 1 }
+					}
+				})
+			}, callbackResponse);
+
+			expect(InventorySlot.update).toHaveBeenCalledWith({
+				itemId: mockItem.id,
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1'
+			}, {
+				where: {
+					slot: 1,
+					itemCategory: ItemCategory.WEAPON,
+					playerId: mockPlayer.id
+				}
+			});
 		});
 	});
 

--- a/Core/src/core/utils/ItemUtils.ts
+++ b/Core/src/core/utils/ItemUtils.ts
@@ -114,6 +114,8 @@ type WhoIsConcerned = {
 
 type ConcernedItems = {
 	item: GenericItem;
+	itemLevel?: number;
+	itemEnchantmentId?: string | null;
 	itemToReplace?: InventorySlot;
 	itemToReplaceInstance?: GenericItem;
 };
@@ -131,14 +133,21 @@ type SellKeepItemOptions = {
  * @param item
  * @param itemToReplace
  */
-async function dontKeepOriginalItem(response: CrowniclesPacket[], player: Player, item: GenericItem, itemToReplace: InventorySlot): Promise<void> {
+async function dontKeepOriginalItem(
+	response: CrowniclesPacket[],
+	player: Player,
+	item: GenericItem,
+	itemToReplace: InventorySlot,
+	itemLevel = 0,
+	itemEnchantmentId: string | null = null
+): Promise<void> {
 	response.push(makePacket(ItemAcceptPacket, {
-		itemWithDetails: toItemWithDetails(player, item, 0, null)
+		itemWithDetails: toItemWithDetails(player, item, itemLevel, itemEnchantmentId)
 	}));
 	await InventorySlot.update({
 		itemId: item.id,
-		itemLevel: 0,
-		itemEnchantmentId: null
+		itemLevel,
+		itemEnchantmentId
 	}, {
 		where: {
 			slot: itemToReplace.slot,
@@ -222,6 +231,8 @@ async function sellOrKeepItem(
 	whoIsConcerned: WhoIsConcerned,
 	{
 		item,
+		itemLevel,
+		itemEnchantmentId,
 		itemToReplace,
 		itemToReplaceInstance
 	}: ConcernedItems,
@@ -234,7 +245,7 @@ async function sellOrKeepItem(
 	const player = whoIsConcerned.player;
 	await player.reload();
 	if (!keepOriginal) {
-		await dontKeepOriginalItem(response, player, item, itemToReplace!);
+		await dontKeepOriginalItem(response, player, item, itemToReplace!, itemLevel, itemEnchantmentId);
 		item = itemToReplaceInstance!;
 		resaleMultiplier = 1;
 	}
@@ -258,13 +269,22 @@ async function sellOrKeepItem(
  * @param tradableItems
  * @param sellKeepOptions
  */
-function getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned: WhoIsConcerned, toTradeItem: GenericItem, tradableItems: InventorySlot[], sellKeepOptions: SellKeepItemOptions) {
+function getMoreThan2ItemsSwitchingEndCallback(
+	whoIsConcerned: WhoIsConcerned,
+	toTradeItem: GenericItem,
+	itemLevel: number,
+	itemEnchantmentId: string | null,
+	tradableItems: InventorySlot[],
+	sellKeepOptions: SellKeepItemOptions
+) {
 	return async (collector: ReactionCollectorInstance, response: CrowniclesPacket[]): Promise<void> => {
 		const reaction = collector.getFirstReaction();
 		await whoIsConcerned.player.reload();
 
 		const concernedItems: ConcernedItems = {
-			item: toTradeItem
+			item: toTradeItem,
+			itemLevel,
+			itemEnchantmentId
 		};
 
 		if (reaction?.reaction.type === ReactionCollectorItemChoiceItemReaction.name) {
@@ -293,6 +313,8 @@ function getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned: WhoIsConcerned, t
 
 type ItemsToManage = {
 	toTradeItem: GenericItem;
+	itemLevel: number;
+	itemEnchantmentId: string | null;
 	tradableItems: InventorySlot[];
 };
 
@@ -313,6 +335,8 @@ function manageMoreThan2ItemsSwitching(
 	whoIsConcerned: WhoIsConcerned,
 	{
 		toTradeItem,
+		itemLevel,
+		itemEnchantmentId,
 		tradableItems
 	}: ItemsToManage,
 	sellKeepOptions: SellKeepItemOptions,
@@ -341,7 +365,14 @@ function manageMoreThan2ItemsSwitching(
 			reactionLimit: 1,
 			mainPacket: false
 		},
-		getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned, toTradeItem, tradableItems, sellKeepOptions)
+		getMoreThan2ItemsSwitchingEndCallback(
+			whoIsConcerned,
+			toTradeItem,
+			itemLevel,
+			itemEnchantmentId,
+			tradableItems,
+			sellKeepOptions
+		)
 	)
 		.block(keycloakId, BlockingConstants.REASONS.ACCEPT_ITEM)
 		.build());
@@ -475,6 +506,8 @@ export async function giveItemToPlayer(
 	if (maxSlots >= 2) {
 		manageMoreThan2ItemsSwitching(response, context, whoIsConcerned, {
 			toTradeItem: item,
+			itemLevel,
+			itemEnchantmentId,
 			tradableItems: items
 		}, { resaleMultiplier }, canDrinkThisPotion);
 		return;
@@ -495,6 +528,8 @@ export async function giveItemToPlayer(
 		},
 		getGiveItemToPlayerEndCallback(whoIsConcerned, {
 			item,
+			itemLevel,
+			itemEnchantmentId,
 			itemToReplace,
 			itemToReplaceInstance
 		}, resaleMultiplier)


### PR DESCRIPTION
## Summary

- carry generated item levels and enchantments through full-inventory replacement collectors
- persist those attributes when the selected inventory slot is replaced
- add a regression test for the multi-slot replacement flow

Fixes #4481

## Testing

- `pnpm exec vitest run` (85 files, 1368 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/core/utils/ItemUtils.ts`