### PR TITLE
Scale PvP fight money rewards by league

### DIFF
--- a/Core/__tests__/core/data/League.test.ts
+++ b/Core/__tests__/core/data/League.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { LeagueInfoConstants } from "../../../../Lib/src/constants/LeagueInfoConstants";
+import { League } from "../../../src/data/League";
+
+describe("League", () => {
+	it("returns its configured PvP fight win money reward", () => {
+		for (const [leagueId, expectedReward] of LeagueInfoConstants.FIGHT_WIN_MONEY_REWARDS.entries()) {
+			const league = new League();
+			league.id = leagueId;
+
+			expect(league.getFightWinMoneyReward()).toBe(expectedReward);
+		}
+	});
+});

--- a/Core/src/commands/player/FightCommand.ts
+++ b/Core/src/commands/player/FightCommand.ts
@@ -131,9 +131,11 @@ async function calculateMoneyReward(
 	fightInitiatorInformation: FightInitiatorInformation,
 	response: CrowniclesPacket[]
 ): Promise<number> {
+	const winMoneyReward = fightInitiatorInformation.initiatorPlayer.getLeague().getFightWinMoneyReward();
+
 	// Determine the bonus to reward based on a game result
 	const bonusByResult = {
-		[EloGameResult.WIN]: FightConstants.REWARDS.WIN_MONEY_BONUS,
+		[EloGameResult.WIN]: winMoneyReward,
 		[EloGameResult.DRAW]: FightConstants.REWARDS.DRAW_MONEY_BONUS,
 		[EloGameResult.LOSS]: FightConstants.REWARDS.LOSS_MONEY_BONUS
 	};
@@ -145,14 +147,15 @@ async function calculateMoneyReward(
 	const lossCount = summary.played - (summary.draw + summary.won);
 
 	const alreadyAwardedMoney =
-		summary.won * FightConstants.REWARDS.WIN_MONEY_BONUS
+		summary.won * winMoneyReward
 		+ summary.draw * FightConstants.REWARDS.DRAW_MONEY_BONUS
 		+ lossCount * FightConstants.REWARDS.LOSS_MONEY_BONUS;
+	const maxMoneyBonus = winMoneyReward * FightConstants.REWARDS.MAX_REWARDED_WINS;
 
 	// Apply cap to money rewards if necessary
-	if (alreadyAwardedMoney > FightConstants.REWARDS.MAX_MONEY_BONUS) {
+	if (alreadyAwardedMoney > maxMoneyBonus) {
 		extraMoneyBonus = Math.max(
-			FightConstants.REWARDS.MAX_MONEY_BONUS - (alreadyAwardedMoney - extraMoneyBonus),
+			maxMoneyBonus - (alreadyAwardedMoney - extraMoneyBonus),
 			0
 		);
 	}

--- a/Core/src/data/League.ts
+++ b/Core/src/data/League.ts
@@ -11,6 +11,12 @@ export class League extends Data<number> {
 
 	public readonly maxGloryPoints!: number;
 
+	/**
+	 * Get the amount of money awarded for a PvP fight win
+	 */
+	public getFightWinMoneyReward(): number {
+		return LeagueInfoConstants.FIGHT_WIN_MONEY_REWARDS[this.id];
+	}
 
 	/**
 	 * Get the amount of money to award to the player

--- a/Lib/src/constants/FightConstants.ts
+++ b/Lib/src/constants/FightConstants.ts
@@ -17,10 +17,9 @@ export abstract class FightConstants {
 	static readonly REWARDS = {
 		NUMBER_OF_WIN_THAT_AWARD_SCORE_BONUS: 3,
 		SCORE_BONUS_AWARD: 35,
-		WIN_MONEY_BONUS: 750,
 		DRAW_MONEY_BONUS: 150,
 		LOSS_MONEY_BONUS: 10,
-		MAX_MONEY_BONUS: 3750
+		MAX_REWARDED_WINS: 5
 	};
 
 	static readonly POTION_NO_DRINK_PROBABILITY = {

--- a/Lib/src/constants/LeagueInfoConstants.ts
+++ b/Lib/src/constants/LeagueInfoConstants.ts
@@ -1,15 +1,15 @@
 export abstract class LeagueInfoConstants {
 	static readonly FIGHT_WIN_MONEY_REWARDS = [
 		200, // Wood
-		255, // Rock
-		310, // Iron
-		365, // Bronze
-		420, // Silver
-		475, // Gold
-		530, // Diamond
-		585, // Elite
-		640, // Infinite
-		695, // Legendary
+		250, // Rock
+		300, // Iron
+		350, // Bronze
+		400, // Silver
+		450, // Gold
+		500, // Diamond
+		550, // Elite
+		600, // Infinite
+		650, // Legendary
 		750 // Royal
 	];
 

--- a/Lib/src/constants/LeagueInfoConstants.ts
+++ b/Lib/src/constants/LeagueInfoConstants.ts
@@ -1,4 +1,18 @@
 export abstract class LeagueInfoConstants {
+	static readonly FIGHT_WIN_MONEY_REWARDS = [
+		200, // Wood
+		255, // Rock
+		310, // Iron
+		365, // Bronze
+		420, // Silver
+		475, // Gold
+		530, // Diamond
+		585, // Elite
+		640, // Infinite
+		695, // Legendary
+		750 // Royal
+	];
+
 	static readonly MONEY_TO_AWARD = [
 		250, // Wood
 		300, // Rock

--- a/Lib/tests/constants/FightConstants.test.ts
+++ b/Lib/tests/constants/FightConstants.test.ts
@@ -12,9 +12,10 @@ describe("FightConstants PvP rewards", () => {
 		expect(winRewards).toHaveLength(LeagueInfoConstants.MONEY_TO_AWARD.length);
 		expect(winRewards[0]).toBe(200);
 		expect(winRewards[LeagueInfoConstants.ROYAL_LEAGUE_ID]).toBe(750);
-		for (let leagueId = 1; leagueId < winRewards.length; leagueId++) {
-			expect(winRewards[leagueId] - winRewards[leagueId - 1]).toBe(55);
+		for (let leagueId = 1; leagueId < LeagueInfoConstants.ROYAL_LEAGUE_ID; leagueId++) {
+			expect(winRewards[leagueId] - winRewards[leagueId - 1]).toBe(50);
 		}
+		expect(winRewards[LeagueInfoConstants.ROYAL_LEAGUE_ID] - winRewards[LeagueInfoConstants.ROYAL_LEAGUE_ID - 1]).toBe(100);
 	});
 
 	it("does not make intentional losses or draws more profitable than a Wood league win", () => {

--- a/Lib/tests/constants/FightConstants.test.ts
+++ b/Lib/tests/constants/FightConstants.test.ts
@@ -1,16 +1,27 @@
 import {describe, expect, it} from "vitest";
 import {FightConstants} from "../../src/constants/FightConstants";
+import {LeagueInfoConstants} from "../../src/constants/LeagueInfoConstants";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import {CrowniclesIcons} from "../../src/CrowniclesIcons";
 
 describe("FightConstants PvP rewards", () => {
-	it("rewards active play without making intentional losses profitable", () => {
+	it("scales win rewards progressively from Wood to Royal league", () => {
+		const winRewards = LeagueInfoConstants.FIGHT_WIN_MONEY_REWARDS;
+
+		expect(winRewards).toHaveLength(LeagueInfoConstants.MONEY_TO_AWARD.length);
+		expect(winRewards[0]).toBe(200);
+		expect(winRewards[LeagueInfoConstants.ROYAL_LEAGUE_ID]).toBe(750);
+		for (let leagueId = 1; leagueId < winRewards.length; leagueId++) {
+			expect(winRewards[leagueId] - winRewards[leagueId - 1]).toBe(55);
+		}
+	});
+
+	it("does not make intentional losses or draws more profitable than a Wood league win", () => {
 		const rewards = FightConstants.REWARDS;
 
-		expect(rewards.WIN_MONEY_BONUS * 5).toBe(rewards.MAX_MONEY_BONUS);
-		expect(rewards.LOSS_MONEY_BONUS * 5).toBeLessThan(rewards.WIN_MONEY_BONUS);
-		expect(rewards.DRAW_MONEY_BONUS).toBeLessThan(rewards.WIN_MONEY_BONUS);
+		expect(rewards.LOSS_MONEY_BONUS * rewards.MAX_REWARDED_WINS).toBeLessThan(LeagueInfoConstants.FIGHT_WIN_MONEY_REWARDS[0]);
+		expect(rewards.DRAW_MONEY_BONUS).toBeLessThan(LeagueInfoConstants.FIGHT_WIN_MONEY_REWARDS[0]);
 	});
 });
 


### PR DESCRIPTION
Fait dépendre la récompense en argent d'une victoire PvP de la ligue du joueur.

- attribue 200 pièces en ligue Bois, puis augmente la récompense de 50 par ligue jusqu'à 650 en ligue Légendaire ;
- porte la récompense à 750 en ligue Royale, soit un dernier palier de 100 pièces ;
- conserve le plafond quotidien à l'équivalent de cinq victoires dans la ligue courante ;
- ajoute des tests sur la progression et la récupération de la récompense par le modèle de ligue.

Validations :
- `pnpm eslint` dans Core et Lib
- `pnpm tsc` dans Core et Lib
- `pnpm test` dans Core (1510 tests)
- `pnpm test` dans Lib (580 tests)

Closes #4546