### PR TITLE
Prevent Coco Village entry after departure outcomes

### DIFF
--- a/Core/__tests__/core/data/events/CocoVillageEvent.test.ts
+++ b/Core/__tests__/core/data/events/CocoVillageEvent.test.ts
@@ -1,0 +1,12 @@
+import {
+	describe, expect, it
+} from "vitest";
+import cocoVillageEvent from "../../../../resources/events/50.json";
+
+describe("Coco Village event", () => {
+	it("forces every leave outcome to continue travelling", () => {
+		const leaveOutcomes = Object.values(cocoVillageEvent.possibilities.leave.outcomes);
+
+		expect(leaveOutcomes.every(outcome => outcome.forceLeaveCity)).toBe(true);
+	});
+});

--- a/Core/resources/events/50.json
+++ b/Core/resources/events/50.json
@@ -28,12 +28,16 @@
     "leave": {
       "outcomes": {
         "0": {
+          "forceLeaveCity": true,
           "health": 10
         },
         "1": {
+          "forceLeaveCity": true,
           "money": -100
         },
-        "2": {}
+        "2": {
+          "forceLeaveCity": true
+        }
       }
     },
     "nap": {

--- a/Core/src/core/report/ReportBigEventService.ts
+++ b/Core/src/core/report/ReportBigEventService.ts
@@ -167,6 +167,7 @@ async function applyLockedOutcomeUnderLock(
 	if (newMapLink || !isDead) {
 		await chooseDestination(context, lockedPlayer, newMapLink, response, {
 			mainPacket: false,
+			allowStayInCity: randomOutcome[1].forceLeaveCity !== true,
 			forceStayInCity: randomOutcome[1].forceStayInCity ?? false
 		});
 	}

--- a/Core/src/data/events/PossibilityOutcome.ts
+++ b/Core/src/data/events/PossibilityOutcome.ts
@@ -432,6 +432,12 @@ export interface PossibilityOutcome {
 	forceStayInCity?: boolean;
 
 	/**
+	 * Prevent the player from staying in the city after the outcome while still
+	 * allowing them to choose their next destination.
+	 */
+	forceLeaveCity?: boolean;
+
+	/**
 	 * Tags
 	 */
 	tags?: string[];


### PR DESCRIPTION
## Summary

- add a big-event outcome flag that prevents staying in a city while preserving destination selection
- apply it to departure outcomes in Coco Village events 34 and 50
- add regression tests for both event resources

## Validation

- `cd Core && pnpm tsc`
- `cd Core && pnpm eslint`
- `cd Core && pnpm test` (1,503 tests)

Fixes #4487
