### PR TITLE
Refactor city service availability payload

### DIFF
--- a/Core/__tests__/core/report/ReportCityServiceAvailability.test.ts
+++ b/Core/__tests__/core/report/ReportCityServiceAvailability.test.ts
@@ -1,0 +1,19 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { CITY_SERVICES } from "../../../../Lib/src/constants/CityServiceConstants";
+import { getAvailableCityServices } from "../../../src/core/report/ReportCityServiceAvailability";
+
+describe("getAvailableCityServices", () => {
+	it("returns available services in their shared definition order", () => {
+		expect(getAvailableCityServices({
+			[CITY_SERVICES.BLACKSMITH]: true,
+			[CITY_SERVICES.ROYAL_BLACKSMITH]: false,
+			[CITY_SERVICES.ENCHANTER]: true,
+			[CITY_SERVICES.BOSS_ARCHIVIST]: false
+		})).toEqual([
+			CITY_SERVICES.BLACKSMITH,
+			CITY_SERVICES.ENCHANTER
+		]);
+	});
+});

--- a/Core/src/commands/player/GardenCommand.ts
+++ b/Core/src/commands/player/GardenCommand.ts
@@ -98,6 +98,7 @@ async function buildGardenCollectorData(params: GardenCollectorDataParams): Prom
 		gardenOnly: true,
 		mapTypeId: MapLocationDataController.instance.getById(destinationId)!.type,
 		mapLocationId: destinationId,
