### PR TITLE
fix item attribute loss and inventory slot corruption

### DIFF
--- a/Core/__tests__-integration/handlers/home-chest-deposit.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/home-chest-deposit.race.integration.test.ts
@@ -9,11 +9,13 @@ import type { Player as PlayerType } from "../../src/core/database/game/models/P
 import type { Home as HomeType } from "../../src/core/database/game/models/Home";
 import type { HomeChestSlot as HomeChestSlotType } from "../../src/core/database/game/models/HomeChestSlot";
 import type { InventorySlot as InventorySlotType } from "../../src/core/database/game/models/InventorySlot";
+import type { InventoryInfo as InventoryInfoType } from "../../src/core/database/game/models/InventoryInfo";
 import { ItemCategory } from "../../../Lib/src/constants/ItemConstants";
 import { HomeConstants } from "../../../Lib/src/constants/HomeConstants";
 import { CommandReportHomeChestActionReq } from "../../../Lib/src/packets/commands/CommandReportPacket";
 
 type ReportCityChestServiceModule = typeof import("../../src/core/report/ReportCityChestService");
+type InventorySlotIntegrityMigrationModule = typeof import("../../src/core/database/game/migrations/067-inventory-slot-integrity");
 
 const N_CONCURRENT = 25;
 const KEYCLOAK_ID = "race-home-chest-deposit";
