### PR TITLE
Replace stale home chest slot count

### DIFF
--- a/Discord/__tests__/home/ChestFeatureHandler.test.ts
+++ b/Discord/__tests__/home/ChestFeatureHandler.test.ts
@@ -152,7 +152,7 @@ describe("ChestFeatureHandler", () => {
 			expect(option!.value).toBe(HomeMenuIds.CHEST_MENU);
 		});
 
-		it("should show filled/total slot count", () => {
+		it("should show a generic storage description", () => {
 			const ctx = createHandlerContext({
 				homeData: createChestHomeData({
 					chestItems: [
@@ -171,8 +171,7 @@ describe("ChestFeatureHandler", () => {
 			});
 			const option = handler.getMenuOption(ctx);
 			expect(option).not.toBeNull();
-			expect(option!.description).toContain('"filled":1');
-			expect(option!.description).toContain('"total":5');
+			expect(option!.description).toBe("commands:report.city.homes.chest.menuDescription");
 		});
 
 		it("should return null when no chest slots", () => {

--- a/Discord/src/commands/player/report/home/features/ChestFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/ChestFeatureHandler.ts
@@ -70,16 +70,9 @@ export class ChestFeatureHandler implements HomeFeatureHandler {
 			return null;
 		}
 
-		const chest = ctx.homeData.chest;
-		const filledCount = chest?.chestItems.length ?? 0;
-		const slots = ctx.homeData.features.chestSlots;
-		const totalSlots = slots.weapon + slots.armor + slots.potion + slots.object;
-
 		return {
 			label: i18n.t("commands:report.city.homes.chest.menuLabel", { lng: ctx.lng }),
-			description: i18n.t("commands:report.city.homes.chest.menuDescription", {
-				lng: ctx.lng, filled: filledCount, total: totalSlots
-			}),
+			description: i18n.t("commands:report.city.homes.chest.menuDescription", { lng: ctx.lng }),
 			emoji: CrowniclesIcons.city.homeUpgrades.chest,
 			value: HomeMenuIds.CHEST_MENU,
 			buttonLabel: i18n.t("commands:report.city.homes.chest.buttonLabel", { lng: ctx.lng })

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -1225,7 +1225,7 @@
         },
         "chest": {
           "menuLabel": "Coffre de rangement",
-          "menuDescription": "{{filled}}/{{total}} emplacements utilisés",
+          "menuDescription": "Stockez vos objets de rechange",
           "buttonLabel": "Ouvrir",
           "available": "{emote:city.homeUpgrades.chest} Votre coffre vous permet de stocker des objets de rechange.",
           "title": "{{pseudo}}, coffre de rangement",


### PR DESCRIPTION
## Summary
- replace the stale home chest slot counter with a generic storage description
- keep detailed capacity counters inside the refreshed chest menus
- update the chest menu unit test

## Tests
- `cd Discord && pnpm eslint`
- `cd Discord && pnpm exec vitest run __tests__/home/ChestFeatureHandler.test.ts`
- `cd Discord && pnpm exec vitest run __tests__/translations/cityMenuTranslations.test.ts`

Fixes #4478
