### PR TITLE
Empêcher les deadlocks au renouvellement des missions quotidiennes

### DIFF
--- a/Core/__tests__/core/utils/withLockedPlayerAndMissions.test.ts
+++ b/Core/__tests__/core/utils/withLockedPlayerAndMissions.test.ts
@@ -3,10 +3,15 @@ import {
 } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+	getDailyMission: vi.fn(),
 	getOfPlayer: vi.fn(),
 	playerLockKey: vi.fn((id: number) => ({ model: "Player", id })),
 	missionsLockKey: vi.fn((id: number) => ({ model: "PlayerMissionsInfo", id })),
 	withLockedEntities: vi.fn()
+}));
+
+vi.mock("../../../src/core/database/game/models/DailyMission", () => ({
+	DailyMissions: { getOrGenerate: mocks.getDailyMission }
 }));
 
 vi.mock("../../../src/core/database/game/models/Player", () => ({
@@ -29,15 +34,17 @@ describe("withLockedPlayerAndMissions", () => {
 		vi.clearAllMocks();
 	});
 
-	it("prewarms PlayerMissionsInfo before acquiring both lock keys", async () => {
+	it("prewarms daily mission and PlayerMissionsInfo before acquiring both lock keys", async () => {
 		const lockedPlayer = { id: 42 };
 		const lockedMissionsInfo = { playerId: 42 };
+		mocks.getDailyMission.mockResolvedValue({});
 		mocks.getOfPlayer.mockResolvedValue(lockedMissionsInfo);
 		mocks.withLockedEntities.mockImplementation(async (_keys, callback) => callback([lockedPlayer, lockedMissionsInfo]));
 		const body = vi.fn().mockResolvedValue("done");
 
 		const result = await withLockedPlayerAndMissions(42, body);
 
+		expect(mocks.getDailyMission).toHaveBeenCalledOnce();
 		expect(mocks.getOfPlayer).toHaveBeenCalledWith(42);
 		expect(mocks.withLockedEntities).toHaveBeenCalledWith(
 			[
@@ -46,6 +53,7 @@ describe("withLockedPlayerAndMissions", () => {
 			],
 			expect.any(Function)
 		);
+		expect(mocks.getDailyMission.mock.invocationCallOrder[0]).toBeLessThan(mocks.getOfPlayer.mock.invocationCallOrder[0]);
 		expect(mocks.getOfPlayer.mock.invocationCallOrder[0]).toBeLessThan(mocks.withLockedEntities.mock.invocationCallOrder[0]);
 		expect(body).toHaveBeenCalledWith(lockedPlayer);
 		expect(result).toBe("done");

--- a/Core/src/core/utils/withLockedPlayerAndMissions.ts
+++ b/Core/src/core/utils/withLockedPlayerAndMissions.ts
@@ -1,6 +1,7 @@
 import Player from "../database/game/models/Player";
 import PlayerMissionsInfo, { PlayerMissionsInfos } from "../database/game/models/PlayerMissionsInfo";
 import { withLockedEntities } from "../../../../Lib/src/locks/withLockedEntities";
+import { DailyMissions } from "../database/game/models/DailyMission";
 
 /**
  * Lock a player's `Player` **and** `PlayerMissionsInfo` rows (in canonical order) and run
@@ -13,11 +14,15 @@ import { withLockedEntities } from "../../../../Lib/src/locks/withLockedEntities
  * letting the nested mission update acquire `player_missions_info` inverts the canonical lock
  * order (`players -> player_missions_info`) and can deadlock against a concurrent standalone
  * mission update on the same player. Acquiring both rows up-front keeps the order canonical.
+ * The daily mission is resolved before either row is locked because its rollover resets every
+ * `player_missions_info` row. Running that reset under a per-player lock can deadlock with another
+ * player's concurrent rollover.
  *
  * @param playerId The player whose rows to lock.
  * @param body Critical section. Receives the fresh, locked `Player`.
  */
 export async function withLockedPlayerAndMissions<T>(playerId: number, body: (lockedPlayer: Player) => Promise<T>): Promise<T> {
+	await DailyMissions.getOrGenerate();
 	await PlayerMissionsInfos.getOfPlayer(playerId);
 	return await withLockedEntities(
 		[Player.lockKey(playerId), PlayerMissionsInfo.lockKey(playerId)] as const,


### PR DESCRIPTION
## Résumé

- résout la mission quotidienne avant d'acquérir les verrous du joueur et de ses missions
- empêche la remise à zéro globale de `player_missions_info` de s'exécuter dans une transaction qui verrouille déjà un joueur
- vérifie par test l'ordre entre le préchauffage quotidien et l'acquisition des verrous

## Validation

- `pnpm test` (`89` fichiers, `1 489` tests)
- `pnpm eslint`
- `pnpm tsc`

Fixes #4493
