### PR TITLE
Fix garden access while travelling home

### DIFF
--- a/Core/__tests__/core/commands/player/GardenCommand.test.ts
+++ b/Core/__tests__/core/commands/player/GardenCommand.test.ts
@@ -86,6 +86,7 @@ describe("GardenCommand", () => {
 		id: 42,
 		keycloakId: "player-keycloak-id",
 		mapLinkId: 3,
+		startTravelDate: new Date(0),
 		getDestinationId: vi.fn(() => 7),
 		getCurrentCityId: vi.fn(() => null as string | null),
 		getCumulativeEnergy: vi.fn(() => 100),
@@ -100,6 +101,7 @@ describe("GardenCommand", () => {
 		vi.clearAllMocks();
 		reactionCollectorMockState.endCallback = undefined;
 		talismans.hasRemoteHarvestTalisman = false;
+		player.startTravelDate = new Date(0);
 		vi.mocked(PlayerTalismansManager.getOfPlayer).mockResolvedValue(talismans as never);
 
 		vi.mocked(InventorySlots.getOfPlayer).mockResolvedValue([]);
@@ -187,6 +189,25 @@ describe("GardenCommand", () => {
 			player,
 			GardenAccessMode.FULL
 		);
+	});
+
+	it("refuses full access while the player is travelling to their home city", async () => {
+		vi.mocked(Homes.getOfPlayer).mockResolvedValue({
+			id: 1,
+			level: 2,
+			cityId: "coco",
+			getLevel: () => ({
+				features: { gardenPlots: 1 }
+			})
+		} as never);
+		player.getCurrentCityId.mockReturnValue("coco");
+		player.startTravelDate = new Date();
+
+		const response: { type: string; data: { reason: string } }[] = [];
+		await new GardenCommand().execute(response as never, player as never, {} as never, context as never);
+
+		expect(response[0].data.reason).toBe(GardenNoAccessReason.NO_TALISMAN);
+		expect(buildGardenData).not.toHaveBeenCalled();
 	});
 
 	it("builds a garden-only collector with READ_ONLY access when the player is away with the talisman", async () => {

--- a/Core/src/commands/player/GardenCommand.ts
+++ b/Core/src/commands/player/GardenCommand.ts
@@ -58,8 +58,8 @@ function resolveGardenAccess(
 	homeCityId: string,
 	hasRemoteHarvestTalisman: boolean
 ): GardenAccessMode | null {
-	const currentCityId = player.getCurrentCityId();
-	if (!Maps.isTravelling(player) && currentCityId !== null && currentCityId === homeCityId) {
+	const isAtHome = !Maps.isTravelling(player) && player.getCurrentCityId() === homeCityId;
+	if (isAtHome) {
 		return GardenAccessMode.FULL;
 	}
 	return hasRemoteHarvestTalisman ? GardenAccessMode.READ_ONLY : null;

--- a/Core/src/commands/player/GardenCommand.ts
+++ b/Core/src/commands/player/GardenCommand.ts
@@ -31,6 +31,7 @@ import { HomeNestedMenuIds } from "../../../../Lib/src/constants/HomeNestedMenuI
 import { HomeLevel } from "../../../../Lib/src/types/HomeLevel";
 import { PlayerActiveObjects } from "../../core/database/game/models/PlayerActiveObjects";
 import { WhereAllowed } from "../../../../Lib/src/types/WhereAllowed";
+import { Maps } from "../../core/maps/Maps";
 
 type GardenHomeResolution = {
 	home: Home;
@@ -58,7 +59,7 @@ function resolveGardenAccess(
 	hasRemoteHarvestTalisman: boolean
 ): GardenAccessMode | null {
 	const currentCityId = player.getCurrentCityId();
-	if (currentCityId !== null && currentCityId === homeCityId) {
+	if (!Maps.isTravelling(player) && currentCityId !== null && currentCityId === homeCityId) {
 		return GardenAccessMode.FULL;
 	}
 	return hasRemoteHarvestTalisman ? GardenAccessMode.READ_ONLY : null;


### PR DESCRIPTION
## Summary
- require the player to have completed travel before granting full garden access in their home city
- keep remote talisman access read-only while travelling
- add a regression test for travelling toward the home city

## Validation
- `pnpm eslint`
- `pnpm tsc --noEmit`
- `pnpm test` (1,498 tests)

Fixes #4497