### PR TITLE
Prevent mission updates from restoring stale player state

### DIFF
--- a/Core/__tests__/PossibilityOutcome.test.ts
+++ b/Core/__tests__/PossibilityOutcome.test.ts
@@ -30,7 +30,56 @@ vi.mock("../../Lib/src/utils/RandomUtils", () => ({
 	}
 }));
 
+vi.mock("../src/core/blessings/BlessingManager", () => ({
+	BlessingManager: {
+		getInstance: () => ({
+			applyMoneyBlessing: (amount: number): number => amount
+		})
+	}
+}));
+
 describe("applyPossibilityOutcome", () => {
+	it("persists money lost before experience reloads the player", async () => {
+		let persistedMoney = 1000;
+		const player = Object.create(Player.prototype) as Player;
+		Object.assign(player, {
+			id: 1,
+			level: 10,
+			money: persistedMoney,
+			effectDuration: 0,
+			effectId: "",
+			addEnergy: vi.fn(),
+			addExperience: vi.fn(async () => {
+				player.money = persistedMoney;
+				return player;
+			}),
+			addHealth: vi.fn().mockResolvedValue(undefined),
+			addMoney: vi.fn(async ({ amount }: { amount: number }) => {
+				player.money += amount;
+				return player;
+			}),
+			addScore: vi.fn().mockResolvedValue(undefined),
+			addTokens: vi.fn().mockResolvedValue(undefined),
+			save: vi.fn(async () => {
+				persistedMoney = player.money;
+				return player;
+			}),
+			setLastReportWithEffect: vi.fn().mockResolvedValue(undefined)
+		});
+
+		await applyPossibilityOutcome({
+			eventId: 1,
+			possibilityName: "loseMoney",
+			outcome: ["1", { money: -100 }],
+			time: 0
+		}, player, {} as PacketContext, []);
+
+		expect(player.money).toBe(900);
+		expect(player.save).toHaveBeenCalledOnce();
+		expect(vi.mocked(player.save).mock.invocationCallOrder[0])
+			.toBeLessThan(vi.mocked(player.addExperience).mock.invocationCallOrder[0]);
+	});
+
 	it("keeps experience and health gained when experience reloads the player", async () => {
 		const persistedHealth = 1;
 		const initialExperience = 100;

--- a/Core/__tests__/core/report/ReportTokenMerchantService.test.ts
+++ b/Core/__tests__/core/report/ReportTokenMerchantService.test.ts
@@ -1,0 +1,114 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+import type { PacketContext } from "../../../../Lib/src/packets/CrowniclesPacket";
+import { ReactionCollectorTokenMerchantBuyReaction } from "../../../../Lib/src/packets/interaction/ReactionCollectorTokenMerchant";
+import { ShopConstants } from "../../../../Lib/src/constants/ShopConstants";
+import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
+import type { Player } from "../../../src/core/database/game/models/Player";
+import { LogsReadRequests } from "../../../src/core/database/logs/LogsReadRequests";
+import { openTokenMerchant } from "../../../src/core/report/ReportTokenMerchantService";
+import { withLockedPlayerAndMissions } from "../../../src/core/utils/withLockedPlayerAndMissions";
+
+let capturedEndCallback: ((collector: { getFirstReaction: () => unknown }, response: unknown[]) => Promise<void>) | undefined;
+
+vi.mock("../../../src/app", () => ({
+	crowniclesInstance: {
+		logsDatabase: {
+			logClassicalShopBuyout: vi.fn().mockResolvedValue(undefined)
+		}
+	}
+}));
+
+vi.mock("../../../src/core/database/logs/LogsReadRequests", () => ({
+	LogsReadRequests: {
+		getAmountOfTokensBoughtByPlayerToday: vi.fn(),
+		getAmountOfTokensBoughtByPlayerThisWeek: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/missions/MissionsController", () => ({
+	MissionsController: {
+		update: vi.fn().mockResolvedValue(undefined)
+	}
+}));
+
+vi.mock("../../../src/core/utils/BlockingUtils", () => ({
+	BlockingUtils: {
+		blockPlayerUntil: vi.fn(),
+		unblockPlayer: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/utils/ReactionsCollector", () => ({
+	ReactionCollectorInstance: class {
+		constructor(_collector: unknown, _context: unknown, _options: unknown, endCallback: typeof capturedEndCallback) {
+			capturedEndCallback = endCallback;
+		}
+
+		block(): this {
+			return this;
+		}
+
+		build(): this {
+			return this;
+		}
+	}
+}));
+
+vi.mock("../../../src/core/utils/withLockedPlayerAndMissions", () => ({
+	withLockedPlayerAndMissions: vi.fn()
+}));
+
+describe("ReportTokenMerchantService", () => {
+	const player = {
+		id: 1,
+		keycloakId: "token-buyer",
+		money: 5000,
+		tokens: 0,
+		spendMoney: vi.fn().mockResolvedValue(undefined),
+		addTokens: vi.fn().mockResolvedValue(undefined),
+		save: vi.fn().mockResolvedValue(undefined)
+	};
+
+	beforeEach(() => {
+		capturedEndCallback = undefined;
+		vi.clearAllMocks();
+		vi.mocked(LogsReadRequests.getAmountOfTokensBoughtByPlayerToday).mockResolvedValue(0);
+		vi.mocked(LogsReadRequests.getAmountOfTokensBoughtByPlayerThisWeek).mockResolvedValue(0);
+		vi.mocked(withLockedPlayerAndMissions).mockImplementation(async (_playerId, callback) => await callback(player as Player));
+	});
+
+	it("persists the money deduction before granting tokens", async () => {
+		await openTokenMerchant(player as Player, {} as PacketContext, []);
+
+		if (!capturedEndCallback) {
+			throw new Error("Expected token merchant collector callback to be set");
+		}
+		const response: unknown[] = [];
+		await capturedEndCallback({
+			getFirstReaction: () => ({
+				reaction: {
+					type: ReactionCollectorTokenMerchantBuyReaction.name,
+					data: { amount: 5 }
+				}
+			})
+		}, response);
+
+		expect(player.spendMoney).toHaveBeenCalledWith({
+			amount: 5 * ShopConstants.TOKEN_PRICE,
+			response,
+			reason: NumberChangeReason.SHOP
+		});
+		expect(player.addTokens).toHaveBeenCalledWith({
+			amount: 5,
+			response,
+			reason: NumberChangeReason.SHOP
+		});
+		expect(player.save).toHaveBeenCalledTimes(2);
+		expect(player.spendMoney.mock.invocationCallOrder[0])
+			.toBeLessThan(player.save.mock.invocationCallOrder[0]);
+		expect(player.save.mock.invocationCallOrder[0])
+			.toBeLessThan(player.addTokens.mock.invocationCallOrder[0]);
+	});
+});

--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "6.0.2",
+  "version": "6.0.2.a",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/main.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Core/src/commands/admin/testCommands/Player/SetupPlayerTestCommand.ts
+++ b/Core/src/commands/admin/testCommands/Player/SetupPlayerTestCommand.ts
@@ -39,6 +39,14 @@ export const commandInfo: ITestCommand = {
 const setupPlayerTestCommand: ExecuteTestCommandLike = async (player, _args, response, _context) => {
 	const results: string[] = [];
 
+	// Money
+	await player.addMoney({
+		amount: SETUP_DEFAULTS.money - player.money,
+		response,
+		reason: NumberChangeReason.TEST
+	});
+	results.push(`${SETUP_DEFAULTS.money} :moneybag:`);
+
 	// Level & stats
 	player.level = SETUP_DEFAULTS.level;
 	player.score = SETUP_DEFAULTS.score;
@@ -51,14 +59,6 @@ const setupPlayerTestCommand: ExecuteTestCommandLike = async (player, _args, res
 	player.setHealthNoCheck(player.getMaxHealth());
 	crowniclesInstance.logsDatabase.logLevelChange(player.keycloakId, player.level).then();
 	results.push(`Niveau ${SETUP_DEFAULTS.level}, ${SETUP_DEFAULTS.score} points`);
-
-	// Money
-	await player.addMoney({
-		amount: SETUP_DEFAULTS.money - player.money,
-		response,
-		reason: NumberChangeReason.TEST
-	});
-	results.push(`${SETUP_DEFAULTS.money} :moneybag:`);
 
 	// Gems
 	const missionInfo = await PlayerMissionsInfos.getOfPlayer(player.id);

--- a/Core/src/core/report/ReportBigEventService.ts
+++ b/Core/src/core/report/ReportBigEventService.ts
@@ -150,6 +150,7 @@ async function applyLockedOutcomeUnderLock(
 		event, possibility, randomOutcome, time
 	} = outcomeContext;
 	lockedPlayer.nextEvent = null;
+	await lockedPlayer.save();
 
 	const newMapLink = await applyPossibilityOutcome({
 		eventId: event.id,

--- a/Core/src/core/report/ReportTokenMerchantService.ts
+++ b/Core/src/core/report/ReportTokenMerchantService.ts
@@ -112,6 +112,7 @@ async function buyTokens(
 			response,
 			reason: NumberChangeReason.SHOP
 		});
+		await lockedPlayer.save();
 		await lockedPlayer.addTokens({
 			amount,
 			response,

--- a/Core/src/data/events/PossibilityOutcome.ts
+++ b/Core/src/data/events/PossibilityOutcome.ts
@@ -108,7 +108,7 @@ async function applyOutcomeHealth(outcome: PossibilityOutcome, player: Player, r
 	return 0;
 }
 
-async function applyOutcomeMoney(outcome: PossibilityOutcome, time: number, player: Player, response: CrowniclesPacket[]): Promise<number> {
+async function applyOutcomeMoneyUnderLock(outcome: PossibilityOutcome, time: number, player: Player, response: CrowniclesPacket[]): Promise<number> {
 	let moneyChange = (outcome.money ?? 0) + Math.round(time / 10 + RandomUtils.crowniclesRandom.integer(0, time / 10 + player.level / 5 - 1));
 	if (outcome.money && outcome.money < 0 && moneyChange > 0) {
 		moneyChange = Math.floor(outcome.money / 2);
@@ -131,6 +131,9 @@ async function applyOutcomeMoney(outcome: PossibilityOutcome, time: number, play
 			amount: moneyChange,
 			reason: NumberChangeReason.BIG_EVENT
 		});
+	}
+	if (!isMoneyChangePositive) {
+		await player.save();
 	}
 	return BlessingManager.getInstance().applyMoneyBlessing(moneyChange);
 }
@@ -270,7 +273,7 @@ export async function applyPossibilityOutcome(possibilityOutcome: ApplyOutcome, 
 	const score = await applyOutcomeScore(possibilityOutcome.outcome[1], possibilityOutcome.time, player, response);
 
 	// Money
-	const money = await applyOutcomeMoney(possibilityOutcome.outcome[1], possibilityOutcome.time, player, response);
+	const money = await applyOutcomeMoneyUnderLock(possibilityOutcome.outcome[1], possibilityOutcome.time, player, response);
 
 	// Gems
 	const gems = await applyOutcomeGems(possibilityOutcome.outcome[1], player);

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "6.0.2",
+  "version": "6.0.2.a",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "6.0.2",
+  "version": "6.0.2.a",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "6.0.2",
+  "version": "6.0.2.a",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
Corrige les mutations de joueur perdues lorsqu’une mise à jour de mission rechargeait un état obsolète.

- sauvegarde le débit avant d’ajouter les jetons achetés ;
- conserve les pertes d’argent des grands événements avant les récompenses suivantes ;
- persiste la consommation d’un événement forcé avant d’appliquer son résultat ;
- évite que la commande admin `setup` restaure les anciennes statistiques ;
- ajoute des régressions pour le marchand de jetons et les pertes d’argent des grands événements.

Audit complémentaire : les autres pertes d’argent sauvegardent leur état avant une opération susceptible de recharger le joueur, et les gains positifs séquentiels sont déjà persistés par leurs mises à jour de mission.

Validations :
- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` (1509 tests)
- test d’intégration `do-possibility-locked-outcome.race.integration.test.ts`

Closes #4544