### PR TITLE
Preserve player state across nested mission updates

### DIFF
--- a/Core/__tests__-integration/handlers/small-event-player-state.integration.test.ts
+++ b/Core/__tests__-integration/handlers/small-event-player-state.integration.test.ts
@@ -9,8 +9,9 @@ import type { Player as PlayerType } from "../../src/core/database/game/models/P
 import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
 import type { MissionSlot as MissionSlotType } from "../../src/core/database/game/models/MissionSlot";
 import type { DailyMission as DailyMissionType } from "../../src/core/database/game/models/DailyMission";
-import type { PacketContext } from "../../../Lib/src/packets/CrowniclesPacket";
-import type { CrowniclesPacket } from "../../../Lib/src/packets/CrowniclesPacket";
+import type {
+	CrowniclesPacket, PacketContext
+} from "../../../Lib/src/packets/CrowniclesPacket";
 import type { SmallEventClassPacket } from "../../../Lib/src/packets/smallEvents/SmallEventClassPacket";
 
 type ReportSmallEventModule = typeof import("../../src/core/report/ReportSmallEventService");

--- a/Core/__tests__-integration/handlers/small-event-player-state.integration.test.ts
+++ b/Core/__tests__-integration/handlers/small-event-player-state.integration.test.ts
@@ -1,0 +1,179 @@
+import {
+	afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
+import type { MissionSlot as MissionSlotType } from "../../src/core/database/game/models/MissionSlot";
+import type { DailyMission as DailyMissionType } from "../../src/core/database/game/models/DailyMission";
+import type { PacketContext } from "../../../Lib/src/packets/CrowniclesPacket";
+import type { CrowniclesPacket } from "../../../Lib/src/packets/CrowniclesPacket";
+import type { SmallEventClassPacket } from "../../../Lib/src/packets/smallEvents/SmallEventClassPacket";
+
+type ReportSmallEventModule = typeof import("../../src/core/report/ReportSmallEventService");
+type RandomUtilsModule = typeof import("../../../Lib/src/utils/RandomUtils");
+type ClassConstantsModule = typeof import("../../../Lib/src/constants/ClassConstants");
+type LogsConstantsModule = typeof import("../../../Lib/src/constants/LogsConstants");
+
+const HEALTH_GAIN = 3;
+const OTHER_CLASS_ID = 17;
+const INITIAL_HEALTH = 5;
+
+describe("small event player state", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let PlayerMissionsInfo: ModelStatic<PlayerMissionsInfoType>;
+	let MissionSlot: ModelStatic<MissionSlotType>;
+	let DailyMission: ModelStatic<DailyMissionType>;
+	let reportSmallEvent: ReportSmallEventModule;
+	let randomUtils: RandomUtilsModule;
+	let classConstants: ClassConstantsModule;
+	let logsConstants: LogsConstantsModule;
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("smalleventstate");
+		Player = env.crownicles.gameDatabase.sequelize.models.Player as ModelStatic<PlayerType>;
+		PlayerMissionsInfo = env.crownicles.gameDatabase.sequelize.models.PlayerMissionsInfo as ModelStatic<PlayerMissionsInfoType>;
+		MissionSlot = env.crownicles.gameDatabase.sequelize.models.MissionSlot as ModelStatic<MissionSlotType>;
+		DailyMission = env.crownicles.gameDatabase.sequelize.models.DailyMission as ModelStatic<DailyMissionType>;
+		reportSmallEvent = loadProductionModule<ReportSmallEventModule>("core/report/ReportSmallEventService");
+		randomUtils = loadProductionModule<RandomUtilsModule>("../../Lib/src/utils/RandomUtils");
+		classConstants = loadProductionModule<ClassConstantsModule>("../../Lib/src/constants/ClassConstants");
+		logsConstants = loadProductionModule<LogsConstantsModule>("../../Lib/src/constants/LogsConstants");
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await DailyMission.destroy({ truncate: true, force: true });
+			await MissionSlot.destroy({ truncate: true, force: true });
+			await PlayerMissionsInfo.destroy({ truncate: true, force: true });
+			await Player.destroy({ truncate: true, force: true });
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	it("persists class event health before the doReports mission update", async () => {
+		const player = await Player.create({
+			keycloakId: "small-event-health",
+			class: OTHER_CLASS_ID,
+			health: INITIAL_HEALTH
+		});
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		await MissionSlot.create({
+			playerId: player.id,
+			missionId: "earnMoney",
+			missionVariant: 0,
+			missionObjective: 100,
+			numberDone: 0,
+			expiresAt: new Date(Date.now() + 3_600_000),
+			gemsToWin: 0,
+			pointsToWin: 0,
+			xpToWin: 0,
+			moneyToWin: 0
+		});
+		await DailyMission.create({
+			id: 0,
+			missionId: "doReports",
+			missionObjective: 100,
+			missionVariant: 0,
+			gemsToWin: 0,
+			xpToWin: 0,
+			pointsToWin: 0,
+			moneyToWin: 0,
+			lastDate: new Date()
+		});
+		vi.spyOn(randomUtils.RandomUtils.crowniclesRandom, "pick")
+			.mockReturnValue(classConstants.ClassConstants.CLASS_SMALL_EVENT_INTERACTIONS_NAMES.WIN_HEALTH);
+		vi.spyOn(randomUtils.RandomUtils, "rangedInt").mockReturnValue(HEALTH_GAIN);
+		const response: CrowniclesPacket[] = [];
+
+		await reportSmallEvent.executeSmallEvent(response, player, {} as PacketContext, "class");
+
+		expect(response).toEqual(expect.arrayContaining([
+			expect.objectContaining<Partial<SmallEventClassPacket>>({
+				interactionName: classConstants.ClassConstants.CLASS_SMALL_EVENT_INTERACTIONS_NAMES.WIN_HEALTH
+			})
+		]));
+		const freshPlayer = await Player.findByPk(player.id);
+		expect(freshPlayer?.getHealthValue()).toBe(INITIAL_HEALTH + HEALTH_GAIN);
+	});
+
+	it("persists health atomically with mission state", async () => {
+		const player = await Player.create({
+			keycloakId: "direct-health",
+			class: OTHER_CLASS_ID,
+			health: INITIAL_HEALTH
+		});
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		await DailyMission.create({
+			id: 0,
+			missionId: "doReports",
+			missionObjective: 100,
+			missionVariant: 0,
+			gemsToWin: 0,
+			xpToWin: 0,
+			pointsToWin: 0,
+			moneyToWin: 0,
+			lastDate: new Date()
+		});
+
+		await player.addHealth({
+			amount: HEALTH_GAIN,
+			response: [],
+			reason: logsConstants.NumberChangeReason.SMALL_EVENT
+		});
+		expect(player.getHealthValue()).toBe(INITIAL_HEALTH + HEALTH_GAIN);
+		expect(player.changed("health")).toBe(false);
+
+		const freshPlayer = await Player.findByPk(player.id);
+		expect(freshPlayer?.getHealthValue()).toBe(INITIAL_HEALTH + HEALTH_GAIN);
+	});
+
+	it("full-heals from the locked state when the caller is stale", async () => {
+		const player = await Player.create({
+			keycloakId: "stale-full-heal",
+			class: OTHER_CLASS_ID,
+			health: INITIAL_HEALTH
+		});
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		await DailyMission.create({
+			id: 0,
+			missionId: "doReports",
+			missionObjective: 100,
+			missionVariant: 0,
+			gemsToWin: 0,
+			xpToWin: 0,
+			pointsToWin: 0,
+			moneyToWin: 0,
+			lastDate: new Date()
+		});
+		player.setHealthNoCheck(player.getMaxHealth());
+
+		await player.addHealth({
+			amount: player.getMaxHealth(),
+			response: [],
+			reason: logsConstants.NumberChangeReason.GUILD_DAILY,
+			missionHealthParameter: {
+				shouldPokeMission: true,
+				overHealCountsForMission: false
+			}
+		});
+
+		const freshPlayer = await Player.findByPk(player.id);
+		expect(freshPlayer?.getHealthValue()).toBe(player.getMaxHealth());
+	});
+});

