### PR TITLE
Fix moon illumination calculation

### DIFF
--- a/Core/src/core/smallEvents/gardener.ts
+++ b/Core/src/core/smallEvents/gardener.ts
@@ -76,6 +76,8 @@ let moonCache: {
 	illumination: number; fetchedAt: number;
 } | null = null;
 
+const RADIANS_PER_DEGREE = Math.PI / 180;
+
 function getFallbackMoonIllumination(): number {
 	const daysSinceNewMoon = (Date.now() - PlantConstants.LUNAR_FALLBACK.REFERENCE_NEW_MOON) / TimeConstants.MS_TIME.DAY;
 	const phase = (daysSinceNewMoon % PlantConstants.LUNAR_FALLBACK.CYCLE_DAYS) / PlantConstants.LUNAR_FALLBACK.CYCLE_DAYS;
@@ -123,7 +125,7 @@ async function getMoonIllumination(): Promise<number> {
 			return getFallbackMoonIllumination();
 		}
 
-		const illumination = moonphase / 100;
+		const illumination = (1 - Math.cos(moonphase * RADIANS_PER_DEGREE)) / 2;
 		moonCache = {
 			illumination,
 			fetchedAt: Date.now()

--- a/Lib/src/constants/PlantConstants.ts
+++ b/Lib/src/constants/PlantConstants.ts
@@ -489,7 +489,7 @@ export abstract class PlantConstants {
 	 */
 	public static readonly LUNAR_FALLBACK = {
 		CYCLE_DAYS: 29.53058770576,
-		REFERENCE_NEW_MOON: new Date(2000, 0, 6, 18, 14, 0).getTime()
+		REFERENCE_NEW_MOON: Date.UTC(2000, 0, 6, 18, 14, 0)
 	} as const;
 
 	/**


### PR DESCRIPTION
Corrige la conversion de la phase lunaire renvoyée par Met.no afin de calculer une illumination physique comprise entre 0 et 1.

La date de référence du fallback est désormais définie en UTC, afin d’éviter une dérive selon le fuseau du serveur.

Tests :
- pnpm tsc et pnpm eslint dans Core et Lib
- pnpm test dans Core (1367 tests) et Lib (578 tests)
- vérification numérique du cas signalé (moonphase: 51.02)

Fixes #4470