### PR TITLE
Corriger les soins de la bière du capitaine

### DIFF
--- a/Core/__tests__/PossibilityOutcome.test.ts
+++ b/Core/__tests__/PossibilityOutcome.test.ts
@@ -1,0 +1,78 @@
+import {
+	describe, expect, it, vi
+} from "vitest";
+import { NumberChangeReason } from "../../Lib/src/constants/LogsConstants";
+import {
+	CrowniclesPacket, PacketContext
+} from "../../Lib/src/packets/CrowniclesPacket";
+import Player from "../src/core/database/game/models/Player";
+import { applyPossibilityOutcome } from "../src/data/events/PossibilityOutcome";
+
+vi.mock("../src/core/database/game/models/InventorySlot", () => ({
+	InventorySlots: { getPlayerActiveObjects: vi.fn().mockResolvedValue({}) }
+}));
+
+vi.mock("../src/core/database/game/models/PlayerSmallEvent", () => ({
+	PlayerSmallEvents: { calculateCurrentScore: vi.fn().mockResolvedValue(0) }
+}));
+
+vi.mock("../src/core/maps/TravelTime", () => ({
+	TravelTime: { timeTravelledToScore: vi.fn().mockReturnValue(0) }
+}));
+
+vi.mock("../../Lib/src/utils/RandomUtils", () => ({
+	RandomUtils: {
+		crowniclesRandom: {
+			bool: vi.fn(),
+			integer: vi.fn().mockReturnValue(0),
+			pick: vi.fn()
+		}
+	}
+}));
+
+describe("applyPossibilityOutcome", () => {
+	it("keeps health gained after experience reloads the player", async () => {
+		const persistedHealth = 1;
+		let currentHealth = persistedHealth;
+		const player = Object.create(Player.prototype) as Player;
+		Object.assign(player, {
+			id: 1,
+			level: 10,
+			effectDuration: 0,
+			effectId: "",
+			addEnergy: vi.fn(),
+			addExperience: vi.fn(async () => {
+				currentHealth = persistedHealth;
+				return player;
+			}),
+			addHealth: vi.fn(async ({ amount }: { amount: number }) => {
+				currentHealth += amount;
+				return true;
+			}),
+			addMoney: vi.fn().mockResolvedValue(undefined),
+			addScore: vi.fn().mockResolvedValue(undefined),
+			addTokens: vi.fn().mockResolvedValue(undefined),
+			setLastReportWithEffect: vi.fn().mockResolvedValue(undefined)
+		});
+		const response: CrowniclesPacket[] = [];
+
+		await applyPossibilityOutcome({
+			eventId: 67,
+			possibilityName: "accept",
+			outcome: ["1", { health: 15 }],
+			time: 0
+		}, player, {} as PacketContext, response);
+
+		expect(player.addExperience).toHaveBeenCalledWith({
+			amount: expect.any(Number),
+			reason: NumberChangeReason.BIG_EVENT,
+			response
+		});
+		expect(player.addHealth).toHaveBeenCalledWith({
+			amount: 15,
+			reason: NumberChangeReason.BIG_EVENT,
+			response
+		});
+		expect(currentHealth).toBe(16);
+	});
+});

--- a/Core/__tests__/PossibilityOutcome.test.ts
+++ b/Core/__tests__/PossibilityOutcome.test.ts
@@ -31,9 +31,11 @@ vi.mock("../../Lib/src/utils/RandomUtils", () => ({
 }));
 
 describe("applyPossibilityOutcome", () => {
-	it("keeps health gained after experience reloads the player", async () => {
+	it("keeps experience and health gained when experience reloads the player", async () => {
 		const persistedHealth = 1;
+		const initialExperience = 100;
 		let currentHealth = persistedHealth;
+		let currentExperience = initialExperience;
 		const player = Object.create(Player.prototype) as Player;
 		Object.assign(player, {
 			id: 1,
@@ -41,8 +43,9 @@ describe("applyPossibilityOutcome", () => {
 			effectDuration: 0,
 			effectId: "",
 			addEnergy: vi.fn(),
-			addExperience: vi.fn(async () => {
+			addExperience: vi.fn(async ({ amount }: { amount: number }) => {
 				currentHealth = persistedHealth;
+				currentExperience += amount;
 				return player;
 			}),
 			addHealth: vi.fn(async ({ amount }: { amount: number }) => {
@@ -73,6 +76,9 @@ describe("applyPossibilityOutcome", () => {
 			reason: NumberChangeReason.BIG_EVENT,
 			response
 		});
+		expect(vi.mocked(player.addExperience).mock.invocationCallOrder[0])
+			.toBeLessThan(vi.mocked(player.addHealth).mock.invocationCallOrder[0]);
+		expect(currentExperience).toBeGreaterThan(initialExperience);
 		expect(currentHealth).toBe(16);
 	});
 });

--- a/Core/src/data/events/PossibilityOutcome.ts
+++ b/Core/src/data/events/PossibilityOutcome.ts
@@ -272,12 +272,6 @@ export async function applyPossibilityOutcome(possibilityOutcome: ApplyOutcome, 
 	// Money
 	const money = await applyOutcomeMoney(possibilityOutcome.outcome[1], possibilityOutcome.time, player, response);
 
-	// Health
-	const health = await applyOutcomeHealth(possibilityOutcome.outcome[1], player, response);
-
-	// Energy
-	const energy = applyOutcomeEnergy(possibilityOutcome.outcome[1], player, playerActiveObjects);
-
 	// Gems
 	const gems = await applyOutcomeGems(possibilityOutcome.outcome[1], player);
 
@@ -286,6 +280,12 @@ export async function applyPossibilityOutcome(possibilityOutcome: ApplyOutcome, 
 
 	// Experience
 	const experience = await applyOutcomeExperience(possibilityOutcome.outcome[1], player, response);
+
+	// Health
+	const health = await applyOutcomeHealth(possibilityOutcome.outcome[1], player, response);
+
+	// Energy
+	const energy = applyOutcomeEnergy(possibilityOutcome.outcome[1], player, playerActiveObjects);
 
 	// Effect + lost time
 	const effect = await applyOutcomeEffect(possibilityOutcome.outcome[1], player);


### PR DESCRIPTION
## Résumé

- applique les gains d'expérience avant les soins et l'énergie des grands événements
- empêche la réhydratation du joueur pendant le gain d'expérience d'écraser les PV gagnés
- ajoute un test de régression sur les 15 PV de la bière du capitaine

## Validation

- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` (1 490 tests)

Fixes #4488
