### PR TITLE
Empêcher de rejoindre le bateau une fois arrivé en ville

### DIFF
--- a/Core/src/commands/player/JoinBoatCommand.ts
+++ b/Core/src/commands/player/JoinBoatCommand.ts
@@ -44,8 +44,8 @@ import { InventorySlots } from "../../core/database/game/models/InventorySlot";
  * @param playerActiveObjects
  */
 async function canJoinBoat(player: Player, response: CrowniclesPacket[], playerActiveObjects: PlayerActiveObjects): Promise<boolean> {
-	// The player must still be travelling: once arrived (e.g. stopped in a city), joining the boat would grant a full trip's score for free
-	if (Maps.isArrived(player, new Date())) {
+	// The player must not be stopped in a city: joining the boat from there would grant a full trip's score for free
+	if (player.insideCity) {
 		response.push(makePacket(CommandJoinBoatNotTravellingPacketRes, {}));
 		return false;
 	}

--- a/Core/src/commands/player/JoinBoatCommand.ts
+++ b/Core/src/commands/player/JoinBoatCommand.ts
@@ -11,6 +11,7 @@ import {
 	CommandJoinBoatNoMemberOnBoatPacketRes,
 	CommandJoinBoatNotEnoughEnergyPacketRes,
 	CommandJoinBoatNotEnoughGemsPacketRes,
+	CommandJoinBoatNotTravellingPacketRes,
 	CommandJoinBoatPacketReq,
 	CommandJoinBoatRefusePacketRes,
 	CommandJoinBoatTooManyRunsPacketRes
@@ -43,6 +44,12 @@ import { InventorySlots } from "../../core/database/game/models/InventorySlot";
  * @param playerActiveObjects
  */
 async function canJoinBoat(player: Player, response: CrowniclesPacket[], playerActiveObjects: PlayerActiveObjects): Promise<boolean> {
+	// The player must still be travelling: once arrived (e.g. stopped in a city), joining the boat would grant a full trip's score for free
+	if (Maps.isArrived(player, new Date())) {
+		response.push(makePacket(CommandJoinBoatNotTravellingPacketRes, {}));
+		return false;
+	}
+
 	// Check if the player is still part of a guild
 	if (!player.guildId) {
 		response.push(makePacket(CommandJoinBoatNoGuildPacketRes, {}));

--- a/Discord/src/packetHandlers/handlers/commands/player/JoinBoatCommandPacketHandlers.ts
+++ b/Discord/src/packetHandlers/handlers/commands/player/JoinBoatCommandPacketHandlers.ts
@@ -5,6 +5,7 @@ import {
 	CommandJoinBoatNoMemberOnBoatPacketRes,
 	CommandJoinBoatNotEnoughEnergyPacketRes,
 	CommandJoinBoatNotEnoughGemsPacketRes,
+	CommandJoinBoatNotTravellingPacketRes,
 	CommandJoinBoatRefusePacketRes,
 	CommandJoinBoatTooManyRunsPacketRes
 } from "../../../../../../Lib/src/packets/commands/CommandJoinBoatPacket";
@@ -35,6 +36,12 @@ export default class JoinBoatCommandPacketHandlers {
 	async joinBoatNoMemberOnBoat(context: PacketContext, _packet: CommandJoinBoatNoMemberOnBoatPacketRes): Promise<void> {
 		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
 		await replyEphemeralErrorMessage(context, interaction, i18n.t("commands:joinBoat.errorMessage.noMemberOnBoat", { lng: interaction.userLanguage }));
+	}
+
+	@packetHandler(CommandJoinBoatNotTravellingPacketRes)
+	async joinBoatNotTravelling(context: PacketContext, _packet: CommandJoinBoatNotTravellingPacketRes): Promise<void> {
+		const interaction = DiscordCache.getInteraction(context.discord!.interaction)!;
+		await replyEphemeralErrorMessage(context, interaction, i18n.t("commands:joinBoat.errorMessage.notTravelling", { lng: interaction.userLanguage }));
 	}
 
 	@packetHandler(CommandJoinBoatNotEnoughEnergyPacketRes)

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -2741,7 +2741,7 @@
     "errorMessage": {
       "tooManyBoatThisWeek": "Vous êtes allé trop de fois sur le bateau ou vous avez rejoint une guilde cette semaine.",
       "noMemberOnBoat": "Aucun membre actif de votre guilde n'est sur le bateau.",
-      "notTravelling": "Vous ne pouvez rejoindre le bateau que pendant un voyage, pas une fois arrivé à destination.",
+      "notTravelling": "Vous ne pouvez pas rejoindre le bateau depuis une ville, vous devez être en train de voyager.",
       "noGuild": "Vous n'appartenez à aucune guilde.",
       "notEnoughEnergy": "Vous n'avez pas assez d'énergie pour monter sur le bateau.",
       "notEnoughGems": "Vous voulez rejoindre votre guilde mais au moment de payer, vous constatez que vos fonds sont insuffisants."

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -2741,6 +2741,7 @@
     "errorMessage": {
       "tooManyBoatThisWeek": "Vous êtes allé trop de fois sur le bateau ou vous avez rejoint une guilde cette semaine.",
       "noMemberOnBoat": "Aucun membre actif de votre guilde n'est sur le bateau.",
+      "notTravelling": "Vous ne pouvez rejoindre le bateau que pendant un voyage, pas une fois arrivé à destination.",
       "noGuild": "Vous n'appartenez à aucune guilde.",
       "notEnoughEnergy": "Vous n'avez pas assez d'énergie pour monter sur le bateau.",
       "notEnoughGems": "Vous voulez rejoindre votre guilde mais au moment de payer, vous constatez que vos fonds sont insuffisants."

--- a/Lib/src/packets/commands/CommandJoinBoatPacket.ts
+++ b/Lib/src/packets/commands/CommandJoinBoatPacket.ts
@@ -28,6 +28,10 @@ export class CommandJoinBoatNoMemberOnBoatPacketRes extends CrowniclesPacket {
 }
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
+export class CommandJoinBoatNotTravellingPacketRes extends CrowniclesPacket {
+}
+
+@sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class CommandJoinBoatNotEnoughEnergyPacketRes extends CrowniclesPacket {
 }
 


### PR DESCRIPTION
## Problème

En utilisant `/joinboat` une fois arrivé à destination (stationné dans une ville), le score de montée sur le bateau était calculé sur un temps de trajet complet. Le joueur récupérait donc l'équivalent des points d'un trajet entier sans le parcourir.

## Correctif

Ajout d'une vérification `Maps.isArrived` dans `canJoinBoat` : la commande n'est désormais disponible que pendant un voyage, pas une fois arrivé à destination. Un nouveau packet `CommandJoinBoatNotTravellingPacketRes` renvoie un message d'erreur explicite côté Discord.

Le small event `goToPVEIsland` n'est pas concerné (il ne se déclenche que pendant un voyage).

Closes #4507