@@ -42,7 +44,9 @@ describe("ReportCityChestService.handleChestAction deposit race", () => {
 	let Home: ModelStatic<HomeType>;
 	let HomeChestSlot: ModelStatic<HomeChestSlotType>;
 	let InventorySlot: ModelStatic<InventorySlotType>;
+	let InventoryInfo: ModelStatic<InventoryInfoType>;
 	let chestService: ReportCityChestServiceModule;
+	let inventorySlotIntegrityMigration: InventorySlotIntegrityMigrationModule;
 
 	beforeAll(async () => {
 		env = await setupCoreForTests("homechestdeposit");
@@ -50,8 +54,12 @@ describe("ReportCityChestService.handleChestAction deposit race", () => {
 		Home = env.crownicles.gameDatabase.sequelize.models.Home as ModelStatic<HomeType>;
 		HomeChestSlot = env.crownicles.gameDatabase.sequelize.models.HomeChestSlot as ModelStatic<HomeChestSlotType>;
 		InventorySlot = env.crownicles.gameDatabase.sequelize.models.InventorySlot as ModelStatic<InventorySlotType>;
+		InventoryInfo = env.crownicles.gameDatabase.sequelize.models.InventoryInfo as ModelStatic<InventoryInfoType>;
 		chestService = loadProductionModule<ReportCityChestServiceModule>(
 			"core/report/ReportCityChestService"
+		);
+		inventorySlotIntegrityMigration = loadProductionModule<InventorySlotIntegrityMigrationModule>(
+			"core/database/game/migrations/067-inventory-slot-integrity"
 		);
 	});
 
@@ -64,6 +72,7 @@ describe("ReportCityChestService.handleChestAction deposit race", () => {
 		try {
 			await HomeChestSlot.destroy({ truncate: true, force: true });
 			await InventorySlot.destroy({ truncate: true, force: true });
+			await InventoryInfo.destroy({ truncate: true, force: true });
 			await Home.destroy({ truncate: true, force: true });
 			await Player.destroy({ truncate: true, force: true });
 		}
@@ -137,5 +146,201 @@ describe("ReportCityChestService.handleChestAction deposit race", () => {
 		const occupied = filledChestSlots.filter(chestSlot => chestSlot.itemId !== 0);
 		expect(occupied).toHaveLength(1);
 		expect(occupied[0].itemId).toBe(DEPOSITED_WEAPON_ID);
+	});
+
+	it("reuses the first missing reserve slot when withdrawing from the chest", async () => {
+		const player = await Player.create({ keycloakId: `${KEYCLOAK_ID}-gap` });
+		const home = await Home.create({
+			ownerId: player.id,
+			cityId: "gap-test-city",
+			level: HOME_LEVEL_WITH_MULTIPLE_CHEST_SLOTS
+		});
+		await InventoryInfo.create({
+			playerId: player.id,
+			weaponSlots: 1,
+			armorSlots: 1,
+			potionSlots: 1,
+			objectSlots: 2,
+			plantSlots: 1
+		});
+		await InventorySlot.bulkCreate([
+			{
+				playerId: player.id,
+				slot: 0,
+				itemCategory: ItemCategory.OBJECT,
+				itemId: 1,
+				itemLevel: 0,
+				itemEnchantmentId: null,
+				remainingPotionUsages: null
+			},
+			{
+				playerId: player.id,
+				slot: 2,
+				itemCategory: ItemCategory.OBJECT,
+				itemId: 2,
+				itemLevel: 0,
+				itemEnchantmentId: null,
+				remainingPotionUsages: null
+			}
+		]);
+		await HomeChestSlot.create({
+			homeId: home.id,
+			slot: 1,
+			itemCategory: ItemCategory.OBJECT,
+			itemId: 3,
+			itemLevel: 0,
+			itemEnchantmentId: null,
+			remainingPotionUsages: null
+		});
+
+		const result = await chestService.handleChestAction(player.keycloakId, {
+			action: HomeConstants.CHEST_ACTIONS.WITHDRAW,
+			slot: 1,
+			itemCategory: ItemCategory.OBJECT,
+			chestSlot: -1
+		}, []);
+
+		expect(result.success).toBe(true);
+		const reserveSlots = await InventorySlot.findAll({
+			where: {
+				playerId: player.id,
+				itemCategory: ItemCategory.OBJECT
+			},
+			order: [["slot", "ASC"]]
+		});
+		expect(reserveSlots.map(slot => [slot.slot, slot.itemId])).toEqual([
+			[0, 1],
+			[1, 3],
+			[2, 2]
+		]);
+	});
+
+	it("preserves potion usages through a chest deposit and withdrawal", async () => {
+		const player = await Player.create({ keycloakId: `${KEYCLOAK_ID}-potion` });
+		const home = await Home.create({
+			ownerId: player.id,
+			cityId: "potion-test-city",
+			level: HOME_LEVEL_WITH_MULTIPLE_CHEST_SLOTS
+		});
+		await InventorySlot.create({
+			playerId: player.id,
+			slot: 0,
+			itemCategory: ItemCategory.POTION,
+			itemId: 12,
+			itemLevel: 0,
+			itemEnchantmentId: null,
+			remainingPotionUsages: 1
+		});
+		await HomeChestSlot.create({
+			homeId: home.id,
+			slot: 1,
+			itemCategory: ItemCategory.POTION,
+			itemId: 0,
+			itemLevel: 0,
+			itemEnchantmentId: null,
+			remainingPotionUsages: null
+		});
+
+		const depositResult = await chestService.handleChestAction(player.keycloakId, {
+			action: HomeConstants.CHEST_ACTIONS.DEPOSIT,
+			slot: 0,
+			itemCategory: ItemCategory.POTION,
+			chestSlot: -1
+		}, []);
+		expect(depositResult.success).toBe(true);
+		await expect(HomeChestSlot.findOne({
+			where: {
+				homeId: home.id,
+				slot: 1,
+				itemCategory: ItemCategory.POTION
+			}
+		})).resolves.toMatchObject({
+			itemId: 12,
+			remainingPotionUsages: 1
+		});
+
+		const withdrawResult = await chestService.handleChestAction(player.keycloakId, {
+			action: HomeConstants.CHEST_ACTIONS.WITHDRAW,
+			slot: 1,
+			itemCategory: ItemCategory.POTION,
+			chestSlot: -1
+		}, []);
+		expect(withdrawResult.success).toBe(true);
+		await expect(InventorySlot.findOne({
+			where: {
+				playerId: player.id,
+				slot: 0,
+				itemCategory: ItemCategory.POTION
+			}
+		})).resolves.toMatchObject({
+			itemId: 12,
+			remainingPotionUsages: 1
+		});
+	});
+
+	it("compacts existing reserve gaps without losing item attributes", async () => {
+		const player = await Player.create({ keycloakId: `${KEYCLOAK_ID}-migration` });
+		await InventorySlot.bulkCreate([
+			{
+				playerId: player.id,
+				slot: 0,
+				itemCategory: ItemCategory.WEAPON,
+				itemId: 1,
+				itemLevel: 0,
+				itemEnchantmentId: null
+			},
+			{
+				playerId: player.id,
+				slot: 2,
+				itemCategory: ItemCategory.WEAPON,
+				itemId: 0,
+				itemLevel: 0,
+				itemEnchantmentId: null
+			},
+			{
+				playerId: player.id,
+				slot: 3,
+				itemCategory: ItemCategory.WEAPON,
+				itemId: 2,
+				itemLevel: 4,
+				itemEnchantmentId: "allAttack1"
+			},
+			{
+				playerId: player.id,
+				slot: 5,
+				itemCategory: ItemCategory.WEAPON,
+				itemId: 3,
+				itemLevel: 2,
+				itemEnchantmentId: null
+			}
+		]);
+
+		await inventorySlotIntegrityMigration.compactInventorySlots(
+			env.crownicles.gameDatabase.sequelize.getQueryInterface()
+		);
+
+		const slots = await InventorySlot.findAll({
+			where: {
+				playerId: player.id,
+				itemCategory: ItemCategory.WEAPON
+			},
+			order: [["slot", "ASC"]]
+		});
+		expect(slots.map(slot => ({
+			slot: slot.slot,
+			itemId: slot.itemId,
+			itemLevel: slot.itemLevel,
+			itemEnchantmentId: slot.itemEnchantmentId
+		}))).toEqual([
+			{
+				slot: 0, itemId: 1, itemLevel: 0, itemEnchantmentId: null
+			},
+			{
+				slot: 1, itemId: 2, itemLevel: 4, itemEnchantmentId: "allAttack1"
+			},
+			{
+				slot: 2, itemId: 3, itemLevel: 2, itemEnchantmentId: null
+			}
+		]);
 	});
 });

--- a/Core/__tests__/core/commands/gdpr/GDPRExportCoverage.test.ts
+++ b/Core/__tests__/core/commands/gdpr/GDPRExportCoverage.test.ts
@@ -332,6 +332,7 @@ const PLAYER_DATA_EXPORT_FIELD_COVERAGE = {
 		"itemId",
 		"itemLevel",
 		"itemEnchantmentId",
+		"remainingPotionUsages",
 		"createdAt",
 		"updatedAt"
 	],

--- a/Core/__tests__/core/utils/EquipActionService.test.ts
+++ b/Core/__tests__/core/utils/EquipActionService.test.ts
@@ -11,6 +11,7 @@ let mockSlots: {
 	itemId: number;
 	itemLevel: number;
 	itemEnchantmentId: string | null;
+	remainingPotionUsages: number | null;
 	isEquipped: () => boolean;
 	save: ReturnType<typeof vi.fn>;
 	destroy: ReturnType<typeof vi.fn>;
@@ -28,7 +29,8 @@ const createMockInventorySlot = (
 	itemCategory: number,
 	itemId: number,
 	itemLevel = 1,
-	itemEnchantmentId: string | null = null
+	itemEnchantmentId: string | null = null,
+	remainingPotionUsages: number | null = null
 ) => ({
 	playerId,
 	slot,
@@ -36,6 +38,7 @@ const createMockInventorySlot = (
 	itemId,
 	itemLevel,
 	itemEnchantmentId,
+	remainingPotionUsages,
 	isEquipped: () => slot === 0,
 	save: vi.fn().mockResolvedValue(undefined),
 	destroy: vi.fn().mockImplementation(async function(this: typeof mockSlots[0]) {
@@ -68,6 +71,7 @@ vi.mock("../../../src/core/database/game/models/InventorySlot", () => ({
 			itemId: number;
 			itemLevel: number;
 			itemEnchantmentId: string | null;
+			remainingPotionUsages: number | null;
 		}) => {
 			const newSlot = createMockInventorySlot(
 				data.playerId,
@@ -75,7 +79,8 @@ vi.mock("../../../src/core/database/game/models/InventorySlot", () => ({
 				data.itemCategory,
 				data.itemId,
 				data.itemLevel,
-				data.itemEnchantmentId
+				data.itemEnchantmentId,
+				data.remainingPotionUsages
 			);
 			mockSlots.push(newSlot);
 			return Promise.resolve(newSlot);
@@ -282,6 +287,26 @@ describe("EquipActionService", () => {
 			// Item moved to existing empty reserve slot
 			const reserveSlot = mockSlots.find(s => s.slot === 1 && s.itemCategory === ItemCategory.WEAPON);
 			expect(reserveSlot?.itemId).toBe(100);
+		});
+
+		it("should reuse the first missing reserve slot", async () => {
+			mockSlots = [
+				createMockInventorySlot(1, 0, ItemCategory.WEAPON, 100, 1, null),
+				createMockInventorySlot(1, 2, ItemCategory.WEAPON, 200, 1, null)
+			];
+			mockInventoryInfo.slotLimitForCategory.mockReturnValue(3);
+
+			const packet = {
+				action: ItemConstants.EQUIP_ACTIONS.DEPOSIT,
+				itemCategory: ItemCategory.WEAPON,
+				slot: 0
+			} as CommandEquipActionReq;
+
+			const result = await handleEquipAction("valid-player", packet);
+
+			expect(result.success).toBe(true);
+			expect(mockSlots.find(s => s.slot === 1)?.itemId).toBe(100);
+			expect(mockSlots.some(s => s.slot >= 3)).toBe(false);
 		});
 
 		it("should account for home inventory bonus when checking capacity", async () => {

--- a/Core/__tests__/core/utils/ItemUtils.test.ts
+++ b/Core/__tests__/core/utils/ItemUtils.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	generateRandomLootEnchantment, giveItemToPlayer, toItemWithDetails
 } from '../../../src/core/utils/ItemUtils';
-import { InventorySlots } from '../../../src/core/database/game/models/InventorySlot';
+import InventorySlot, { InventorySlots } from '../../../src/core/database/game/models/InventorySlot';
 import { InventoryInfos } from '../../../src/core/database/game/models/InventoryInfo';
 import { MissionsController } from '../../../src/core/missions/MissionsController';
 import { BlockingUtils } from '../../../src/core/utils/BlockingUtils';
@@ -13,6 +13,20 @@ import { CrowniclesPacket, PacketContext } from '../../../../Lib/src/packets/Cro
 import { ItemFoundPacket } from '../../../../Lib/src/packets/events/ItemFoundPacket';
 import { ReactionCollectorInstance } from '../../../src/core/utils/ReactionsCollector';
 import { RandomUtils } from '../../../../Lib/src/utils/RandomUtils';
+import { ReactionCollectorItemChoiceItemReaction } from '../../../../Lib/src/packets/interaction/ReactionCollectorItemChoice';
+import { ReactionCollectorAcceptReaction } from '../../../../Lib/src/packets/interaction/ReactionCollectorPacket';
+import { MainItem } from '../../../src/data/MainItem';
+
+type CapturedCollector = {
+	getFirstReaction: () => {
+		reaction: {
+			type: string;
+			data?: unknown;
+		};
+	} | undefined;
+};
+
+let capturedCollectorCallback: ((collector: CapturedCollector, response: CrowniclesPacket[]) => Promise<void>) | undefined;
 
 // Mock all external dependencies
 vi.mock('../../../src/core/database/game/models/InventorySlot');
@@ -28,7 +42,7 @@ vi.mock('../../../src/core/utils/BlockingUtils');
 vi.mock('../../../src/core/utils/ReactionsCollector', () => ({
 	ReactionCollectorInstance: class {
 		constructor(collector: any, context: any, options: any, callback: any) {
-			// Mock properties
+			capturedCollectorCallback = callback;
 		}
 		block() {
 			return this;
@@ -116,6 +130,7 @@ describe('ItemUtils - giveItemToPlayer', () => {
 	beforeEach(() => {
 		// Clear all mocks
 		vi.clearAllMocks();
+		capturedCollectorCallback = undefined;
 
 		// Mock player
 		mockPlayer = {
@@ -151,12 +166,16 @@ describe('ItemUtils - giveItemToPlayer', () => {
 				slot: 0,
 				itemCategory: ItemCategory.WEAPON,
 				itemId: 50,
+				itemLevel: 0,
+				itemEnchantmentId: null,
+				remainingPotionUsages: null,
 				isEquipped: vi.fn().mockReturnValue(true),
 				isPotion: vi.fn().mockReturnValue(false),
 				getItem: vi.fn().mockReturnValue({
 					id: 50,
 					rarity: ItemRarity.COMMON,
 					getCategory: vi.fn().mockReturnValue(ItemCategory.WEAPON),
+					getItemAddedValue: vi.fn().mockReturnValue(5),
 					getDisplayPacket: vi.fn().mockReturnValue({ id: 50, name: 'Slot Item' })
 				})
 			}
@@ -246,6 +265,18 @@ describe('ItemUtils - giveItemToPlayer', () => {
 			expect(mockResponse.length).toBeGreaterThanOrEqual(1);
 		});
 
+		it('should not auto-sell a better variant of the same item', async () => {
+			mockInventorySlots[0].itemId = mockItem.id;
+
+			await giveItemToPlayer(mockResponse, mockContext, mockPlayer, mockItem, {
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1'
+			});
+
+			expect(capturedCollectorCallback).toBeDefined();
+			expect(mockPlayer.addMoney).not.toHaveBeenCalled();
+		});
+
 		it('should create reaction collector for single slot category', async () => {
 			// Arrange
 			mockInventoryInfo.slotLimitForCategory.mockReturnValue(1);
@@ -256,6 +287,49 @@ describe('ItemUtils - giveItemToPlayer', () => {
 			// Assert
 			expect(mockResponse).toHaveLength(2); // ItemFoundPacket + ReactionCollectorInstance
 			expect(mockResponse[1]).toBeInstanceOf(ReactionCollectorInstance);
+		});
+
+		it('should preserve attributes when replacing a single-slot item', async () => {
+			Object.setPrototypeOf(mockItem, MainItem.prototype);
+			mockItem.getDisplayPacket.mockImplementation((level: number, enchantmentId?: string) => ({
+				id: mockItem.id,
+				itemLevel: level,
+				itemEnchantmentId: enchantmentId
+			}));
+
+			await giveItemToPlayer(mockResponse, mockContext, mockPlayer, mockItem, {
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1'
+			});
+
+			const callbackResponse: CrowniclesPacket[] = [];
+			await capturedCollectorCallback!({
+				getFirstReaction: () => ({
+					reaction: { type: ReactionCollectorAcceptReaction.name }
+				})
+			}, callbackResponse);
+
+			expect(InventorySlot.update).toHaveBeenCalledWith({
+				itemId: mockItem.id,
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1',
+				remainingPotionUsages: null
+			}, {
+				where: {
+					slot: 0,
+					itemCategory: ItemCategory.WEAPON,
+					playerId: mockPlayer.id
+				}
+			});
+			expect(callbackResponse[0]).toEqual({
+				type: 'ItemAcceptPacket',
+				data: {
+					itemWithDetails: expect.objectContaining({
+						itemLevel: 4,
+						itemEnchantmentId: 'attack_1'
+					})
+				}
+			});
 		});
 
 		it('should handle multi-slot categories with choice collector', async () => {
@@ -284,6 +358,55 @@ describe('ItemUtils - giveItemToPlayer', () => {
 			// Assert
 			expect(mockResponse).toHaveLength(2); // ItemFoundPacket + ReactionCollectorInstance
 			expect(mockResponse[1]).toBeInstanceOf(ReactionCollectorInstance);
+		});
+
+		it('should preserve attributes when replacing a multi-slot item', async () => {
+			mockInventoryInfo.slotLimitForCategory.mockReturnValue(2);
+			mockInventorySlots.push({
+				playerId: 1,
+				slot: 1,
+				itemCategory: ItemCategory.WEAPON,
+				itemId: 60,
+				itemLevel: 2,
+				itemEnchantmentId: null,
+				remainingPotionUsages: null,
+				isEquipped: vi.fn().mockReturnValue(false),
+				isPotion: vi.fn().mockReturnValue(false),
+				getItem: vi.fn().mockReturnValue({
+					id: 60,
+					rarity: ItemRarity.COMMON,
+					getCategory: vi.fn().mockReturnValue(ItemCategory.WEAPON),
+					getItemAddedValue: vi.fn().mockReturnValue(5),
+					getDisplayPacket: vi.fn().mockReturnValue({ id: 60, name: 'Second Weapon' })
+				})
+			});
+
+			await giveItemToPlayer(mockResponse, mockContext, mockPlayer, mockItem, {
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1'
+			});
+
+			await capturedCollectorCallback!({
+				getFirstReaction: () => ({
+					reaction: {
+						type: ReactionCollectorItemChoiceItemReaction.name,
+						data: { slot: 1 }
+					}
+				})
+			}, []);
+
+			expect(InventorySlot.update).toHaveBeenCalledWith({
+				itemId: mockItem.id,
+				itemLevel: 4,
+				itemEnchantmentId: 'attack_1',
+				remainingPotionUsages: null
+			}, {
+				where: {
+					slot: 1,
+					itemCategory: ItemCategory.WEAPON,
+					playerId: mockPlayer.id
+				}
+			});
 		});
 	});
 

--- a/Core/src/commands/admin/gdpr/exporters/PlayerDataExporter.ts
+++ b/Core/src/commands/admin/gdpr/exporters/PlayerDataExporter.ts
@@ -272,6 +272,7 @@ async function exportHomeScopedData(homeId: number, csvFiles: GDPRCsvFiles): Pro
 			itemId: slot.itemId,
 			itemLevel: slot.itemLevel,
 			itemEnchantmentId: slot.itemEnchantmentId,
+			remainingPotionUsages: slot.remainingPotionUsages,
 			createdAt: slot.createdAt,
 			updatedAt: slot.updatedAt
 		})));

--- a/Core/src/commands/player/InventoryPotionUtils.ts
+++ b/Core/src/commands/player/InventoryPotionUtils.ts
@@ -3,5 +3,5 @@ import { Potion } from "../../data/Potion";
 import { NO_STAT_COMPARISON } from "../../../../Lib/src/types/StatValues";
 
 export function buildPotionDisplayPacket(item: InventorySlot): ReturnType<Potion["getDisplayPacket"]> {
-	return (item.getItem() as Potion).getDisplayPacket(NO_STAT_COMPARISON, item.remainingPotionUsages);
+	return (item.getItem() as Potion).getDisplayPacket(NO_STAT_COMPARISON, item.remainingPotionUsages ?? undefined);
 }

--- a/Core/src/core/database/game/migrations/067-inventory-slot-integrity.ts
+++ b/Core/src/core/database/game/migrations/067-inventory-slot-integrity.ts
@@ -1,0 +1,52 @@
+import {
+	DataTypes, QueryInterface
+} from "sequelize";
+
+export async function compactInventorySlots(context: QueryInterface): Promise<void> {
+	await context.sequelize.query(`
+		DELETE FROM inventory_slots
+		WHERE slot > 0
+		  AND itemId = 0
+	`);
+	await context.sequelize.query(`
+		CREATE TEMPORARY TABLE inventory_slot_compaction AS
+		SELECT playerId,
+		       itemCategory,
+		       slot AS oldSlot,
+		       ROW_NUMBER() OVER (PARTITION BY playerId, itemCategory ORDER BY slot) AS newSlot
+		FROM inventory_slots
+		WHERE slot > 0
+	`);
+	await context.sequelize.query(`
+		UPDATE inventory_slots inventorySlot
+		INNER JOIN inventory_slot_compaction compaction
+		        ON compaction.playerId = inventorySlot.playerId
+		       AND compaction.itemCategory = inventorySlot.itemCategory
+		       AND compaction.oldSlot = inventorySlot.slot
+		SET inventorySlot.slot = -inventorySlot.slot
+		WHERE compaction.oldSlot <> compaction.newSlot
+	`);
+	await context.sequelize.query(`
+		UPDATE inventory_slots inventorySlot
+		INNER JOIN inventory_slot_compaction compaction
+		        ON compaction.playerId = inventorySlot.playerId
+		       AND compaction.itemCategory = inventorySlot.itemCategory
+		       AND compaction.oldSlot = -inventorySlot.slot
+		SET inventorySlot.slot = compaction.newSlot
+		WHERE compaction.oldSlot <> compaction.newSlot
+	`);
+	await context.sequelize.query("DROP TEMPORARY TABLE inventory_slot_compaction");
+}
+
+export async function up({ context }: { context: QueryInterface }): Promise<void> {
+	await context.addColumn("home_chest_slots", "remainingPotionUsages", {
+		type: DataTypes.INTEGER,
+		allowNull: true,
+		defaultValue: null
+	});
+	await compactInventorySlots(context);
+}
+
+export async function down({ context }: { context: QueryInterface }): Promise<void> {
+	await context.removeColumn("home_chest_slots", "remainingPotionUsages");
+}

--- a/Core/src/core/database/game/migrations/067-inventory-slot-integrity.ts
+++ b/Core/src/core/database/game/migrations/067-inventory-slot-integrity.ts
@@ -48,5 +48,6 @@ export async function up({ context }: { context: QueryInterface }): Promise<void
 }
 
 export async function down({ context }: { context: QueryInterface }): Promise<void> {
+	// The slot renumbering is a one-way data repair; only the additive column is reverted.
 	await context.removeColumn("home_chest_slots", "remainingPotionUsages");
 }

--- a/Core/src/core/database/game/models/HomeChestSlot.ts
+++ b/Core/src/core/database/game/models/HomeChestSlot.ts
@@ -28,6 +28,8 @@ export class HomeChestSlot extends Model {
 
 	declare itemEnchantmentId: string | null;
 
+	declare remainingPotionUsages: number | null;
+
 	declare updatedAt: Date;
 
 	declare createdAt: Date;
@@ -52,7 +54,7 @@ export class HomeChestSlot extends Model {
 	}
 
 	itemWithDetails(player: Player): ItemWithDetails {
-		return toItemWithDetails(player, this.getItem()!, this.itemLevel, this.itemEnchantmentId);
+		return toItemWithDetails(player, this.getItem()!, this.itemLevel, this.itemEnchantmentId, this.remainingPotionUsages);
 	}
 }
 
@@ -102,6 +104,7 @@ export class HomeChestSlots {
 			itemId: number;
 			itemLevel: number;
 			itemEnchantmentId: null;
+			remainingPotionUsages: null;
 		}[] = [];
 
 		const categoryMap: {
@@ -131,7 +134,8 @@ export class HomeChestSlots {
 					itemCategory: category,
 					itemId: 0,
 					itemLevel: 0,
-					itemEnchantmentId: null
+					itemEnchantmentId: null,
+					remainingPotionUsages: null
 				});
 			}
 		}
@@ -208,6 +212,11 @@ export function initModel(sequelize: Sequelize): void {
 		},
 		itemEnchantmentId: {
 			type: DataTypes.STRING,
+			allowNull: true,
+			defaultValue: null
+		},
+		remainingPotionUsages: {
+			type: DataTypes.INTEGER,
 			allowNull: true,
 			defaultValue: null
 		},

--- a/Core/src/core/database/game/models/InventorySlot.ts
+++ b/Core/src/core/database/game/models/InventorySlot.ts
@@ -42,7 +42,7 @@ export class InventorySlot extends Model {
 
 	declare itemEnchantmentId: string | null;
 
-	declare remainingPotionUsages: number;
+	declare remainingPotionUsages: number | null;
 
 	declare updatedAt: Date;
 
@@ -96,7 +96,7 @@ export class InventorySlot extends Model {
 	}
 
 	itemWithDetails(player: Player): ItemWithDetails {
-		return toItemWithDetails(player, this.getItem()!, this.itemLevel, this.itemEnchantmentId);
+		return toItemWithDetails(player, this.getItem()!, this.itemLevel, this.itemEnchantmentId, this.remainingPotionUsages);
 	}
 }
 
@@ -398,6 +398,11 @@ export function initModel(sequelize: Sequelize): void {
 		},
 		itemEnchantmentId: {
 			type: DataTypes.STRING,
+			allowNull: true,
+			defaultValue: null
+		},
+		remainingPotionUsages: {
+			type: DataTypes.INTEGER,
 			allowNull: true,
 			defaultValue: null
 		},

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -80,6 +80,7 @@ import { Homes } from "./Home";
 import { getSlotCountForCategory } from "../../../../../../Lib/src/types/HomeFeatures";
 import { RecipeDiscoveryService } from "../../../cooking/RecipeDiscoveryService";
 import { RecipeDiscoverySource } from "../../../../../../Lib/src/constants/CookingConstants";
+import { buildNewItemSlotData } from "../../../utils/ItemSlotUtils";
 
 export type PlayerEditValueParameters = {
 	player: Player;
@@ -695,17 +696,9 @@ export class Player extends Model {
 		const invInfo = await InventoryInfos.getOfPlayer(this.id);
 		const category = item.getCategory();
 		const equippedItem = invSlots.filter(slot => slot.itemCategory === category && slot.isEquipped())[0];
-
-		// Only apply level and enchantment for weapons and armors
-		const isWeaponOrArmor = category === ItemCategory.WEAPON || category === ItemCategory.ARMOR;
-		const effectiveLevel = isWeaponOrArmor ? itemLevel : 0;
-		const effectiveEnchantmentId = isWeaponOrArmor ? itemEnchantmentId : null;
+		const slotData = buildNewItemSlotData(item, itemLevel, itemEnchantmentId);
 		if (equippedItem && equippedItem.itemId === 0) {
-			await InventorySlot.update({
-				itemId: item.id,
-				itemLevel: effectiveLevel,
-				itemEnchantmentId: effectiveEnchantmentId
-			}, {
+			await InventorySlot.update(slotData, {
 				where: {
 					playerId: this.id,
 					itemCategory: category,
@@ -726,10 +719,8 @@ export class Player extends Model {
 				await InventorySlot.create({
 					playerId: this.id,
 					itemCategory: category,
-					itemId: item.id,
 					slot: i,
-					itemLevel: effectiveLevel,
-					itemEnchantmentId: effectiveEnchantmentId
+					...slotData
 				});
 				return true;
 			}

--- a/Core/src/core/report/ReportCityBlacksmithService.ts
+++ b/Core/src/core/report/ReportCityBlacksmithService.ts
@@ -26,6 +26,8 @@ import { MaterialQuantity } from "../../../../Lib/src/types/MaterialQuantity";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { crowniclesInstance } from "../../app";
 import { MissionsController } from "../missions/MissionsController";
+import { Homes } from "../database/game/models/Home";
+import { buildUpgradeStationData } from "./ReportCityService";
 
 export interface UpgradeItemValidationResult {
 	itemToUpgrade?: {
@@ -231,13 +233,38 @@ export async function handleUpgradeItemReaction(
 		return;
 	}
 
-	const { itemToUpgrade } = validation;
-
 	await withLockedPlayerAndMissions(player.id, async lockedPlayer => {
 		await executeUpgradeItemUnderLock({
-			lockedPlayer, reaction, data, itemToUpgrade: itemToUpgrade!, response
+			lockedPlayer, reaction, data, response
 		});
 	});
+}
+
+async function refreshUpgradeStationDataUnderLock(
+	player: Player,
+	data: ReactionCollectorCityData
+): Promise<ReactionCollectorCityData | null> {
+	const home = await Homes.getOfPlayer(player.id);
+	const homeLevel = home?.getLevel();
+	const ownedHome = data.home.owned;
+	if (!homeLevel || !ownedHome) {
+		return null;
+	}
+
+	const inventory = await InventorySlots.getOfPlayer(player.id);
+	const materials = await Materials.getPlayerMaterials(player.id);
+	const materialMap = new Map(materials.map(material => [material.materialId, material.quantity]));
+	return {
+		...data,
+		home: {
+			...data.home,
+			owned: {
+				...ownedHome,
+				features: homeLevel.features,
+				upgradeStation: buildUpgradeStationData(inventory, materialMap, homeLevel, player)
+			}
+		}
+	};
 }
 
 /**
@@ -273,14 +300,18 @@ async function executeUpgradeItemUnderLock(params: {
 	lockedPlayer: Player;
 	reaction: ReactionCollectorUpgradeItemReaction;
 	data: ReactionCollectorCityData;
-	itemToUpgrade: NonNullable<ReturnType<typeof validateUpgradeItemRequest>["itemToUpgrade"]>;
 	response: CrowniclesPacket[];
 }): Promise<void> {
 	const {
-		lockedPlayer, reaction, data, itemToUpgrade, response
+		lockedPlayer, reaction, data, response
 	} = params;
 
-	const revalidation = validateUpgradeItemRequest(lockedPlayer, reaction, data);
+	const freshData = await refreshUpgradeStationDataUnderLock(lockedPlayer, data);
+	if (!freshData) {
+		CrowniclesLogger.error(`Player ${lockedPlayer.keycloakId} tried to upgrade an item but current home data is unavailable.`);
+		return;
+	}
+	const revalidation = validateUpgradeItemRequest(lockedPlayer, reaction, freshData);
 	if (revalidation.logError) {
 		CrowniclesLogger.error(revalidation.logError);
 		return;
@@ -289,6 +320,7 @@ async function executeUpgradeItemUnderLock(params: {
 		response.push(revalidation.error);
 		return;
 	}
+	const itemToUpgrade = revalidation.itemToUpgrade!;
 
 	const materialsToConsume = itemToUpgrade.requiredMaterials.map(m => ({
 		materialId: m.materialId,

--- a/Core/src/core/report/ReportCityChestService.ts
+++ b/Core/src/core/report/ReportCityChestService.ts
@@ -21,13 +21,19 @@ import {
 	HomeChestSlot, HomeChestSlots
 } from "../database/game/models/HomeChestSlot";
 import InventoryInfo from "../database/game/models/InventoryInfo";
-import { buildChestData } from "./ReportCityService";
+import {
+	buildChestData, buildUpgradeStationData
+} from "./ReportCityService";
 import { withLockedEntities } from "../../../../Lib/src/locks/withLockedEntities";
 import {
 	CrowniclesPacket, makePacket
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { MissionsController } from "../missions/MissionsController";
 import { updateHaveItemRarityMission } from "../utils/ItemUtils";
+import {
+	clearItemSlotData, copyItemSlotData, findFirstFreeBackupSlot, ItemSlotData
+} from "../utils/ItemSlotUtils";
+import { Materials } from "../database/game/models/Material";
 
 type ChestActionResult = Omit<CommandReportHomeChestActionRes, "name">;
 
@@ -80,7 +86,7 @@ async function getBackupInventoryCapacity(player: Player, home: Home, itemCatego
 	return inventoryInfo ? inventoryInfo.slotLimitForCategory(itemCategory) + bonusForCategory : 1;
 }
 
-async function placeItemInBackupSlot(backupSlots: InventorySlot[], item: ItemPlacement): Promise<boolean> {
+async function placeItemInBackupSlot(backupSlots: InventorySlot[], item: ItemSlotData): Promise<boolean> {
 	const emptyBackupSlot = backupSlots.find(slot => slot.itemId === 0);
 	if (!emptyBackupSlot) {
 		return false;
@@ -90,15 +96,15 @@ async function placeItemInBackupSlot(backupSlots: InventorySlot[], item: ItemPla
 	return true;
 }
 
-async function createBackupSlot(player: Player, itemCategory: ItemCategory, item: ItemPlacement, backupSlots: InventorySlot[]): Promise<void> {
-	const nextSlot = backupSlots.length > 0 ? Math.max(...backupSlots.map(slot => slot.slot)) + 1 : 1;
+async function createBackupSlot(player: Player, itemCategory: ItemCategory, item: ItemSlotData, slot: number): Promise<void> {
 	await InventorySlot.create({
 		playerId: player.id,
-		slot: nextSlot,
+		slot,
 		itemCategory,
 		itemId: item.itemId,
 		itemLevel: item.itemLevel,
-		itemEnchantmentId: item.itemEnchantmentId
+		itemEnchantmentId: item.itemEnchantmentId,
+		remainingPotionUsages: item.remainingPotionUsages
 	});
 }
 
@@ -180,13 +186,16 @@ async function runChestActionUnderLock(
 	// Build refreshed chest data
 	const playerInventory = await InventorySlots.getOfPlayer(player.id);
 	const refreshedData = await buildChestData(home, homeLevel, playerInventory, player);
+	const playerMaterials = await Materials.getPlayerMaterials(player.id);
+	const playerMaterialMap = new Map(playerMaterials.map(material => [material.materialId, material.quantity]));
 
 	return {
 		success: true,
 		chestItems: refreshedData.chestItems,
 		depositableItems: refreshedData.depositableItems,
 		slotsPerCategory: refreshedData.slotsPerCategory,
-		inventoryCapacity: refreshedData.inventoryCapacity
+		inventoryCapacity: refreshedData.inventoryCapacity,
+		upgradeStation: buildUpgradeStationData(playerInventory, playerMaterialMap, homeLevel, player)
 	};
 }
 
@@ -246,7 +255,7 @@ async function processChestDeposit(
  */
 async function clearInventorySlotUnderLock(slot: InventorySlot): Promise<void> {
 	if (slot.slot === 0) {
-		resetItemFields(slot);
+		clearItemSlotData(slot);
 		await slot.save();
 	}
 	else {
@@ -255,38 +264,16 @@ async function clearInventorySlotUnderLock(slot: InventorySlot): Promise<void> {
 }
 
 async function clearChestSlotUnderLock(chestSlot: HomeChestSlot): Promise<void> {
-	resetItemFields(chestSlot);
+	clearItemSlotData(chestSlot);
 	await chestSlot.save();
 }
 
-/**
- * Reset item-related fields on any slot-like entity.
- */
-function resetItemFields(target: {
-	itemId: number; itemLevel: number; itemEnchantmentId: string | null;
-}): void {
-	target.itemId = 0;
-	target.itemLevel = 0;
-	target.itemEnchantmentId = null;
-}
-
-/**
- * Item data to be placed in an inventory slot.
- */
-interface ItemPlacement {
-	itemId: number;
-	itemLevel: number;
-	itemEnchantmentId: string | null;
-}
-
-type SaveableItemSlot = ItemPlacement & {
+type SaveableItemSlot = ItemSlotData & {
 	save(): Promise<unknown>;
 };
 
-async function assignItemToSlotUnderLock(slot: SaveableItemSlot, item: ItemPlacement): Promise<void> {
-	slot.itemId = item.itemId;
-	slot.itemLevel = item.itemLevel;
-	slot.itemEnchantmentId = item.itemEnchantmentId;
+async function assignItemToSlotUnderLock(slot: SaveableItemSlot, item: ItemSlotData): Promise<void> {
+	copyItemSlotData(slot, item);
 	await slot.save();
 }
 
@@ -298,7 +285,7 @@ async function placeItemInInventory(
 	player: Player,
 	home: Home,
 	itemCategory: ItemCategory,
-	item: ItemPlacement
+	item: ItemSlotData
 ): Promise<ChestError | null> {
 	const playerInventory = await InventorySlots.getOfPlayer(player.id);
 
@@ -314,8 +301,9 @@ async function placeItemInInventory(
 	}
 
 	const maxSlots = await getBackupInventoryCapacity(player, home, itemCategory);
-	if (backupSlots.length < maxSlots - 1) {
-		await createBackupSlot(player, itemCategory, item, backupSlots);
+	const freeSlot = findFirstFreeBackupSlot(backupSlots, maxSlots);
+	if (freeSlot !== null) {
+		await createBackupSlot(player, itemCategory, item, freeSlot);
 		return null;
 	}
 
@@ -336,7 +324,8 @@ async function processChestWithdraw(
 	const error = await placeItemInInventory(player, home, itemCategory, {
 		itemId: chestSlot.itemId,
 		itemLevel: chestSlot.itemLevel,
-		itemEnchantmentId: chestSlot.itemEnchantmentId
+		itemEnchantmentId: chestSlot.itemEnchantmentId,
+		remainingPotionUsages: chestSlot.remainingPotionUsages
 	});
 
 	if (error) {
@@ -375,10 +364,11 @@ async function processChestSwap({
 	}
 
 	// Swap: exchange items between inventory slot and chest slot
-	const temp: ItemPlacement = {
+	const temp: ItemSlotData = {
 		itemId: inventorySlot.itemId,
 		itemLevel: inventorySlot.itemLevel,
-		itemEnchantmentId: inventorySlot.itemEnchantmentId
+		itemEnchantmentId: inventorySlot.itemEnchantmentId,
+		remainingPotionUsages: inventorySlot.remainingPotionUsages
 	};
 	await assignItemToSlotUnderLock(inventorySlot, chestSlot);
 	await assignItemToSlotUnderLock(chestSlot, temp);

--- a/Core/src/core/utils/EquipActionService.ts
+++ b/Core/src/core/utils/EquipActionService.ts
@@ -16,26 +16,11 @@ import { Homes } from "../database/game/models/Home";
 import {
 	EMPTY_SLOTS_PER_CATEGORY, getSlotCountForCategory
 } from "../../../../Lib/src/types/HomeFeatures";
+import {
+	clearItemSlotData, copyItemSlotData, findFirstFreeBackupSlot, ItemSlotData
+} from "./ItemSlotUtils";
 
 type EquipActionResult = Omit<CommandEquipActionRes, "name">;
-
-/**
- * Copy item data (id, level, enchantment) from one slot to another.
- */
-function copySlotData(target: InventorySlot, source: InventorySlot): void {
-	target.itemId = source.itemId;
-	target.itemLevel = source.itemLevel;
-	target.itemEnchantmentId = source.itemEnchantmentId;
-}
-
-/**
- * Clear all item data from a slot (set to empty).
- */
-function clearSlot(slot: InventorySlot): void {
-	slot.itemId = 0;
-	slot.itemLevel = 0;
-	slot.itemEnchantmentId = null;
-}
 
 /**
  * Handle an equip/deposit action from AsyncPacketSender.
@@ -116,21 +101,21 @@ async function processEquip(playerId: number, reserveSlot: number, category: Ite
 
 	// If active slot is empty (id=0), just move the reserve item and destroy the reserve slot
 	if (activeSlot.itemId === 0) {
-		copySlotData(activeSlot, toEquip);
+		copyItemSlotData(activeSlot, toEquip);
 		await activeSlot.save();
 		await toEquip.destroy();
 	}
 	else {
 		// Swap: exchange data between active and reserve slots
-		const tempId = activeSlot.itemId;
-		const tempLevel = activeSlot.itemLevel;
-		const tempEnchantment = activeSlot.itemEnchantmentId;
+		const activeItem: ItemSlotData = {
+			itemId: activeSlot.itemId,
+			itemLevel: activeSlot.itemLevel,
+			itemEnchantmentId: activeSlot.itemEnchantmentId,
+			remainingPotionUsages: activeSlot.remainingPotionUsages
+		};
 
-		copySlotData(activeSlot, toEquip);
-
-		toEquip.itemId = tempId;
-		toEquip.itemLevel = tempLevel;
-		toEquip.itemEnchantmentId = tempEnchantment;
+		copyItemSlotData(activeSlot, toEquip);
+		copyItemSlotData(toEquip, activeItem);
 
 		await activeSlot.save();
 		await toEquip.save();
@@ -168,7 +153,7 @@ async function processDeposit(playerId: number, category: ItemCategory): Promise
 	}
 
 	// Clear active slot
-	clearSlot(activeSlot);
+	clearItemSlotData(activeSlot);
 	await activeSlot.save();
 
 	return null;
@@ -185,23 +170,22 @@ async function placeItemInBackupSlot({
 }): Promise<EquipError | null> {
 	const emptySlot = backupSlots.find(s => s.itemId === 0);
 	if (emptySlot) {
-		copySlotData(emptySlot, source);
+		copyItemSlotData(emptySlot, source);
 		await emptySlot.save();
 		return null;
 	}
 
 	// maxSlots includes the equipped slot (slot 0), so backup capacity is maxSlots - 1
-	if (backupSlots.length < maxSlots - 1) {
-		const nextSlot = backupSlots.length > 0
-			? Math.max(...backupSlots.map(s => s.slot)) + 1
-			: 1;
+	const freeSlot = findFirstFreeBackupSlot(backupSlots, maxSlots);
+	if (freeSlot !== null) {
 		await InventorySlot.create({
 			playerId,
-			slot: nextSlot,
+			slot: freeSlot,
 			itemCategory: category,
 			itemId: source.itemId,
 			itemLevel: source.itemLevel,
-			itemEnchantmentId: source.itemEnchantmentId
+			itemEnchantmentId: source.itemEnchantmentId,
+			remainingPotionUsages: source.remainingPotionUsages
 		});
 		return null;
 	}

--- a/Core/src/core/utils/ItemSlotUtils.ts
+++ b/Core/src/core/utils/ItemSlotUtils.ts
@@ -1,0 +1,61 @@
+import { ItemCategory } from "../../../../Lib/src/constants/ItemConstants";
+import { GenericItem } from "../../data/GenericItem";
+
+export type ItemSlotData = {
+	itemId: number;
+	itemLevel: number;
+	itemEnchantmentId: string | null;
+	remainingPotionUsages: number | null;
+};
+
+type MutableItemSlotData = ItemSlotData & {
+	slot?: number;
+};
+
+export function buildNewItemSlotData(
+	item: GenericItem,
+	itemLevel = 0,
+	itemEnchantmentId: string | null = null
+): ItemSlotData {
+	const category = item.getCategory();
+	const hasEquipmentAttributes = category === ItemCategory.WEAPON || category === ItemCategory.ARMOR;
+	return {
+		itemId: item.id,
+		itemLevel: hasEquipmentAttributes ? itemLevel : 0,
+		itemEnchantmentId: hasEquipmentAttributes ? itemEnchantmentId : null,
+		remainingPotionUsages: null
+	};
+}
+
+export function copyItemSlotData(target: MutableItemSlotData, source: ItemSlotData): void {
+	target.itemId = source.itemId;
+	target.itemLevel = source.itemLevel;
+	target.itemEnchantmentId = source.itemEnchantmentId;
+	target.remainingPotionUsages = source.remainingPotionUsages;
+}
+
+export function clearItemSlotData(target: MutableItemSlotData): void {
+	copyItemSlotData(target, {
+		itemId: 0,
+		itemLevel: 0,
+		itemEnchantmentId: null,
+		remainingPotionUsages: null
+	});
+}
+
+export function itemSlotDataEquals(first: ItemSlotData, second: ItemSlotData): boolean {
+	return first.itemId === second.itemId
+		&& first.itemLevel === second.itemLevel
+		&& first.itemEnchantmentId === second.itemEnchantmentId
+		&& first.remainingPotionUsages === second.remainingPotionUsages;
+}
+
+export function findFirstFreeBackupSlot(slots: { slot: number }[], maxSlots: number): number | null {
+	const occupiedSlots = new Set(slots.map(slot => slot.slot));
+	for (let slot = 1; slot < maxSlots; slot++) {
+		if (!occupiedSlots.has(slot)) {
+			return slot;
+		}
+	}
+	return null;
+}

--- a/Core/src/core/utils/ItemUtils.ts
+++ b/Core/src/core/utils/ItemUtils.ts
@@ -46,6 +46,9 @@ import { TravelTime } from "../maps/TravelTime";
 import { PlayerActiveObjects } from "../database/game/models/PlayerActiveObjects";
 import { Homes } from "../database/game/models/Home";
 import { getSlotCountForCategory } from "../../../../Lib/src/types/HomeFeatures";
+import {
+	buildNewItemSlotData, ItemSlotData, itemSlotDataEquals
+} from "./ItemSlotUtils";
 
 
 /**
@@ -101,10 +104,20 @@ export async function checkDrinkPotionMissions(response: CrowniclesPacket[], pla
 	});
 }
 
-export function toItemWithDetails(player: Player, item: GenericItem, itemLevel: number, itemEnchantmentId: string | null): ItemWithDetails {
-	return item instanceof MainItem
-		? (item as MainItem).getDisplayPacket(itemLevel, itemEnchantmentId ?? undefined, player.getMaxStatsValue())
-		: (item as SupportItem).getDisplayPacket(player.getMaxStatsValue());
+export function toItemWithDetails(
+	player: Player,
+	item: GenericItem,
+	itemLevel: number,
+	itemEnchantmentId: string | null,
+	remainingPotionUsages: number | null = null
+): ItemWithDetails {
+	if (item instanceof MainItem) {
+		return item.getDisplayPacket(itemLevel, itemEnchantmentId ?? undefined, player.getMaxStatsValue());
+	}
+	if (item instanceof Potion) {
+		return item.getDisplayPacket(player.getMaxStatsValue(), remainingPotionUsages ?? undefined);
+	}
+	return (item as SupportItem).getDisplayPacket(player.getMaxStatsValue());
 }
 
 type WhoIsConcerned = {
@@ -112,8 +125,13 @@ type WhoIsConcerned = {
 	inventorySlots: InventorySlot[];
 };
 
-type ConcernedItems = {
+type ItemToGive = {
 	item: GenericItem;
+	slotData: ItemSlotData;
+};
+
+type ConcernedItems = {
+	itemToGive: ItemToGive;
 	itemToReplace?: InventorySlot;
 	itemToReplaceInstance?: GenericItem;
 };
@@ -131,15 +149,25 @@ type SellKeepItemOptions = {
  * @param item
  * @param itemToReplace
  */
-async function dontKeepOriginalItem(response: CrowniclesPacket[], player: Player, item: GenericItem, itemToReplace: InventorySlot): Promise<void> {
+async function dontKeepOriginalItem(
+	response: CrowniclesPacket[],
+	player: Player,
+	itemToGive: ItemToGive,
+	itemToReplace: InventorySlot
+): Promise<void> {
+	const {
+		item, slotData
+	} = itemToGive;
 	response.push(makePacket(ItemAcceptPacket, {
-		itemWithDetails: toItemWithDetails(player, item, 0, null)
+		itemWithDetails: toItemWithDetails(
+			player,
+			item,
+			slotData.itemLevel,
+			slotData.itemEnchantmentId,
+			slotData.remainingPotionUsages
+		)
 	}));
-	await InventorySlot.update({
-		itemId: item.id,
-		itemLevel: 0,
-		itemEnchantmentId: null
-	}, {
+	await InventorySlot.update(slotData, {
 		where: {
 			slot: itemToReplace.slot,
 			itemCategory: itemToReplace.itemCategory,
@@ -221,7 +249,7 @@ async function sellOrKeepItem(
 	response: CrowniclesPacket[],
 	whoIsConcerned: WhoIsConcerned,
 	{
-		item,
+		itemToGive,
 		itemToReplace,
 		itemToReplaceInstance
 	}: ConcernedItems,
@@ -232,9 +260,10 @@ async function sellOrKeepItem(
 	}: SellKeepItemOptions
 ): Promise<void> {
 	const player = whoIsConcerned.player;
+	let item = itemToGive.item;
 	await player.reload();
 	if (!keepOriginal) {
-		await dontKeepOriginalItem(response, player, item, itemToReplace!);
+		await dontKeepOriginalItem(response, player, itemToGive, itemToReplace!);
 		item = itemToReplaceInstance!;
 		resaleMultiplier = 1;
 	}
@@ -258,13 +287,18 @@ async function sellOrKeepItem(
  * @param tradableItems
  * @param sellKeepOptions
  */
-function getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned: WhoIsConcerned, toTradeItem: GenericItem, tradableItems: InventorySlot[], sellKeepOptions: SellKeepItemOptions) {
+function getMoreThan2ItemsSwitchingEndCallback(
+	whoIsConcerned: WhoIsConcerned,
+	itemToGive: ItemToGive,
+	tradableItems: InventorySlot[],
+	sellKeepOptions: SellKeepItemOptions
+): (collector: ReactionCollectorInstance, response: CrowniclesPacket[]) => Promise<void> {
 	return async (collector: ReactionCollectorInstance, response: CrowniclesPacket[]): Promise<void> => {
 		const reaction = collector.getFirstReaction();
 		await whoIsConcerned.player.reload();
 
 		const concernedItems: ConcernedItems = {
-			item: toTradeItem
+			itemToGive
 		};
 
 		if (reaction?.reaction.type === ReactionCollectorItemChoiceItemReaction.name) {
@@ -280,10 +314,10 @@ function getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned: WhoIsConcerned, t
 		BlockingUtils.unblockPlayer(whoIsConcerned.player.keycloakId, BlockingConstants.REASONS.ACCEPT_ITEM);
 
 		if (reaction?.reaction.type === ReactionCollectorItemChoiceDrinkPotionReaction.name) {
-			await consumePotion(response, toTradeItem as Potion, whoIsConcerned.player, InventorySlots.slotsToActiveObjects(whoIsConcerned.inventorySlots));
+			await consumePotion(response, itemToGive.item as Potion, whoIsConcerned.player, InventorySlots.slotsToActiveObjects(whoIsConcerned.inventorySlots));
 			await whoIsConcerned.player.save();
 			await MissionsController.update(whoIsConcerned.player, response, { missionId: "findOrBuyItem" });
-			await checkDrinkPotionMissions(response, whoIsConcerned.player, toTradeItem as Potion, await InventorySlots.getOfPlayer(whoIsConcerned.player.id));
+			await checkDrinkPotionMissions(response, whoIsConcerned.player, itemToGive.item as Potion, await InventorySlots.getOfPlayer(whoIsConcerned.player.id));
 		}
 		else {
 			await sellOrKeepItem(response, whoIsConcerned, concernedItems, sellKeepOptions);
@@ -292,7 +326,7 @@ function getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned: WhoIsConcerned, t
 }
 
 type ItemsToManage = {
-	toTradeItem: GenericItem;
+	itemToGive: ItemToGive;
 	tradableItems: InventorySlot[];
 };
 
@@ -312,7 +346,7 @@ function manageMoreThan2ItemsSwitching(
 	context: PacketContext,
 	whoIsConcerned: WhoIsConcerned,
 	{
-		toTradeItem,
+		itemToGive,
 		tradableItems
 	}: ItemsToManage,
 	sellKeepOptions: SellKeepItemOptions,
@@ -323,8 +357,8 @@ function manageMoreThan2ItemsSwitching(
 
 	const collector = new ReactionCollectorItemChoice({
 		item: {
-			id: toTradeItem.id,
-			category: toTradeItem.getCategory()
+			id: itemToGive.item.id,
+			category: itemToGive.item.getCategory()
 		}
 	},
 	tradableItems.map(i => ({
@@ -341,7 +375,7 @@ function manageMoreThan2ItemsSwitching(
 			reactionLimit: 1,
 			mainPacket: false
 		},
-		getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned, toTradeItem, tradableItems, sellKeepOptions)
+		getMoreThan2ItemsSwitchingEndCallback(whoIsConcerned, itemToGive, tradableItems, sellKeepOptions)
 	)
 		.block(keycloakId, BlockingConstants.REASONS.ACCEPT_ITEM)
 		.build());
@@ -360,7 +394,11 @@ async function manageGiveItemRelateds(response: CrowniclesPacket[], player: Play
 		.then();
 }
 
-function getGiveItemToPlayerEndCallback(whoIsConcerned: WhoIsConcerned, concernedItems: ConcernedItems, resaleMultiplier: number) {
+function getGiveItemToPlayerEndCallback(
+	whoIsConcerned: WhoIsConcerned,
+	concernedItems: ConcernedItems,
+	resaleMultiplier: number
+): (collector: ReactionCollectorInstance, response: CrowniclesPacket[]) => Promise<void> {
 	return async (collector: ReactionCollectorInstance, response: CrowniclesPacket[]): Promise<void> => {
 		const reaction = collector.getFirstReaction();
 		const isValidated = reaction && reaction.reaction.type === ReactionCollectorAcceptReaction.name;
@@ -369,10 +407,10 @@ function getGiveItemToPlayerEndCallback(whoIsConcerned: WhoIsConcerned, concerne
 		BlockingUtils.unblockPlayer(whoIsConcerned.player.keycloakId, BlockingConstants.REASONS.ACCEPT_ITEM);
 
 		if (reaction?.reaction.type === ReactionCollectorItemAcceptDrinkPotionReaction.name) {
-			await consumePotion(response, concernedItems.item as Potion, whoIsConcerned.player, InventorySlots.slotsToActiveObjects(whoIsConcerned.inventorySlots));
+			await consumePotion(response, concernedItems.itemToGive.item as Potion, whoIsConcerned.player, InventorySlots.slotsToActiveObjects(whoIsConcerned.inventorySlots));
 			await whoIsConcerned.player.save();
 			await MissionsController.update(whoIsConcerned.player, response, { missionId: "findOrBuyItem" });
-			await checkDrinkPotionMissions(response, whoIsConcerned.player, concernedItems.item as Potion, await InventorySlots.getOfPlayer(whoIsConcerned.player.id));
+			await checkDrinkPotionMissions(response, whoIsConcerned.player, concernedItems.itemToGive.item as Potion, await InventorySlots.getOfPlayer(whoIsConcerned.player.id));
 		}
 		else {
 			await sellOrKeepItem(response, whoIsConcerned, concernedItems, {
@@ -434,6 +472,11 @@ export async function giveItemToPlayer(
 	const {
 		resaleMultiplier = 1, canDrinkImmediately = true, itemLevel = 0, itemEnchantmentId = null
 	} = options;
+	const slotData = buildNewItemSlotData(item, itemLevel, itemEnchantmentId);
+	const itemToGive: ItemToGive = {
+		item,
+		slotData
+	};
 	const inventorySlots = await InventorySlots.getOfPlayer(player.id);
 	const whoIsConcerned = {
 		player,
@@ -441,10 +484,16 @@ export async function giveItemToPlayer(
 	};
 
 	response.push(makePacket(ItemFoundPacket, {
-		itemWithDetails: toItemWithDetails(player, item, itemLevel, itemEnchantmentId)
+		itemWithDetails: toItemWithDetails(
+			player,
+			item,
+			slotData.itemLevel,
+			slotData.itemEnchantmentId,
+			slotData.remainingPotionUsages
+		)
 	}));
 
-	if (await player.giveItem(item, itemLevel, itemEnchantmentId)) {
+	if (await player.giveItem(item, slotData.itemLevel, slotData.itemEnchantmentId)) {
 		await manageGiveItemRelateds(response, player, item);
 		return;
 	}
@@ -458,12 +507,12 @@ export async function giveItemToPlayer(
 	const itemToReplace = inventorySlots.filter((slot: InventorySlot) => (maxSlots === 1 ? slot.isEquipped() : slot.slot === 1) && slot.itemCategory === category)[0];
 	const canDrinkThisPotion = canPotionBeDrunkImmediately(item, canDrinkImmediately);
 	const autoSell = item.getCategory() !== ItemCategory.POTION || (item as Potion).isFightPotion() // Because we can't drink immediately these potions
-		? items.length === items.filter((slot: InventorySlot) => slot.itemId === item.id).length
+		? items.length === items.filter((slot: InventorySlot) => itemSlotDataEquals(slot, slotData)).length
 		: false;
 
 	if (autoSell) {
 		await sellOrKeepItem(response, whoIsConcerned, {
-			item
+			itemToGive
 		}, {
 			keepOriginal: true,
 			resaleMultiplier,
@@ -474,7 +523,7 @@ export async function giveItemToPlayer(
 
 	if (maxSlots >= 2) {
 		manageMoreThan2ItemsSwitching(response, context, whoIsConcerned, {
-			toTradeItem: item,
+			itemToGive,
 			tradableItems: items
 		}, { resaleMultiplier }, canDrinkThisPotion);
 		return;
@@ -494,7 +543,7 @@ export async function giveItemToPlayer(
 			mainPacket: false
 		},
 		getGiveItemToPlayerEndCallback(whoIsConcerned, {
-			item,
+			itemToGive,
 			itemToReplace,
 			itemToReplaceInstance
 		}, resaleMultiplier)

--- a/Discord/__tests__/home/ChestFeatureHandler.test.ts
+++ b/Discord/__tests__/home/ChestFeatureHandler.test.ts
@@ -76,8 +76,10 @@ import {
  */
 function createChestHomeData(options?: {
 	chestSlots?: { weapon: number; armor: number; object: number; potion: number };
+	inventoryCapacity?: { weapon: number; armor: number; object: number; potion: number };
 	chestItems?: { slot: number; category: ItemCategory; details: any }[];
 	depositableItems?: { slot: number; category: ItemCategory; details: any }[];
+	upgradeStation?: ReturnType<typeof createHomeData>["upgradeStation"];
 	plantStorage?: { plantId: number; quantity: number; maxCapacity: number }[];
 	playerPlantSlots?: { slot: number; plantId: number }[];
 	plantMaxCapacity?: number;
@@ -87,11 +89,12 @@ function createChestHomeData(options?: {
 	};
 	const homeData = createHomeData({
 		garden: undefined,
+		upgradeStation: options?.upgradeStation,
 		chest: {
 			chestItems: options?.chestItems ?? [],
 			depositableItems: options?.depositableItems ?? [],
 			slotsPerCategory: slots,
-			inventoryCapacity: {
+			inventoryCapacity: options?.inventoryCapacity ?? {
 				weapon: 5, armor: 5, object: 5, potion: 5
 			},
 			plantStorage: options?.plantStorage,
@@ -358,6 +361,48 @@ describe("ChestFeatureHandler", () => {
 			const menuId = menus.registerMenu.mock.calls[0][0];
 			expect(menuId).toContain(HomeMenuIds.CHEST_CATEGORY_DETAIL_PREFIX);
 		});
+
+		it("should offer a swap when the chest and inventory reserve are full", async () => {
+			const ctx = createHandlerContext({
+				homeData: createChestHomeData({
+					chestSlots: { weapon: 1, armor: 0, object: 0, potion: 0 },
+					inventoryCapacity: { weapon: 2, armor: 1, object: 1, potion: 1 },
+					chestItems: [{
+						slot: 1,
+						category: ItemCategory.WEAPON,
+						details: { itemId: 1, attack: 10, defense: 0, speed: 0, level: 1 }
+					}],
+					depositableItems: [
+						{
+							slot: 0,
+							category: ItemCategory.WEAPON,
+							details: { itemId: 2, attack: 15, defense: 0, speed: 0, level: 1 }
+						},
+						{
+							slot: 1,
+							category: ItemCategory.WEAPON,
+							details: { itemId: 3, attack: 12, defense: 0, speed: 0, level: 1 }
+						}
+					]
+				})
+			});
+			const interaction = createMockComponentInteraction();
+			const menus = createMockNestedMenus();
+
+			await handler.handleSubMenuSelection(
+				ctx,
+				`${HomeMenuIds.CHEST_CATEGORY_PREFIX}${ItemCategory.WEAPON}`,
+				interaction as never,
+				menus as never
+			);
+
+			const registeredMenu = menus.registerMenu.mock.calls[0][1];
+			const container = registeredMenu.containers[0] as ContainerBuilder;
+			const buttons = container.components
+				.filter((component): component is ActionRowBuilder<any> => component instanceof ActionRowBuilder)
+				.flatMap(row => row.components);
+			expect(buttons.some(button => button.data.custom_id?.startsWith(HomeMenuIds.CHEST_SWAP_SELECT_PREFIX))).toBe(true);
+		});
 	});
 
 	describe("handleSubMenuSelection - MQTT actions", () => {
@@ -415,6 +460,49 @@ describe("ChestFeatureHandler", () => {
 
 			expect(handled).toBe(true);
 			expect(mockSendPacket).toHaveBeenCalledOnce();
+		});
+
+		it("should refresh the upgrade station after an inventory mutation", async () => {
+			const previousUpgradeStation = {
+				upgradeableItems: [],
+				maxUpgradeableRarity: 1
+			};
+			const refreshedUpgradeStation = {
+				upgradeableItems: [],
+				maxUpgradeableRarity: 2
+			};
+			const ctx = createHandlerContext({
+				homeData: createChestHomeData({
+					upgradeStation: previousUpgradeStation,
+					chestItems: [{
+						slot: 1,
+						category: ItemCategory.WEAPON,
+						details: { itemId: 1, attack: 10, defense: 0, speed: 0, level: 1 }
+					}]
+				})
+			});
+			const interaction = createMockComponentInteraction();
+			const menus = createMockNestedMenus();
+			const mockSendPacket = vi.mocked(DiscordMQTT.asyncPacketSender.sendPacketAndHandleResponse);
+			mockSendPacket.mockImplementation(async (context, _packet, callback) => {
+				await callback(context, "CommandReportHomeChestActionRes", {
+					success: true,
+					chestItems: [],
+					depositableItems: [],
+					slotsPerCategory: { weapon: 1, armor: 1, object: 1, potion: 1 },
+					inventoryCapacity: { weapon: 2, armor: 1, object: 1, potion: 1 },
+					upgradeStation: refreshedUpgradeStation
+				} as never);
+			});
+
+			await handler.handleSubMenuSelection(
+				ctx,
+				`${HomeMenuIds.CHEST_WITHDRAW_PREFIX}${ItemCategory.WEAPON}_1`,
+				interaction as never,
+				menus as never
+			);
+
+			expect(ctx.homeData.upgradeStation).toBe(refreshedUpgradeStation);
 		});
 
 		it("should send plant deposit MQTT packet", async () => {

--- a/Discord/src/commands/player/report/home/features/ChestFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/ChestFeatureHandler.ts
@@ -417,7 +417,7 @@ export class ChestFeatureHandler implements HomeFeatureHandler {
 		// Inventory capacity info
 		const activeItem = categoryDepositableItems.find(item => item.slot === 0);
 		const backupCount = categoryDepositableItems.filter(item => item.slot > 0).length;
-		const maxBackup = getSlotCountForCategory(chest.inventoryCapacity, catInfo.category);
+		const maxBackup = Math.max(getSlotCountForCategory(chest.inventoryCapacity, catInfo.category) - 1, 0);
 		const isInventoryFull = activeItem !== undefined && backupCount >= maxBackup;
 
 		text += `\n${i18n.t("commands:report.city.homes.chest.inventoryInfo", {
@@ -706,6 +706,9 @@ export class ChestFeatureHandler implements HomeFeatureHandler {
 					ctx.homeData.chest.depositableItems = response.depositableItems;
 					ctx.homeData.chest.slotsPerCategory = response.slotsPerCategory;
 					ctx.homeData.chest.inventoryCapacity = response.inventoryCapacity;
+				}
+				if (ctx.homeData.upgradeStation && response.upgradeStation) {
+					ctx.homeData.upgradeStation = response.upgradeStation;
 				}
 
 				// Re-register the chest categories menu with updated counts

--- a/Lib/src/packets/commands/CommandReportPacket.ts
+++ b/Lib/src/packets/commands/CommandReportPacket.ts
@@ -27,6 +27,9 @@ export {
 import {
 	CookingCraftError, CookingMenuSnapshot
 } from "../../types/CookingTypes";
+import type { ReactionCollectorCityData } from "../interaction/ReactionCollectorCity";
+
+type HomeUpgradeStationData = NonNullable<NonNullable<ReactionCollectorCityData["home"]["owned"]>["upgradeStation"]>;
 
 export type ChestError = typeof HomeConstants.CHEST_ERRORS[keyof typeof HomeConstants.CHEST_ERRORS];
 export type { ChestAction } from "../../constants/HomeConstants";
@@ -481,6 +484,9 @@ export class CommandReportHomeChestActionRes extends CrowniclesPacket {
 
 	/** Max backup slots per category in the player's inventory */
 	inventoryCapacity!: ChestSlotsPerCategory;
+
+	/** Refreshed home upgrade station after inventory mutations */
+	upgradeStation?: HomeUpgradeStationData;
 }
 
 // Garden packets


### PR DESCRIPTION
## Contexte

Correction propre et coordonnée de plusieurs bugs d'inventaire/coffre de la milestone 6.0.2, remplaçant la PR externe #4482. Tous ces bugs partagent une cause racine : plusieurs représentations divergentes d'un même objet et deux allocateurs de slots distincts.

Repart d'une branche interne sur `develop`.

## Changements

Abstraction partagée `Core/src/core/utils/ItemSlotUtils.ts` qui unifie les 4 attributs d'un objet (`itemId`, `itemLevel`, `itemEnchantmentId`, `remainingPotionUsages`) et fournit un allocateur du premier slot de réserve libre borné à la capacité. Utilisée par tous les flux (ajout, remplacement, coffre, équipement).

### Fixes #4481 — enchantements/niveaux perdus au remplacement
- Attributs normalisés une seule fois via `buildNewItemSlotData`, puis conservés dans le paquet « objet trouvé », l'écriture directe et les remplacements mono/multi-slots.
- L'auto-vente compare désormais `itemId + itemLevel + itemEnchantmentId` : une meilleure variante du même objet n'est plus vendue automatiquement.

### Fixes #4480 — objets invisibles / slots qui gonflent
- `max(slot)+1` remplacé par `findFirstFreeBackupSlot` dans le coffre et l'équipement.
- Migration `067-inventory-slot-integrity` : supprime les réserves vides et compacte les slots existants en `1..n` **sans toucher aux attributs**.

### Fixes #4501 — swap coffre plein / forgeron maison obsolète
- Correction du `-1` manquant sur la capacité de réserve côté Discord (le mode swap ne s'activait jamais quand l'inventaire était réellement plein).
- Core renvoie un snapshot rafraîchi du forgeron après chaque action coffre.
- L'amélioration est **revalidée sous verrou** contre l'état réel de la base avant de consommer les matériaux (empêche un ancien bouton d'améliorer le nouvel objet d'un slot après un swap).

### Fixes #4471 — usages de potion
- `remainingPotionUsages` désormais mappé dans Sequelize et conservé à travers coffre et équipement, avec colonne ajoutée au coffre et export RGPD complété.

## Tests
- Core : 85 fichiers, 1371 tests — TypeScript + ESLint OK
- Discord : 24 fichiers, 253 tests — TypeScript + ESLint OK
- Lib : 21 fichiers, 578 tests — TypeScript + ESLint OK
- Intégration MariaDB (`home-chest-deposit.race`) : 4/4 — dépôt concurrent, réutilisation du trou au retrait, usages de potion préservés, compactage des données existantes.

## Impact données de prod
- 2 objets déjà hors capacité (2 joueurs) et ~65 joueurs en état à risque seront réparés par la migration de compactage.
- Aucune perte d'objet, de niveau, d'enchantement ni d'usage : seuls les numéros de slots sont réindexés.
