### PR TITLE
Fix spendMoney state regressions

### DIFF
--- a/Core/__tests__/core/commands/guild/GuildCreateCommand.test.ts
+++ b/Core/__tests__/core/commands/guild/GuildCreateCommand.test.ts
@@ -109,6 +109,9 @@ describe("GuildCreateCommand", () => {
 		vi.clearAllMocks();
 		player.guildId = null;
 		player.money = GuildCreateConstants.PRICE;
+		player.spendMoney.mockImplementation(async () => {
+			player.guildId = null;
+		});
 		vi.mocked(Guilds.getByName).mockResolvedValue(null);
 		vi.mocked(Guild.create).mockResolvedValue(newGuild as never);
 		vi.mocked(PlayerMissionsInfos.getOfPlayer).mockResolvedValue(null as never);
@@ -138,5 +141,8 @@ describe("GuildCreateCommand", () => {
 			chiefId: player.id,
 			treasury: GuildCreateConstants.INITIAL_TREASURY
 		});
+		expect(player.guildId).toBe(newGuild.id);
+		expect(player.spendMoney.mock.invocationCallOrder[0])
+			.toBeLessThan(player.save.mock.invocationCallOrder[0]);
 	});
 });

--- a/Core/__tests__/core/report/ReportCityInnService.test.ts
+++ b/Core/__tests__/core/report/ReportCityInnService.test.ts
@@ -1,0 +1,98 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
+import type { ReactionCollectorInnMealReaction } from "../../../../Lib/src/packets/interaction/ReactionCollectorCity";
+import type { Player } from "../../../src/core/database/game/models/Player";
+import { InventorySlots } from "../../../src/core/database/game/models/InventorySlot";
+import { MissionsController } from "../../../src/core/missions/MissionsController";
+import { handleInnMealReaction } from "../../../src/core/report/ReportCityInnService";
+import { withLockedPlayerAndMissions } from "../../../src/core/utils/withLockedPlayerAndMissions";
+
+vi.mock("../../../src/app", () => ({
+	crowniclesInstance: {
+		logsDatabase: {
+			logInnMeal: vi.fn().mockResolvedValue(undefined)
+		}
+	}
+}));
+
+vi.mock("../../../src/core/database/game/models/InventorySlot", () => ({
+	InventorySlots: {
+		getPlayerActiveObjects: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/missions/MissionsController", () => ({
+	MissionsController: {
+		update: vi.fn().mockResolvedValue(undefined)
+	}
+}));
+
+vi.mock("../../../src/core/utils/withLockedPlayerAndMissions", () => ({
+	withLockedPlayerAndMissions: vi.fn()
+}));
+
+describe("handleInnMealReaction", () => {
+	const activeObjects = {};
+	const player = {
+		id: 1,
+		keycloakId: "inn-meal-player",
+		money: 1000,
+		fightPointsLost: 10,
+		lastMealAt: null as Date | null,
+		canEat: vi.fn().mockReturnValue(true),
+		nextMealAvailableAt: vi.fn(),
+		getCumulativeEnergy: vi.fn().mockReturnValue(5),
+		spendMoney: vi.fn(),
+		addEnergy: vi.fn(),
+		eatMeal: vi.fn(),
+		save: vi.fn().mockResolvedValue(undefined),
+		getCurrentCityId: vi.fn().mockReturnValue(null)
+	};
+	const reaction = {
+		innId: "inn",
+		meal: {
+			mealId: "meal",
+			price: 100,
+			energy: 4
+		}
+	} as ReactionCollectorInnMealReaction;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		player.money = 1000;
+		player.fightPointsLost = 10;
+		player.lastMealAt = null;
+		player.canEat.mockReturnValue(true);
+		player.spendMoney.mockImplementation(async () => {
+			player.fightPointsLost = 10;
+			player.lastMealAt = null;
+		});
+		player.addEnergy.mockImplementation(() => {
+			player.fightPointsLost = 6;
+		});
+		player.eatMeal.mockImplementation(() => {
+			player.lastMealAt = new Date();
+		});
+		vi.mocked(InventorySlots.getPlayerActiveObjects).mockResolvedValue(activeObjects as never);
+		vi.mocked(withLockedPlayerAndMissions).mockImplementation(async (_playerId, callback) => await callback(player as Player));
+	});
+
+	it("applies energy and cooldown after spendMoney reloads the player", async () => {
+		await handleInnMealReaction(player as Player, reaction, []);
+
+		expect(player.spendMoney).toHaveBeenCalledWith({
+			response: expect.any(Array),
+			amount: reaction.meal.price,
+			reason: NumberChangeReason.INN_MEAL
+		});
+		expect(player.fightPointsLost).toBe(6);
+		expect(player.lastMealAt).toBeInstanceOf(Date);
+		expect(player.spendMoney.mock.invocationCallOrder[0])
+			.toBeLessThan(player.addEnergy.mock.invocationCallOrder[0]);
+		expect(player.addEnergy.mock.invocationCallOrder[0])
+			.toBeLessThan(player.save.mock.invocationCallOrder[0]);
+		expect(MissionsController.update).toHaveBeenCalledWith(player, expect.any(Array), { missionId: "innMeal" });
+	});
+});

