### PR TITLE
Corriger les notifications de bonus journalier et d'arrivée en ville

### DIFF
--- a/Core/src/core/bot/Crownicles.ts
+++ b/Core/src/core/bot/Crownicles.ts
@@ -289,50 +289,68 @@ export class Crownicles {
 	}
 
 	static async reportNotifications(): Promise<void> {
-		if (PacketUtils.isMqttConnected()) {
-			const notifications = await ScheduledReportNotifications.getNotificationsBeforeDate(new Date());
-			if (notifications.length !== 0) {
-				PacketUtils.sendNotifications(notifications.map(notification => makePacket(ReachDestinationNotificationPacket, {
-					keycloakId: notification.keycloakId,
-					mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
-					mapId: notification.mapId
-				})));
-				await ScheduledReportNotifications.bulkDelete(notifications);
+		try {
+			if (PacketUtils.isMqttConnected()) {
+				const notifications = await ScheduledReportNotifications.getNotificationsBeforeDate(new Date());
+				if (notifications.length !== 0) {
+					PacketUtils.sendNotifications(notifications.map(notification => makePacket(ReachDestinationNotificationPacket, {
+						keycloakId: notification.keycloakId,
+						mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
+						mapId: notification.mapId
+					})));
+					await ScheduledReportNotifications.bulkDelete(notifications);
+				}
+			}
+			else {
+				CrowniclesLogger.error(`MQTT is not connected, can't do report notifications. Trying again in ${TimeoutFunctionsConstants.REPORT_NOTIFICATIONS} ms`);
 			}
 		}
-		else {
-			CrowniclesLogger.error(`MQTT is not connected, can't do report notifications. Trying again in ${TimeoutFunctionsConstants.REPORT_NOTIFICATIONS} ms`);
+		catch (error) {
+			CrowniclesLogger.errorWithObj("Error while dispatching report notifications", error);
 		}
-
-		setTimeout(Crownicles.reportNotifications, TimeoutFunctionsConstants.REPORT_NOTIFICATIONS);
+		finally {
+			setTimeout(Crownicles.reportNotifications, TimeoutFunctionsConstants.REPORT_NOTIFICATIONS);
+		}
 	}
 
 	static async dailyBonusNotifications(): Promise<void> {
-		if (PacketUtils.isMqttConnected()) {
-			const notifications = await ScheduledDailyBonusNotifications.getNotificationsBeforeDate(new Date());
-			if (notifications.length !== 0) {
-				PacketUtils.sendNotifications(notifications.map(notification => makePacket(DailyBonusNotificationPacket, {
-					keycloakId: notification.keycloakId
-				})));
-				await ScheduledDailyBonusNotifications.bulkDelete(notifications);
+		try {
+			if (PacketUtils.isMqttConnected()) {
+				const notifications = await ScheduledDailyBonusNotifications.getNotificationsBeforeDate(new Date());
+				if (notifications.length !== 0) {
+					PacketUtils.sendNotifications(notifications.map(notification => makePacket(DailyBonusNotificationPacket, {
+						keycloakId: notification.keycloakId
+					})));
+					await ScheduledDailyBonusNotifications.bulkDelete(notifications);
+				}
+			}
+			else {
+				CrowniclesLogger.error(`MQTT is not connected, can't do daily bonus notifications. Trying again in ${TimeoutFunctionsConstants.DAILY_TIMEOUT} ms`);
 			}
 		}
-		else {
-			CrowniclesLogger.error(`MQTT is not connected, can't do daily bonus notifications. Trying again in ${TimeoutFunctionsConstants.DAILY_TIMEOUT} ms`);
+		catch (error) {
+			CrowniclesLogger.errorWithObj("Error while dispatching daily bonus notifications", error);
 		}
-
-		setTimeout(Crownicles.dailyBonusNotifications, TimeoutFunctionsConstants.DAILY_TIMEOUT);
+		finally {
+			setTimeout(Crownicles.dailyBonusNotifications, TimeoutFunctionsConstants.DAILY_TIMEOUT);
+		}
 	}
 
 	static async expeditionNotifications(): Promise<void> {
-		if (PacketUtils.isMqttConnected()) {
-			await processDueExpeditionNotifications();
+		try {
+			if (PacketUtils.isMqttConnected()) {
+				await processDueExpeditionNotifications();
+			}
+			else {
+				CrowniclesLogger.error(`MQTT is not connected, can't do expedition notifications. Trying again in ${TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS} ms`);
+			}
 		}
-		else {
-			CrowniclesLogger.error(`MQTT is not connected, can't do expedition notifications. Trying again in ${TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS} ms`);
+		catch (error) {
+			CrowniclesLogger.errorWithObj("Error while dispatching expedition notifications", error);
 		}
-
-		setTimeout(Crownicles.expeditionNotifications, TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS);
+		finally {
+			setTimeout(Crownicles.expeditionNotifications, TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS);
+		}
 	}
 
 	/**

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -1975,7 +1975,6 @@ export function initModel(sequelize: Sequelize): void {
 			if (
 				travelEndDate > now
 				&& destinationId !== null
-				&& !CityDataController.instance.getCityByMapId(destinationId) // Don't schedule notifications for cities
 			) {
 				await ScheduledReportNotifications.scheduleNotification(instance.id, instance.keycloakId, destinationId, travelEndDate);
 				return;


### PR DESCRIPTION
## Contexte

Deux bugs de notifications signalés :
- #4494 — la notification de **bonus journalier** ne marche plus
- #4495 — la notification de **fin de trajet** n'arrive pas lorsqu'on arrive dans une **ville**

## Analyse

### #4495 — arrivée en ville
Depuis le rework du flux de voyage en ville (`insideCity`, #3769), une ville est désormais une seule map atteinte par une route normale (les liens internes de ville ont été supprimés). La condition de planification dans `Player.afterSave` utilisait :

```ts
&& !CityDataController.instance.getCityByMapId(destinationId) // Don't schedule notifications for cities
```

Avant #3769 la vérification portait sur le lien courant (`getCityByMapLinkId(instance.mapLinkId)`, les petits sauts internes de ville). Depuis, elle porte sur la **destination**, ce qui exclut **toute** arrivée dont la destination est une ville → aucune notification n'est jamais planifiée pour une arrivée en ville.

**Correctif :** suppression de l'exclusion. Les villes n'ayant plus de liens internes, une arrivée en ville est un trajet normal qui doit être notifié comme les autres.

### #4494 — bonus journalier
Preuves en production :
- `scheduled_daily_bonus_notifications` : **46 notifications échues** (scheduledAt < now) jamais supprimées/envoyées, alors que `scheduled_report_notifications` en a **0** en retard.
- Logs Core : rejets non gérés périodiques `Connection timeout: failed to create socket`.

Les boucles de dispatch (`reportNotifications`, `dailyBonusNotifications`, `expeditionNotifications`) plaçaient leur `setTimeout` de re-planification **après** un `await` susceptible de throw, et sont appelées via `.then()` sans `.catch()`. Une erreur DB transitoire propage l'exception, le `setTimeout` n'est jamais atteint et **la boucle meurt définitivement** (jusqu'au prochain redémarrage du Core). La boucle du bonus journalier (toutes les 10 s) est morte ; celle des rapports (toutes les 60 s) était encore vivante — d'où l'asymétrie observée.

**Correctif :** `try/catch/finally` autour du corps de chaque boucle, avec le `setTimeout` dans le `finally` → les boucles se ré-planifient toujours, même après une erreur transitoire (auto-réparation).

## Changements
- `Core/src/core/database/game/models/Player.ts` : suppression de l'exclusion des villes.
- `Core/src/core/bot/Crownicles.ts` : boucles de dispatch résilientes (report, daily bonus, expedition).

## Vérifications
- `pnpm tsc` ✅
- `pnpm eslint` ✅
- `pnpm test` ✅ (1377 tests)

Fixes #4494
Fixes #4495
