### PR TITLE
fix cooking not counting carried plants

### DIFF
--- a/Core/__tests__/core/cooking/CookingService.test.ts
+++ b/Core/__tests__/core/cooking/CookingService.test.ts
@@ -1,5 +1,5 @@
 import {
-	describe, expect, it
+	describe, expect, it, vi
 } from "vitest";
 import { CookingService } from "../../../src/core/cooking/CookingService";
 import {
@@ -9,6 +9,8 @@ import {
 import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
 import { PlantId } from "../../../../Lib/src/constants/PlantConstants";
 import { Constants } from "../../../../Lib/src/constants/Constants";
+import { HomePlantStorages } from "../../../src/core/database/game/models/HomePlantStorage";
+import { PlayerPlantSlots } from "../../../src/core/database/game/models/PlayerPlantSlot";
 
 /**
  * Minimal recipe factory for testing
@@ -313,6 +315,51 @@ describe("CookingService - pure functions", () => {
 			const recipe = createTestRecipe({ id: "other_recipe" });
 			const result = build(0, recipe, { ...baseContext, pinnedRecipeId: "potion_health_1" });
 			expect(result.isSecret).toBe(true);
+		});
+	});
+
+	describe("buildPlantAvailabilityMap", () => {
+		const buildMap = (CookingService as unknown as {
+			buildPlantAvailabilityMap: (homeId: number, playerId: number) => Promise<Map<number, number>>;
+		}).buildPlantAvailabilityMap.bind(CookingService);
+
+		it("should combine home plant storage with carried plant slots", async () => {
+			const storageSpy = vi.spyOn(HomePlantStorages, "getOfHome").mockResolvedValue([
+				{ plantId: PlantId.COMMON_HERB, quantity: 2 },
+				{ plantId: PlantId.GOLDEN_CLOVER, quantity: 5 }
+			] as unknown as Awaited<ReturnType<typeof HomePlantStorages.getOfHome>>);
+			const carriedSpy = vi.spyOn(PlayerPlantSlots, "getCarriedPlantCounts").mockResolvedValue(new Map<PlantId, number>([
+				[PlantId.COMMON_HERB, 1],
+				[PlantId.ANCIENT_TREE, 3]
+			]));
+
+			const map = await buildMap(1, 1);
+
+			// Storage + carried are summed for the same plant
+			expect(map.get(PlantId.COMMON_HERB)).toBe(3);
+			// Storage-only plant keeps its quantity
+			expect(map.get(PlantId.GOLDEN_CLOVER)).toBe(5);
+			// Carried-only plant is now available even without any home storage entry
+			expect(map.get(PlantId.ANCIENT_TREE)).toBe(3);
+
+			storageSpy.mockRestore();
+			carriedSpy.mockRestore();
+		});
+
+		it("should count carried plants when the home storage is empty", async () => {
+			const storageSpy = vi.spyOn(HomePlantStorages, "getOfHome").mockResolvedValue(
+				[] as unknown as Awaited<ReturnType<typeof HomePlantStorages.getOfHome>>
+			);
+			const carriedSpy = vi.spyOn(PlayerPlantSlots, "getCarriedPlantCounts").mockResolvedValue(new Map<PlantId, number>([
+				[PlantId.COMMON_HERB, 2]
+			]));
+
+			const map = await buildMap(1, 1);
+
+			expect(map.get(PlantId.COMMON_HERB)).toBe(2);
+
+			storageSpy.mockRestore();
+			carriedSpy.mockRestore();
 		});
 	});
 });

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -1,6 +1,7 @@
 import Player from "../database/game/models/Player";
 import { Materials } from "../database/game/models/Material";
 import { HomePlantStorages } from "../database/game/models/HomePlantStorage";
+import { PlayerPlantSlots } from "../database/game/models/PlayerPlantSlot";
 import {
 	Guilds, Guild
 } from "../database/game/models/Guild";
@@ -192,8 +193,7 @@ export class CookingService {
 		});
 
 		// Load all plant storages once to avoid N+1 queries
-		const allPlantStorages = await HomePlantStorages.getOfHome(homeId);
-		const plantStorageMap = new Map(allPlantStorages.map(s => [s.plantId, s.quantity]));
+		const plantStorageMap = await CookingService.buildPlantAvailabilityMap(homeId, player.id);
 
 		const context: RecipeSlotContext = {
 			furnacePosition: player.furnacePosition,
@@ -209,6 +209,23 @@ export class CookingService {
 			slotIndex: i,
 			recipe: recipe ? CookingService.buildRecipeSlotData(i, recipe, context) : null
 		}));
+	}
+
+	/**
+	 * Build the map of plants available for cooking, combining the home plant storage
+	 * (chest) with the plants the player carries in their inventory plant slots.
+	 * Cooking consumes from both, so availability must account for both.
+	 */
+	private static async buildPlantAvailabilityMap(homeId: number, playerId: number): Promise<Map<number, number>> {
+		const allPlantStorages = await HomePlantStorages.getOfHome(homeId);
+		const plantAvailability = new Map<number, number>(allPlantStorages.map(s => [s.plantId, s.quantity]));
+
+		const carriedPlants = await PlayerPlantSlots.getCarriedPlantCounts(playerId);
+		for (const [plantId, count] of carriedPlants) {
+			plantAvailability.set(plantId, (plantAvailability.get(plantId) ?? 0) + count);
+		}
+
+		return plantAvailability;
 	}
 
 	/**
@@ -372,6 +389,29 @@ export class CookingService {
 	}
 
 	/**
+	 * Consume the plants required by a recipe. Plants are drawn from the home plant
+	 * storage (chest) first, then from the plants the player carries in their inventory
+	 * plant slots for any remaining quantity.
+	 */
+	private static async consumeRecipePlants(homeId: number, playerId: number, plants: CookingRecipe["plants"]): Promise<void> {
+		for (const plant of plants) {
+			let remaining = plant.quantity;
+
+			const storage = await HomePlantStorages.getForPlant(homeId, plant.plantId);
+			if (storage && storage.quantity > 0) {
+				const fromStorage = Math.min(storage.quantity, remaining);
+				storage.quantity -= fromStorage;
+				await storage.save();
+				remaining -= fromStorage;
+			}
+
+			if (remaining > 0) {
+				await PlayerPlantSlots.consumeCarriedPlants(playerId, plant.plantId, remaining);
+			}
+		}
+	}
+
+	/**
 	 * Execute a craft: consume ingredients, calculate result, give XP
 	 */
 	static async executeCraft(params: {
@@ -384,14 +424,8 @@ export class CookingService {
 		} = params;
 		const grade = getCookingGrade(player.cookingLevel);
 
-		// Consume plants (batched per plant type)
-		for (const plant of recipe.plants) {
-			const storage = await HomePlantStorages.getForPlant(homeId, plant.plantId);
-			if (storage) {
-				storage.quantity = Math.max(0, storage.quantity - plant.quantity);
-				await storage.save();
-			}
-		}
+		// Consume plants: draw from the home plant storage first, then from the carried plant slots
+		await CookingService.consumeRecipePlants(homeId, player.id, recipe.plants);
 
 		// Consume materials (with possible material save buff)
 		const materialSaved = await CookingService.consumeMaterialsWithSaveBuff({
@@ -610,8 +644,7 @@ export class CookingService {
 
 		const playerMaterials = await Materials.getPlayerMaterials(params.player.id);
 		const materialMap = new Map(playerMaterials.map(m => [m.materialId, m.quantity]));
-		const allPlantStorages = await HomePlantStorages.getOfHome(params.homeId);
-		const plantStorageMap = new Map(allPlantStorages.map(s => [s.plantId, s.quantity]));
+		const plantStorageMap = await CookingService.buildPlantAvailabilityMap(params.homeId, params.player.id);
 
 		const {
 			ingredients, hasIngredients

--- a/Core/src/core/database/game/models/PlayerPlantSlot.ts
+++ b/Core/src/core/database/game/models/PlayerPlantSlot.ts
@@ -184,6 +184,49 @@ export class PlayerPlantSlots {
 			}
 		}) > 0;
 	}
+
+	/**
+	 * Count the plants carried by the player in their plant slots (excluding the seed slot),
+	 * grouped by plant type. Each occupied plant slot holds exactly one plant.
+	 */
+	public static async getCarriedPlantCounts(playerId: number): Promise<Map<PlantId, number>> {
+		const plantSlots = await PlayerPlantSlots.getPlantSlots(playerId);
+		const counts = new Map<PlantId, number>();
+		for (const slot of plantSlots) {
+			if (slot.plantId !== 0) {
+				counts.set(slot.plantId, (counts.get(slot.plantId) ?? 0) + 1);
+			}
+		}
+		return counts;
+	}
+
+	/**
+	 * Consume up to `amount` carried plants of a given type by clearing plant slots.
+	 * Returns the number of plants actually consumed.
+	 */
+	public static async consumeCarriedPlants(playerId: number, plantId: PlantId, amount: number): Promise<number> {
+		if (amount <= 0) {
+			return 0;
+		}
+		const slots = await PlayerPlantSlot.findAll({
+			where: {
+				playerId,
+				slotType: PLANT_SLOT_TYPE.PLANT,
+				plantId
+			},
+			order: [["slot", "ASC"]]
+		});
+		let consumed = 0;
+		for (const slot of slots) {
+			if (consumed >= amount) {
+				break;
+			}
+			slot.plantId = 0;
+			await slot.save();
+			consumed++;
+		}
+		return consumed;
+	}
 }
 
 export function initModel(sequelize: Sequelize): void {


### PR DESCRIPTION
## Contexte

Fixes #4498

Lors de la cuisine, seules les plantes stockées dans le coffre de la maison (`HomePlantStorages`) étaient prises en compte pour déterminer si une recette pouvait être réalisée et pour consommer les ingrédients. Les plantes portées par le joueur dans ses emplacements d'inventaire (`PlayerPlantSlots`) étaient ignorées : il fallait d'abord les déposer au coffre. Les matériaux, eux, étaient déjà comptés depuis l'inventaire du joueur, d'où l'incohérence signalée.

## Changements

- `PlayerPlantSlots.getCarriedPlantCounts` : compte les plantes portées par type.
- `PlayerPlantSlots.consumeCarriedPlants` : consomme des plantes portées en vidant les emplacements concernés.
- `CookingService.buildPlantAvailabilityMap` : fusionne le stockage du coffre avec les plantes portées pour le calcul de disponibilité (utilisé par le menu des recettes et la recette épinglée).
- `CookingService.consumeRecipePlants` : consomme d'abord depuis le coffre, puis depuis les emplacements portés pour le reste.

## Tests

- Ajout de tests unitaires pour `buildPlantAvailabilityMap` (fusion coffre + plantes portées, et cas coffre vide).
- `pnpm eslint` et `pnpm test` verts dans Core (1379 tests).