--- a/Core/__tests__/core/smallEvents/CartSmallEvent.test.ts
+++ b/Core/__tests__/core/smallEvents/CartSmallEvent.test.ts
@@ -1,0 +1,127 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+import { ReactionCollectorAcceptReaction } from "../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
+import type { Player } from "../../../src/core/database/game/models/Player";
+import { MapLinkDataController } from "../../../src/data/MapLink";
+import { MapLocationDataController } from "../../../src/data/MapLocation";
+import { smallEventFuncs } from "../../../src/core/smallEvents/cart";
+import { PlayerSmallEvents } from "../../../src/core/database/game/models/PlayerSmallEvent";
+import { withLockedPlayerAndMissionsSafe } from "../../../src/core/utils/withLockedPlayerAndMissionsSafe";
+
+let capturedEndCallback: ((collector: { getFirstReaction: () => unknown }, response: unknown[]) => Promise<void>) | undefined;
+
+vi.mock("../../../src/app", () => ({
+	crowniclesInstance: {
+		logsDatabase: {
+			logTeleportation: vi.fn().mockResolvedValue(undefined)
+		}
+	}
+}));
+
+vi.mock("../../../src/core/database/game/models/PlayerSmallEvent", () => ({
+	PlayerSmallEvents: {
+		calculateCurrentScore: vi.fn(),
+		removeSmallEventsOfPlayer: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/utils/BlockingUtils", () => ({
+	BlockingUtils: {
+		blockPlayerUntil: vi.fn(),
+		unblockPlayer: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/utils/ReactionsCollector", () => ({
+	ReactionCollectorInstance: class {
+		constructor(_collector: unknown, _context: unknown, _options: unknown, endCallback: typeof capturedEndCallback) {
+			capturedEndCallback = endCallback;
+		}
+
+		block(): this {
+			return this;
+		}
+
+		build(): this {
+			return this;
+		}
+	}
+}));
+
+vi.mock("../../../src/core/utils/withLockedPlayerAndMissionsSafe", () => ({
+	withLockedPlayerAndMissionsSafe: vi.fn()
+}));
+
+vi.mock("../../../src/data/MapLink", () => ({
+	MapLinkDataController: {
+		instance: {
+			generateRandomMapLinkDifferentOfCurrent: vi.fn()
+		}
+	}
+}));
+
+vi.mock("../../../src/data/MapLocation", () => ({
+	MapLocationDataController: {
+		instance: {
+			getById: vi.fn()
+		}
+	}
+}));
+
+vi.mock("../../../../Lib/src/utils/RandomUtils", () => ({
+	RandomUtils: {
+		crowniclesRandom: {
+			realZeroToOneInclusive: vi.fn().mockReturnValue(0)
+		}
+	}
+}));
+
+describe("cart small event", () => {
+	const player = {
+		id: 1,
+		keycloakId: "cart-player",
+		money: 2000,
+		mapLinkId: 1,
+		addScore: vi.fn().mockResolvedValue(undefined),
+		spendMoney: vi.fn(),
+		save: vi.fn().mockResolvedValue(undefined)
+	};
+
+	beforeEach(() => {
+		capturedEndCallback = undefined;
+		vi.clearAllMocks();
+		player.money = 2000;
+		player.mapLinkId = 1;
+		player.spendMoney.mockImplementation(async () => {
+			player.mapLinkId = 1;
+		});
+		vi.mocked(MapLinkDataController.instance.generateRandomMapLinkDifferentOfCurrent).mockReturnValue({
+			id: 2,
+			endMap: 3
+		} as never);
+		vi.mocked(MapLocationDataController.instance.getById).mockReturnValue({ type: "plain" } as never);
+		vi.mocked(PlayerSmallEvents.calculateCurrentScore).mockResolvedValue(0);
+		vi.mocked(PlayerSmallEvents.removeSmallEventsOfPlayer).mockResolvedValue(undefined);
+		vi.mocked(withLockedPlayerAndMissionsSafe).mockImplementation(async (_player, _caller, callback) => {
+			await callback(player as Player);
+		});
+	});
+
+	it("applies the destination after spendMoney reloads the player", async () => {
+		smallEventFuncs.executeSmallEvent([], player as Player, {} as never);
+
+		if (!capturedEndCallback) {
+			throw new Error("Expected cart collector callback to be set");
+		}
+		await capturedEndCallback({
+			getFirstReaction: () => ({
+				reaction: { type: ReactionCollectorAcceptReaction.name }
+			})
+		}, []);
+
+		expect(player.mapLinkId).toBe(2);
+		expect(player.spendMoney.mock.invocationCallOrder[0])
+			.toBeLessThan(player.save.mock.invocationCallOrder[0]);
+	});
+});

--- a/Core/src/commands/guild/GuildCreateCommand.ts
+++ b/Core/src/commands/guild/GuildCreateCommand.ts
@@ -142,12 +142,12 @@ async function applyLockedAcceptGuildCreate(
 		chiefId: player.id,
 		treasury: GuildCreateConstants.INITIAL_TREASURY
 	});
-	player.guildId = newGuild.id;
 	await player.spendMoney({
 		amount: GuildCreateConstants.PRICE,
 		response,
 		reason: NumberChangeReason.GUILD_CREATE
 	});
+	player.guildId = newGuild.id;
 	newGuild.updateLastDailyAt();
 	await Promise.all([
 		newGuild.save(),

--- a/Core/src/commands/guild/GuildDailyCommand.ts
+++ b/Core/src/commands/guild/GuildDailyCommand.ts
@@ -67,7 +67,7 @@ async function awardGuildWithNewPet(guild: Guild, rewardPacket: CommandGuildDail
  * @param members
  * @param awardingFunctionForAMember
  */
-async function genericAwardingFunction(members: Player[], awardingFunctionForAMember: (member: Player) => Promise<void> | void): Promise<void> {
+async function genericAwardingFunction(members: Player[], awardingFunctionForAMember: (member: Player) => Promise<void>): Promise<void> {
 	for (const member of members) {
 		// We have to check if the member is not KO because if he is, he can't receive the reward
 		if (member.isDead()) {
@@ -194,8 +194,8 @@ async function alterationHealEveryMember(guildLike: GuildLike, response: Crownic
  */
 async function awardPersonalXpToMembers(guildLike: GuildLike, response: CrowniclesPacket[], rewardPacket: CommandGuildDailyRewardPacket): Promise<void> {
 	const xpWon = RandomUtils.rangedInt(GuildDailyConstants.XP, guildLike.guild.level, guildLike.guild.level * GuildDailyConstants.XP_MULTIPLIER);
-	await genericAwardingFunction(guildLike.members, member => {
-		member.addExperience({
+	await genericAwardingFunction(guildLike.members, async member => {
+		await member.addExperience({
 			amount: xpWon,
 			response,
 			reason: NumberChangeReason.GUILD_DAILY
@@ -414,8 +414,8 @@ function generateRandomProperty(guild: Guild): string {
 async function awardMoneyToMembers(guildLike: GuildLike, response: CrowniclesPacket[], rewardPacket: CommandGuildDailyRewardPacket): Promise<void> {
 	const levelUsed = Math.min(guildLike.guild.level, GuildConstants.GOLDEN_GUILD_LEVEL);
 	const moneyWon = RandomUtils.rangedInt(GuildDailyConstants.MONEY, levelUsed, levelUsed * GuildDailyConstants.MONEY_MULTIPLIER);
-	await genericAwardingFunction(guildLike.members, member => {
-		member.addMoney({
+	await genericAwardingFunction(guildLike.members, async member => {
+		await member.addMoney({
 			amount: moneyWon,
 			response,
 			reason: NumberChangeReason.GUILD_DAILY

--- a/Core/src/commands/player/ClassesCommand.ts
+++ b/Core/src/commands/player/ClassesCommand.ts
@@ -31,56 +31,61 @@ import { ClassConstants } from "../../../../Lib/src/constants/ClassConstants";
 import {
 	secondsToMilliseconds
 } from "../../../../Lib/src/utils/TimeUtils";
+import { withLockedPlayerAndMissionsSafe } from "../../core/utils/withLockedPlayerAndMissionsSafe";
 
 function getEndCallback(player: Player) {
 	return async (collector: ReactionCollectorInstance, response: CrowniclesPacket[]): Promise<void> => {
-		BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.CLASS);
-
-		const firstReaction = collector.getFirstReaction();
-		if (!firstReaction || firstReaction.reaction.type === ReactionCollectorRefuseReaction.name) {
-			response.push(makePacket(CommandClassesCancelErrorPacket, {}));
-			return;
-		}
-
-		await player.reload();
-		const selectedClass = (firstReaction.reaction.data as ReactionCollectorChangeClassReaction).classId;
-		const oldClass = ClassDataController.instance.getById(player.class);
-		const newClass = ClassDataController.instance.getById(selectedClass);
-		const level = player.level;
-
-		if (!oldClass || !newClass) {
-			response.push(makePacket(CommandClassesCancelErrorPacket, {}));
-			return;
-		}
-
-		player.class = selectedClass;
-		const playerActiveObjects = await InventorySlots.getPlayerActiveObjects(player.id);
-		await player.addHealth({
-			amount: Math.ceil(
-				player.getHealthValue() / oldClass.getMaxHealthValue(level) * newClass.getMaxHealthValue(level)
-			) - player.getHealthValue(),
-			response,
-			reason: NumberChangeReason.CLASS,
-			missionHealthParameter: {
-				shouldPokeMission: false,
-				overHealCountsForMission: false
+		try {
+			const firstReaction = collector.getFirstReaction();
+			if (!firstReaction || firstReaction.reaction.type === ReactionCollectorRefuseReaction.name) {
+				response.push(makePacket(CommandClassesCancelErrorPacket, {}));
+				return;
 			}
-		});
-		player.setEnergyLost(Math.ceil(
-			player.fightPointsLost / oldClass.getMaxCumulativeEnergyValue(level) * newClass.getMaxCumulativeEnergyValue(level)
-		), NumberChangeReason.CLASS, playerActiveObjects);
-		await player.save();
-		Object.assign(player, await MissionsController.update(player, response, { missionId: "chooseClass" }));
-		Object.assign(player, await MissionsController.update(player, response, {
-			missionId: "chooseClassTier",
-			params: { tier: newClass.classGroup }
-		}));
-		crowniclesInstance?.logsDatabase.logPlayerClassChange(player.keycloakId, newClass.id)
-			.then();
 
-		response.push(makePacket(CommandClassesChangeSuccessPacket, {
-			classId: selectedClass
-		}));
+			await withLockedPlayerAndMissionsSafe(player, "class change", async lockedPlayer => {
+				const selectedClass = (firstReaction.reaction.data as ReactionCollectorChangeClassReaction).classId;
+				const oldClass = ClassDataController.instance.getById(lockedPlayer.class);
+				const newClass = ClassDataController.instance.getById(selectedClass);
+				const level = lockedPlayer.level;
+
+				if (!oldClass || !newClass) {
+					response.push(makePacket(CommandClassesCancelErrorPacket, {}));
+					return;
+				}
+
+				lockedPlayer.class = selectedClass;
+				const playerActiveObjects = await InventorySlots.getPlayerActiveObjects(lockedPlayer.id);
+				await lockedPlayer.addHealth({
+					amount: Math.ceil(
+						lockedPlayer.getHealthValue() / oldClass.getMaxHealthValue(level) * newClass.getMaxHealthValue(level)
+					) - lockedPlayer.getHealthValue(),
+					response,
+					reason: NumberChangeReason.CLASS,
+					missionHealthParameter: {
+						shouldPokeMission: false,
+						overHealCountsForMission: false
+					}
+				});
+				lockedPlayer.setEnergyLost(Math.ceil(
+					lockedPlayer.fightPointsLost / oldClass.getMaxCumulativeEnergyValue(level) * newClass.getMaxCumulativeEnergyValue(level)
+				), NumberChangeReason.CLASS, playerActiveObjects);
+				await lockedPlayer.save();
+				await MissionsController.update(lockedPlayer, response, { missionId: "chooseClass" });
+				await MissionsController.update(lockedPlayer, response, {
+					missionId: "chooseClassTier",
+					params: { tier: newClass.classGroup }
+				});
+				crowniclesInstance?.logsDatabase.logPlayerClassChange(lockedPlayer.keycloakId, newClass.id)
+					.then();
+
+				response.push(makePacket(CommandClassesChangeSuccessPacket, {
+					classId: selectedClass
+				}));
+			});
+		}
+		finally {
+			BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.CLASS);
+		}
 	};
 }
 

--- a/Core/src/commands/player/JoinBoatCommand.ts
+++ b/Core/src/commands/player/JoinBoatCommand.ts
@@ -35,6 +35,7 @@ import { TravelTime } from "../../core/maps/TravelTime";
 import { WhereAllowed } from "../../../../Lib/src/types/WhereAllowed";
 import { PlayerActiveObjects } from "../../core/database/game/models/PlayerActiveObjects";
 import { InventorySlots } from "../../core/database/game/models/InventorySlot";
+import { withLockedPlayerAndMissionsSafe } from "../../core/utils/withLockedPlayerAndMissionsSafe";
 
 
 /**
@@ -83,8 +84,7 @@ async function canJoinBoat(player: Player, response: CrowniclesPacket[], playerA
  * @param response
  * @param playerActiveObjects
  */
-async function acceptJoinBoat(player: Player, response: CrowniclesPacket[], playerActiveObjects: PlayerActiveObjects): Promise<void> {
-	await player.reload();
+async function acceptJoinBoatUnderLock(player: Player, response: CrowniclesPacket[], playerActiveObjects: PlayerActiveObjects): Promise<void> {
 	if (!await canJoinBoat(player, response, playerActiveObjects)) {
 		return;
 	}
@@ -124,13 +124,18 @@ async function acceptJoinBoat(player: Player, response: CrowniclesPacket[], play
 
 function endCallback(player: Player, playerActiveObjects: PlayerActiveObjects): EndCallback {
 	return async (collector, response): Promise<void> => {
-		const reaction = collector.getFirstReaction();
-		BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.PVE_ISLAND);
-		if (reaction && reaction.reaction.type === ReactionCollectorAcceptReaction.name) {
-			await acceptJoinBoat(player, response, playerActiveObjects);
+		try {
+			const reaction = collector.getFirstReaction();
+			if (reaction && reaction.reaction.type === ReactionCollectorAcceptReaction.name) {
+				await withLockedPlayerAndMissionsSafe(player, "join boat", lockedPlayer =>
+					acceptJoinBoatUnderLock(lockedPlayer, response, playerActiveObjects));
+			}
+			else {
+				response.push(makePacket(CommandJoinBoatRefusePacketRes, {}));
+			}
 		}
-		else {
-			response.push(makePacket(CommandJoinBoatRefusePacketRes, {}));
+		finally {
+			BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.PVE_ISLAND);
 		}
 	};
 }

--- a/Core/src/core/report/ReportCityInnService.ts
+++ b/Core/src/core/report/ReportCityInnService.ts
@@ -65,13 +65,13 @@ export async function handleInnMealReaction(
 		}
 
 		const energyBefore = lockedPlayer.getCumulativeEnergy(playerActiveObjects);
-		lockedPlayer.addEnergy(reaction.meal.energy, NumberChangeReason.INN_MEAL, playerActiveObjects);
-		lockedPlayer.eatMeal();
 		await lockedPlayer.spendMoney({
 			response,
 			amount: reaction.meal.price,
 			reason: NumberChangeReason.INN_MEAL
 		});
+		lockedPlayer.addEnergy(reaction.meal.energy, NumberChangeReason.INN_MEAL, playerActiveObjects);
+		lockedPlayer.eatMeal();
 		await lockedPlayer.save();
 		response.push(makePacket(CommandReportEatInnMealRes, {
 			energy: reaction.meal.energy,

--- a/Core/src/core/smallEvents/cart.ts
+++ b/Core/src/core/smallEvents/cart.ts
@@ -69,10 +69,10 @@ async function runCartEndCallbackUnderLock(
 			packet.pointsWon = scoreParameters.amount;
 			const newMapLinkId = destination.isScam ? destination.scamDestination!.id : destination.destination.id;
 			crowniclesInstance?.logsDatabase.logTeleportation(player.keycloakId, player.mapLinkId, newMapLinkId).then();
-			player.mapLinkId = newMapLinkId;
 			await player.spendMoney({
 				amount: destination.price, response, reason: NumberChangeReason.SMALL_EVENT
 			});
+			player.mapLinkId = newMapLinkId;
 		}
 		response.push(makePacket(SmallEventCartPacket, packet));
 	}


### PR DESCRIPTION
Corrige les régressions introduites par la synchronisation de `spendMoney` fusionnée dans la version 6.0.2.b.

- applique `guildId`, l’énergie/cooldown d’auberge et la destination du chariot après la recharge effectuée par `spendMoney` ;
- attend réellement les récompenses personnelles XP/argent de la quotidienne de guilde ;
- garde les changements de classe et l’embarquement sous verrou jusqu’au déblocage ;
- ajoute des régressions pour la création de guilde, le repas d’auberge et le chariot.

Le séquençage complexe des level-ups imbriqués est isolé dans #4552.

Validations :
- `pnpm eslint` dans Core
- `pnpm tsc` dans Core
- `pnpm test` dans Core (1513 tests)

Closes #4551