--- a/Core/__tests__/core/missions/MissionChainStateSync.test.ts
+++ b/Core/__tests__/core/missions/MissionChainStateSync.test.ts
@@ -161,6 +161,40 @@ describe("Mission chain state synchronization", () => {
 		});
 	});
 
+	describe("Player.spendMoney", () => {
+		it("keeps money awarded by the spendMoney mission before applying the debit", async () => {
+			const player = createTestPlayer({ money: 1000 });
+			vi.spyOn(MissionsController, "update").mockResolvedValue(createTestPlayer({ money: 1100 }));
+
+			await player.spendMoney({
+				amount: 50,
+				response,
+				reason: NumberChangeReason.SHOP
+			});
+
+			expect(player.money).toBe(1050);
+		});
+	});
+
+	describe("Player.levelUpIfNeeded", () => {
+		it("does not emit level-up effects when the locked player already leveled", async () => {
+			const player = createTestPlayer();
+			player.needLevelUp = vi.fn().mockReturnValue(true);
+			player.addLevelUpPacket = vi.fn();
+			vi.spyOn(MissionsController, "update").mockImplementation(async (inputPlayer, _response, opts) => {
+				opts.applyOnLockedPlayer?.({
+					...inputPlayer,
+					needLevelUp: () => false
+				} as Player);
+				return inputPlayer;
+			});
+
+			await player.levelUpIfNeeded(response);
+
+			expect(player.addLevelUpPacket).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("Player.addScore", () => {
 		it("should sync changes from mission rewards when earning score", async () => {
 			const player = createTestPlayer({ score: 100, experience: 500 });
@@ -210,5 +244,6 @@ describe("Mission chain state synchronization", () => {
 			expect(player.weeklyScore).toBe(250);
 		});
 	});
+
 });
 

--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "6.0.2.a",
+  "version": "6.0.2.b",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/main.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Core/src/commands/player/ClassesCommand.ts
+++ b/Core/src/commands/player/ClassesCommand.ts
@@ -69,12 +69,12 @@ function getEndCallback(player: Player) {
 		player.setEnergyLost(Math.ceil(
 			player.fightPointsLost / oldClass.getMaxCumulativeEnergyValue(level) * newClass.getMaxCumulativeEnergyValue(level)
 		), NumberChangeReason.CLASS, playerActiveObjects);
-		await MissionsController.update(player, response, { missionId: "chooseClass" });
-		await MissionsController.update(player, response, {
+		await player.save();
+		Object.assign(player, await MissionsController.update(player, response, { missionId: "chooseClass" }));
+		Object.assign(player, await MissionsController.update(player, response, {
 			missionId: "chooseClassTier",
 			params: { tier: newClass.classGroup }
-		});
-		await player.save();
+		}));
 		crowniclesInstance?.logsDatabase.logPlayerClassChange(player.keycloakId, newClass.id)
 			.then();
 

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -353,12 +353,15 @@ export class Player extends Model {
 	 * @param parameters
 	 */
 	public async spendMoney(parameters: EditValueParameters): Promise<Player> {
-		await MissionsController.update(this, parameters.response, {
+		const newPlayer = await MissionsController.update(this, parameters.response, {
 			missionId: "spendMoney",
 			count: parameters.amount
 		});
-		parameters.amount = -parameters.amount;
-		return this.addMoney(parameters);
+		Object.assign(this, newPlayer);
+		return this.addMoney({
+			...parameters,
+			amount: -parameters.amount
+		});
 	}
 
 	/**
@@ -504,6 +507,7 @@ export class Player extends Model {
 			return;
 		}
 
+		let didLevelUp = false;
 		Object.assign(this, await MissionsController.update(this, response, {
 			missionId: "reachLevel",
 			count: locked => locked.level,
@@ -519,8 +523,12 @@ export class Player extends Model {
 				}
 				locked.experience -= locked.getExperienceNeededToLevelUp();
 				locked.level += 1;
+				didLevelUp = true;
 			}
 		}));
+		if (!didLevelUp) {
+			return;
+		}
 		crowniclesInstance?.logsDatabase.logExperienceChange(this.keycloakId, this.experience, NumberChangeReason.LEVEL_UP)
 			.then();
 		crowniclesInstance?.logsDatabase.logLevelChange(this.keycloakId, this.level)
@@ -1306,13 +1314,24 @@ export class Player extends Model {
 		shouldPokeMission: true
 	}): Promise<void> {
 		const maxHealth = this.getMaxHealth();
-		const difference = (health > maxHealth && !missionHealthParameter.overHealCountsForMission ? maxHealth : health < 0 ? 0 : health)
-			- this.health;
-		if (difference > 0 && missionHealthParameter.shouldPokeMission) {
-			await MissionsController.update(this, response, {
+		const healthDelta = health - this.health;
+		if (healthDelta > 0 && missionHealthParameter.shouldPokeMission) {
+			let lockedDifference = 0;
+			const updatedPlayer = await MissionsController.update(this, response, {
 				missionId: "earnLifePoints",
-				count: difference
+				count: () => lockedDifference,
+				applyOnLockedPlayer: locked => {
+					const lockedMaxHealth = locked.getMaxHealth();
+					const lockedHealth = Math.min(locked.health, lockedMaxHealth);
+					const requestedHealth = lockedHealth + healthDelta;
+					lockedDifference = (requestedHealth > lockedMaxHealth && !missionHealthParameter.overHealCountsForMission
+						? lockedMaxHealth
+						: requestedHealth < 0 ? 0 : requestedHealth) - lockedHealth;
+					locked.health = MathUtils.clamp(requestedHealth, 0, lockedMaxHealth);
+				}
 			});
+			Object.assign(this, updatedPlayer);
+			return;
 		}
 		if (health < 0) {
 			this.health = 0;

--- a/Core/src/core/report/ReportCityNotaryService.ts
+++ b/Core/src/core/report/ReportCityNotaryService.ts
@@ -68,6 +68,7 @@ async function persistApartmentBuyUnderLock(params: {
 		amount: price,
 		reason: NumberChangeReason.APARTMENT_BUY
 	});
+	await lockedPlayer.save();
 	try {
 		await Apartment.create({
 			ownerId: lockedPlayer.id,

--- a/Core/src/core/report/ReportSmallEventService.ts
+++ b/Core/src/core/report/ReportSmallEventService.ts
@@ -121,6 +121,7 @@ async function loadAndExecuteSmallEvent(
 	try {
 		const smallEventModule = require.resolve(`../smallEvents/${filename}`);
 		try {
+			// skipcq: JS-0359 - Small event handlers are discovered dynamically from resource names.
 			const smallEvent: SmallEventFuncs = require(smallEventModule).smallEventFuncs;
 			await crowniclesInstance.logsDatabase.logSmallEvent(player.keycloakId, event);
 

--- a/Core/src/core/report/ReportSmallEventService.ts
+++ b/Core/src/core/report/ReportSmallEventService.ts
@@ -124,7 +124,7 @@ async function loadAndExecuteSmallEvent(
 			const smallEvent: SmallEventFuncs = require(smallEventModule).smallEventFuncs;
 			await crowniclesInstance.logsDatabase.logSmallEvent(player.keycloakId, event);
 
-			await runSmallEventUnderPlayerLock(player, event, smallEvent, response, context, playerActiveObjects);
+			await runSmallEventUnderLock(player, event, smallEvent, response, context, playerActiveObjects);
 		}
 		catch (e) {
 			CrowniclesLogger.errorWithObj(`Error while executing ${filename} small event`, e);
@@ -149,7 +149,7 @@ async function loadAndExecuteSmallEvent(
  * their setup phase only — the deferred callback re-locks itself
  * (handled per file in PR-H2).
  */
-async function runSmallEventUnderPlayerLock(
+async function runSmallEventUnderLock(
 	player: Player,
 	event: string,
 	smallEvent: SmallEventFuncs,
@@ -167,6 +167,7 @@ async function runSmallEventUnderPlayerLock(
 		const smallEventRecord = PlayerSmallEvents.createPlayerSmallEvent(lockedPlayer.id, event, Date.now());
 		await smallEventRecord.save();
 		await smallEvent.executeSmallEvent(response, lockedPlayer, context, playerActiveObjects);
+		await lockedPlayer.save();
 		await MissionsController.update(lockedPlayer, response, { missionId: "doReports" });
 	});
 }

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "6.0.2.a",
+  "version": "6.0.2.b",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "6.0.2.a",
+  "version": "6.0.2.b",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "6.0.2.a",
+  "version": "6.0.2.b",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
Complète la correction des états de joueur écrasés par des mises à jour de mission imbriquées.

- applique et persiste les soins sur le joueur verrouillé ;
- conserve les récompenses de mission avant une dépense ;
- évite les effets de level-up dupliqués sur un appelant obsolète ;
- sauvegarde les mutations des petits événements avant `doReports` ;
- préserve la classe et l’énergie pendant les missions de changement de classe ;
- rend le remboursement défensif du notaire strictement neutre ;
- passe les quatre modules en version `6.0.2.b`.

Validations :
- `pnpm eslint` dans Core
- `pnpm tsc` dans Core
- `pnpm test` dans Core (1511 tests)
- intégration MariaDB `small-event-player-state.integration.test.ts` (3 tests)

Closes #4549