### PR TITLE
fix cooked potion find message

### DIFF
--- a/Core/__tests__/core/cooking/ReportCookingPotionOutput.test.ts
+++ b/Core/__tests__/core/cooking/ReportCookingPotionOutput.test.ts
@@ -1,0 +1,52 @@
+import {
+	afterEach, describe, expect, it, vi
+} from "vitest";
+import {
+	CrowniclesPacket, PacketContext
+} from "../../../../Lib/src/packets/CrowniclesPacket";
+import { ItemFoundPacket } from "../../../../Lib/src/packets/events/ItemFoundPacket";
+import {
+	ItemNature, ItemRarity
+} from "../../../../Lib/src/constants/ItemConstants";
+import { ItemWithDetails } from "../../../../Lib/src/types/ItemWithDetails";
+import { CookingRecipeData } from "../../../src/data/CookingRecipeData";
+import {
+	Potion, PotionDataController
+} from "../../../src/data/Potion";
+import { Player } from "../../../src/core/database/game/models/Player";
+import * as ItemUtils from "../../../src/core/utils/ItemUtils";
+import { handlePotionOutput } from "../../../src/core/report/ReportCookingService";
+
+describe("handlePotionOutput", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("uses the standard item flow so a cooked potion emits ItemFoundPacket", async () => {
+		const potion = { id: 42 } as Potion;
+		const player = { giveItem: vi.fn() } as unknown as Player;
+		const context = { frontEndOrigin: "discord" } as PacketContext;
+		const recipe = {
+			potionNature: ItemNature.HEALTH,
+			potionRarity: ItemRarity.RARE
+		} as CookingRecipeData;
+		const itemFoundPacket = {
+			type: ItemFoundPacket.name,
+			data: { itemWithDetails: {} as ItemWithDetails }
+		} as CrowniclesPacket;
+
+		vi.spyOn(PotionDataController.instance, "hasItemWithNatureAndRarity").mockReturnValue(true);
+		vi.spyOn(PotionDataController.instance, "randomItem").mockReturnValue(potion);
+		vi.spyOn(ItemUtils, "giveItemToPlayer").mockImplementation(async response => {
+			response.push(itemFoundPacket);
+		});
+
+		const result = await handlePotionOutput({
+			player, recipe, context, bonus: false
+		});
+
+		expect(ItemUtils.giveItemToPlayer).toHaveBeenCalledWith(expect.any(Array), context, player, potion);
+		expect(player.giveItem).not.toHaveBeenCalled();
+		expect(result.inventorySwapPackets).toEqual([itemFoundPacket]);
+	});
+});

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -431,7 +431,7 @@ interface PotionOutputParams {
 	bonus: boolean;
 }
 
-async function handlePotionOutput({
+export async function handlePotionOutput({
 	player, recipe, context, bonus
 }: PotionOutputParams): Promise<CraftOutputResult> {
 	if (recipe.potionNature === undefined || recipe.potionRarity === undefined) {
@@ -442,17 +442,14 @@ async function handlePotionOutput({
 		return {};
 	}
 	const potion = PotionDataController.instance.randomItem(recipe.potionNature, effectiveRarity);
-	const itemReceived = await player.giveItem(potion);
-	const result: CraftOutputResult = {
+	const inventorySwapPackets: CrowniclesPacket[] = [];
+	await giveItemToPlayer(inventorySwapPackets, context, player, potion);
+	return {
 		potionId: potion.id,
 		potionRarity: effectiveRarity,
+		inventorySwapPackets,
 		bonusHonored: bonus && effectiveRarity > recipe.potionRarity
 	};
-	if (!itemReceived) {
-		result.inventorySwapPackets = [];
-		await giveItemToPlayer(result.inventorySwapPackets, context, player, potion);
-	}
-	return result;
 }
 
 interface PetFoodLockParams {


### PR DESCRIPTION
## Summary
- route cooked potions through the standard item award flow
- emit the item found packet even when inventory space is available
- avoid retrying the same inventory insertion when the potion category is full
- add a focused regression test for cooked potion output packets

## Validation
- `cd Core && pnpm tsc`
- `cd Core && pnpm eslint`
- `cd Core && pnpm test` (1,498 tests)

Fixes #4483