+		availableServices: [],
 		energy: buildEnergyData(params.player, playerActiveObjects),
 		health: buildHealthData(params.player),
 		home: {

--- a/Core/src/commands/player/ReportCommand.ts
+++ b/Core/src/commands/player/ReportCommand.ts
@@ -72,9 +72,6 @@ import { BuildingUpgradeEligibilityMap } from "../../../../Lib/src/types/GuildDo
 import { GuildPets } from "../../core/database/game/models/GuildPet";
 import { PetEntities } from "../../core/database/game/models/PetEntity";
 import { InventorySlots } from "../../core/database/game/models/InventorySlot";
-import { Settings } from "../../core/database/game/models/Setting";
-import { ItemEnchantment } from "../../../../Lib/src/types/ItemEnchantment";
-import { ClassConstants } from "../../../../Lib/src/constants/ClassConstants";
 import { Homes } from "../../core/database/game/models/Home";
 import { Materials } from "../../core/database/game/models/Material";
 import {
@@ -84,6 +81,7 @@ import {
 	validateUseTokensRequest
 } from "../../core/report/ReportTokenHealService";
 import { openTokenMerchant } from "../../core/report/ReportTokenMerchantService";
+import { getAvailableCityServices } from "../../core/report/ReportCityServiceAvailability";
 import {
 	HEAL_VALIDATION_REASONS, USE_TOKENS_VALIDATION_REASONS
 } from "../../core/report/ReportValidationConstants";
@@ -128,7 +126,7 @@ import {
 import { buildRoyalBlacksmithData } from "../../core/report/ReportRoyalBlacksmithService";
 import { handleRoyalBlacksmithUpgradeReaction } from "../../core/report/ReportCityRoyalBlacksmithService";
 import {
-	buildEnchanterData,
+	buildAvailableEnchanterData,
 	buildHomeData,
 	buildApartmentNotaryData,
 	handleBlacksmithDisenchantReaction,
@@ -587,10 +585,9 @@ async function sendCityCollector(
 ): Promise<void> {
 	const playerInventory = await InventorySlots.getOfPlayer(player.id);
 	const playerActiveObjects = InventorySlots.slotsToActiveObjects(playerInventory);
-	const isEnchanterHere = await Settings.ENCHANTER_CITY.getValue() === city.id;
-	const enchantmentId = isEnchanterHere ? await Settings.ENCHANTER_ENCHANTMENT_ID.getValue() : null;
-	const isPlayerMage = player.class === ClassConstants.CLASSES_ID.MYSTIC_MAGE;
-	const enchantment = enchantmentId ? ItemEnchantment.getById(enchantmentId) : null;
+	const enchanter = await buildAvailableEnchanterData({
+		inventory: playerInventory, player
+	}, city.id);
 	const home = await Homes.getOfPlayer(player.id);
 	const homeLevel = home?.getLevel() ?? null;
 	const playerMaterials = await Materials.getPlayerMaterials(player.id);
@@ -696,12 +693,12 @@ async function sendCityCollector(
 	const collectorData: ReactionCollectorCityData = {
 		mapTypeId: MapLocationDataController.instance.getById(player.getDestinationId()!)!.type,
 		mapLocationId: player.getDestinationId()!,
-		availableServices: [
-			...blacksmith ? [CITY_SERVICES.BLACKSMITH] : [],
-			...royalBlacksmith ? [CITY_SERVICES.ROYAL_BLACKSMITH] : [],
-			...isEnchanterHere && enchantment ? [CITY_SERVICES.ENCHANTER] : [],
-			...city.bossArchivistAvailable ? [CITY_SERVICES.BOSS_ARCHIVIST] : []
-		],
+		availableServices: getAvailableCityServices({
+			[CITY_SERVICES.BLACKSMITH]: blacksmith !== undefined,
+			[CITY_SERVICES.ROYAL_BLACKSMITH]: royalBlacksmith !== undefined,
+			[CITY_SERVICES.ENCHANTER]: enchanter !== undefined,
+			[CITY_SERVICES.BOSS_ARCHIVIST]: city.bossArchivistAvailable
+		}),
 		inns: city.inns.map(inn => ({
 			innId: inn.id,
 			meals: city.getTodayInnMeals(inn, new Date()).map(meal => ({
@@ -727,16 +724,7 @@ async function sendCityCollector(
 			current: player.getHealth(),
 			max: player.getMaxHealth()
 		},
-		enchanter: isEnchanterHere && enchantment
-			? await buildEnchanterData(
-				{
-					inventory: playerInventory, player
-				},
-				{
-					enchantment, enchantmentId: enchantmentId!, isPlayerMage
-				}
-			)
-			: undefined,
+		enchanter,
 		home: await buildHomeData(
 			{
 				player, inventory: playerInventory, materialMap: playerMaterialMap

--- a/Core/src/commands/player/ReportCommand.ts
+++ b/Core/src/commands/player/ReportCommand.ts
@@ -19,6 +19,7 @@ import {
 import { BlockingUtils } from "../../core/utils/BlockingUtils";
 import { withLockedPlayerSafe } from "../../core/utils/withLockedPlayerSafe";
 import { BlockingConstants } from "../../../../Lib/src/constants/BlockingConstants";
+import { CITY_SERVICES } from "../../../../Lib/src/constants/CityServiceConstants";
 import { MissionsController } from "../../core/missions/MissionsController";
 import {
 	EndCallback, ReactionCollectorInstance
@@ -695,6 +696,12 @@ async function sendCityCollector(
 	const collectorData: ReactionCollectorCityData = {
 		mapTypeId: MapLocationDataController.instance.getById(player.getDestinationId()!)!.type,
 		mapLocationId: player.getDestinationId()!,
+		availableServices: [
+			...blacksmith ? [CITY_SERVICES.BLACKSMITH] : [],
+			...royalBlacksmith ? [CITY_SERVICES.ROYAL_BLACKSMITH] : [],
+			...isEnchanterHere && enchantment ? [CITY_SERVICES.ENCHANTER] : [],
+			...city.bossArchivistAvailable ? [CITY_SERVICES.BOSS_ARCHIVIST] : []
+		],
 		inns: city.inns.map(inn => ({
 			innId: inn.id,
 			meals: city.getTodayInnMeals(inn, new Date()).map(meal => ({
@@ -720,7 +727,6 @@ async function sendCityCollector(
 			current: player.getHealth(),
 			max: player.getMaxHealth()
 		},
-		bossArchivist: city.bossArchivistAvailable,
 		enchanter: isEnchanterHere && enchantment
 			? await buildEnchanterData(
 				{

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -38,6 +38,8 @@ import { PlayerPlantSlots } from "../database/game/models/PlayerPlantSlot";
 import { buildGardenData } from "./ReportGardenService";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { OwnedApartmentSummary } from "../../../../Lib/src/types/ApartmentLocation";
+import { Settings } from "../database/game/models/Setting";
+import { ClassConstants } from "../../../../Lib/src/constants/ClassConstants";
 
 // Re-exports for backward compatibility
 export {
@@ -203,6 +205,29 @@ export async function buildEnchanterData(
 		playerMoney: player.money,
 		playerGems: playerMissionsInfo.gems
 	};
+}
+
+export async function buildAvailableEnchanterData(
+	playerData: {
+		inventory: InventorySlot[]; player: Player;
+	},
+	cityId: string
+): Promise<EnchanterData | undefined> {
+	if (await Settings.ENCHANTER_CITY.getValue() !== cityId) {
+		return undefined;
+	}
+
+	const enchantmentId = await Settings.ENCHANTER_ENCHANTMENT_ID.getValue();
+	const enchantment = ItemEnchantment.getById(enchantmentId);
+	if (!enchantment) {
+		return undefined;
+	}
+
+	return buildEnchanterData(playerData, {
+		enchantment,
+		enchantmentId,
+		isPlayerMage: playerData.player.class === ClassConstants.CLASSES_ID.MYSTIC_MAGE
+	});
 }
 
 /**

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -60,6 +60,10 @@ export { handleChestAction } from "./ReportCityChestService";
 
 // Type aliases for commonly used nested types from ReactionCollectorCityData
 type EnchanterData = NonNullable<ReactionCollectorCityData["enchanter"]>;
+type EnchanterPlayerData = {
+	inventory: InventorySlot[];
+	player: Player;
+};
 type HomeData = ReactionCollectorCityData["home"];
 type OwnedHomeData = NonNullable<HomeData["owned"]>;
 type UpgradeStationData = NonNullable<OwnedHomeData["upgradeStation"]>;
@@ -152,9 +156,7 @@ export async function buildApartmentNotaryData(
  * Build enchanter data for the city reaction collector
  */
 export async function buildEnchanterData(
-	playerData: {
-		inventory: InventorySlot[]; player: Player;
-	},
+	playerData: EnchanterPlayerData,
 	enchantData: {
 		enchantment: ItemEnchantment; enchantmentId: string; isPlayerMage: boolean;
 	}
@@ -208,9 +210,7 @@ export async function buildEnchanterData(
 }
 
 export async function buildAvailableEnchanterData(
-	playerData: {
-		inventory: InventorySlot[]; player: Player;
-	},
+	playerData: EnchanterPlayerData,
 	cityId: string
 ): Promise<EnchanterData | undefined> {
 	if (await Settings.ENCHANTER_CITY.getValue() !== cityId) {

--- a/Core/src/core/report/ReportCityServiceAvailability.ts
+++ b/Core/src/core/report/ReportCityServiceAvailability.ts
@@ -1,0 +1,9 @@
+import {
+	CITY_SERVICES, CityService
+} from "../../../../Lib/src/constants/CityServiceConstants";
+
+export type CityServiceAvailability = Record<CityService, boolean>;
+
+export function getAvailableCityServices(availability: CityServiceAvailability): CityService[] {
+	return Object.values(CITY_SERVICES).filter(service => availability[service]);
+}

--- a/Discord/__tests__/city/BossArchivistMenu.test.ts
+++ b/Discord/__tests__/city/BossArchivistMenu.test.ts
@@ -2,6 +2,7 @@ import {
 	describe, expect, it, vi
 } from "vitest";
 import { FightConstants } from "../../../Lib/src/constants/FightConstants";
+import { CITY_SERVICES } from "../../../Lib/src/constants/CityServiceConstants";
 import { LANGUAGE } from "../../../Lib/src/Language";
 import { ReactionCollectorCityData } from "../../../Lib/src/packets/interaction/ReactionCollectorCity";
 import { ReactionCollectorCreationPacket } from "../../../Lib/src/packets/interaction/ReactionCollectorPacket";
@@ -41,7 +42,7 @@ function createParams(): CityMenuParams {
 		} as never,
 		packet: {
 			data: {
-				data: { bossArchivist: true } as ReactionCollectorCityData
+				data: { availableServices: [CITY_SERVICES.BOSS_ARCHIVIST] } as ReactionCollectorCityData
 			}
 		} as ReactionCollectorCreationPacket,
 		collectorTime: 60_000,

--- a/Discord/__tests__/city/MainMenuShopHandoff.test.ts
+++ b/Discord/__tests__/city/MainMenuShopHandoff.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../src/utils/DiscordCollectorUtils", () => ({
 }));
 
 import { LANGUAGE } from "../../../Lib/src/Language";
+import { CITY_SERVICES } from "../../../Lib/src/constants/CityServiceConstants";
 import {
 	ReactionCollectorCityData,
 	ReactionCollectorCityShopReaction
@@ -36,6 +37,7 @@ function createPacket(): ReactionCollectorCreationPacket {
 			data: {
 				mapLocationId: 1,
 				mapTypeId: 0,
+				availableServices: [],
 				home: {},
 				apartmentNotary: { ownedApartments: [] },
 				shops: [{
@@ -143,5 +145,27 @@ describe("city shop message handoff", () => {
 		await nestedMenus.stopCurrentCollector();
 
 		expect(message.edit).toHaveBeenCalledOnce();
+	});
+});
+
+describe("city services", () => {
+	it("renders services from availableServices instead of their payload", () => {
+		const packet = createPacket();
+		const data = packet.data.data as ReactionCollectorCityData;
+		data.availableServices = [CITY_SERVICES.BOSS_ARCHIVIST];
+		data.blacksmith = {
+			upgradeableItems: [],
+			disenchantableItems: [],
+			playerMoney: 0
+		};
+
+		const menu = getMainMenu(createMenuParams(packet));
+		const customIds = menu.containers!.flatMap(container => container.components.flatMap(component =>
+			"accessory" in component && component.accessory && "data" in component.accessory
+				? [component.accessory.data.custom_id]
+				: []));
+
+		expect(customIds).toContain(ReportCityMenuIds.BOSS_ARCHIVIST_MENU);
+		expect(customIds).not.toContain(ReportCityMenuIds.BLACKSMITH_MENU);
 	});
 });

--- a/Discord/src/commands/player/report/ReportCityMenu.ts
+++ b/Discord/src/commands/player/report/ReportCityMenu.ts
@@ -16,6 +16,7 @@ import {
 	TextDisplayBuilder
 } from "discord.js";
 import { CrowniclesIcons } from "../../../../../Lib/src/CrowniclesIcons";
+import { CITY_SERVICES } from "../../../../../Lib/src/constants/CityServiceConstants";
 import {
 	ReactionCollectorCreationPacket,
 	ReactionCollectorRefuseReaction
@@ -250,7 +251,7 @@ function addGuildFoodShopSubMenu(menus: Map<string, CrowniclesNestedMenu>, param
 }
 
 function addBossArchivistSubMenus(menus: Map<string, CrowniclesNestedMenu>, params: HomeMenuParams, cityData: ReactionCollectorCityData): void {
-	if (!cityData.bossArchivist) {
+	if (!cityData.availableServices.includes(CITY_SERVICES.BOSS_ARCHIVIST)) {
 		return;
 	}
 	for (const [key, menu] of getBossArchivistMenus(params)) {

--- a/Discord/src/commands/player/report/cityMenu/MainMenu.ts
+++ b/Discord/src/commands/player/report/cityMenu/MainMenu.ts
@@ -15,6 +15,9 @@ import {
 	ReactionCollectorRefuseReaction
 } from "../../../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
 import { CrowniclesIcons } from "../../../../../../Lib/src/CrowniclesIcons";
+import {
+	CITY_SERVICES, CityService
+} from "../../../../../../Lib/src/constants/CityServiceConstants";
 import { Language } from "../../../../../../Lib/src/Language";
 import {
 	CrowniclesNestedMenu,
@@ -111,10 +114,7 @@ function addHomeSection(container: ContainerBuilder, data: ReactionCollectorCity
 	}
 }
 
-type CityServiceDataKey = "blacksmith" | "royalBlacksmith" | "enchanter" | "bossArchivist";
-
 type CityServiceDefinition = {
-	dataKey: CityServiceDataKey;
 	emote: string;
 	titleKey: string;
 	descriptionKey: string;
@@ -123,33 +123,29 @@ type CityServiceDefinition = {
 	buttonStyle?: ButtonStyle;
 };
 
-const CITY_SERVICE_DEFINITIONS: CityServiceDefinition[] = [
-	{
-		dataKey: "blacksmith",
+const CITY_SERVICE_DEFINITIONS: Record<CityService, CityServiceDefinition> = {
+	[CITY_SERVICES.BLACKSMITH]: {
 		emote: CrowniclesIcons.city.services.blacksmith,
 		titleKey: "commands:report.city.blacksmith.menuLabel",
 		descriptionKey: "commands:report.city.blacksmith.menuDescription",
 		customId: ReportCityMenuIds.BLACKSMITH_MENU,
 		buttonLabelKey: "commands:report.city.buttons.enterForge"
 	},
-	{
-		dataKey: "royalBlacksmith",
+	[CITY_SERVICES.ROYAL_BLACKSMITH]: {
 		emote: CrowniclesIcons.city.services.royalBlacksmith,
 		titleKey: "commands:report.city.royalBlacksmith.menuLabel",
 		descriptionKey: "commands:report.city.royalBlacksmith.menuDescription",
 		customId: ReportCityMenuIds.ROYAL_BLACKSMITH_MENU,
 		buttonLabelKey: "commands:report.city.royalBlacksmith.enterButton"
 	},
-	{
-		dataKey: "enchanter",
+	[CITY_SERVICES.ENCHANTER]: {
 		emote: CrowniclesIcons.city.services.enchanter,
 		titleKey: "commands:report.city.reactions.enchanter.label",
 		descriptionKey: "commands:report.city.reactions.enchanter.description",
 		customId: ReportCityMenuIds.ENCHANTER_MENU,
 		buttonLabelKey: "commands:report.city.buttons.talkToEnchanter"
 	},
-	{
-		dataKey: "bossArchivist",
+	[CITY_SERVICES.BOSS_ARCHIVIST]: {
 		emote: CrowniclesIcons.city.services.bossArchivist,
 		titleKey: "commands:report.city.bossArchivist.serviceTitle",
 		descriptionKey: "commands:report.city.bossArchivist.serviceDescription",
@@ -157,15 +153,15 @@ const CITY_SERVICE_DEFINITIONS: CityServiceDefinition[] = [
 		buttonLabelKey: "commands:report.city.bossArchivist.visit",
 		buttonStyle: ReportCityButtonStyles.OPTION
 	}
-];
+};
 
 function addServicesSection(container: ContainerBuilder, data: ReactionCollectorCityData, lng: Language): void {
-	const availableServices = CITY_SERVICE_DEFINITIONS.filter(service => data[service.dataKey]);
-	if (availableServices.length === 0) {
+	if (data.availableServices.length === 0) {
 		return;
 	}
 	container.addSeparatorComponents(new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small));
-	for (const service of availableServices) {
+	for (const serviceKey of data.availableServices) {
+		const service = CITY_SERVICE_DEFINITIONS[serviceKey];
 		addCitySection({
 			container,
 			emote: service.emote,

--- a/Lib/src/constants/CityServiceConstants.ts
+++ b/Lib/src/constants/CityServiceConstants.ts
@@ -1,0 +1,8 @@
+export const CITY_SERVICES = {
+	BLACKSMITH: "blacksmith",
+	ROYAL_BLACKSMITH: "royalBlacksmith",
+	ENCHANTER: "enchanter",
+	BOSS_ARCHIVIST: "bossArchivist"
+} as const;
+
+export type CityService = typeof CITY_SERVICES[keyof typeof CITY_SERVICES];

--- a/Lib/src/packets/interaction/ReactionCollectorCity.ts
+++ b/Lib/src/packets/interaction/ReactionCollectorCity.ts
@@ -26,11 +26,14 @@ import { OwnedPet } from "../../types/OwnedPet";
 import { OwnedApartmentSummary } from "../../types/ApartmentLocation";
 import { GardenAccessMode } from "../../types/GardenAccessMode";
 import { GardenConstants } from "../../constants/GardenConstants";
+import { CityService } from "../../constants/CityServiceConstants";
 
 export class ReactionCollectorCityData extends ReactionCollectorData {
 	mapTypeId!: string;
 
 	mapLocationId!: number;
+
+	availableServices!: CityService[];
 
 	/**
 	 * If set, the Discord side should auto-navigate to this menu after rendering.
@@ -75,8 +78,6 @@ export class ReactionCollectorCityData extends ReactionCollectorData {
 		current: number;
 		max: number;
 	};
-
-	bossArchivist?: boolean;
 
 	enchanter?: {
 		enchantableItems: {


### PR DESCRIPTION
## Summary

- add shared city service keys and expose `availableServices` in the city collector payload
- build the service list in Core while keeping service-specific payloads separate
- render Discord city services and register the boss archivist menus from the shared list
- cover list-driven service rendering independently from payload presence

## Validation

- `Lib`: `pnpm eslint`, `pnpm tsc`, `pnpm test` (579 tests)
- `Core`: `pnpm eslint`, `pnpm tsc`, `pnpm test` (1498 tests)
- `Discord`: `pnpm eslint`, `pnpm test` (258 tests)

Fixes #4464