### PR TITLE
fix #4562 dedupe arrival notification via atomic claim

### DIFF
--- a/Core/__tests__/core/bot/ReportNotifications.test.ts
+++ b/Core/__tests__/core/bot/ReportNotifications.test.ts
@@ -1,0 +1,69 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+
+vi.mock("../../../src/core/database/game/models/ScheduledReportNotification", () => ({
+	ScheduledReportNotifications: {
+		getNotificationsBeforeDate: vi.fn(),
+		claimNotification: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/utils/PacketUtils", () => ({
+	PacketUtils: {
+		sendNotifications: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/data/MapLocation", () => ({
+	MapLocationDataController: {
+		instance: {
+			getById: vi.fn(() => ({ type: 0 }))
+		}
+	}
+}));
+
+import { processDueReportNotifications } from "../../../src/core/bot/ReportNotifications";
+import { ScheduledReportNotifications } from "../../../src/core/database/game/models/ScheduledReportNotification";
+import { PacketUtils } from "../../../src/core/utils/PacketUtils";
+import { ReachDestinationNotificationPacket } from "../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
+
+describe("processDueReportNotifications", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("sends a claimed arrival notification exactly once", async () => {
+		vi.mocked(ScheduledReportNotifications.getNotificationsBeforeDate).mockResolvedValue([
+			{
+				playerId: 1, keycloakId: "player", mapId: 42
+			}
+		] as never);
+		vi.mocked(ScheduledReportNotifications.claimNotification).mockResolvedValue(true);
+
+		await processDueReportNotifications();
+
+		expect(ScheduledReportNotifications.claimNotification).toHaveBeenCalledWith(1);
+		expect(PacketUtils.sendNotifications).toHaveBeenCalledOnce();
+		const packets = vi.mocked(PacketUtils.sendNotifications).mock.calls[0][0];
+		expect(packets).toHaveLength(1);
+		expect(packets[0]).toBeInstanceOf(ReachDestinationNotificationPacket);
+		expect(packets[0]).toMatchObject({
+			keycloakId: "player", mapId: 42
+		});
+	});
+
+	it("does not send a notification already claimed by the afterSave hook", async () => {
+		vi.mocked(ScheduledReportNotifications.getNotificationsBeforeDate).mockResolvedValue([
+			{
+				playerId: 1, keycloakId: "player", mapId: 42
+			}
+		] as never);
+		vi.mocked(ScheduledReportNotifications.claimNotification).mockResolvedValue(false);
+
+		await processDueReportNotifications();
+
+		expect(ScheduledReportNotifications.claimNotification).toHaveBeenCalledWith(1);
+		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
+	});
+});

--- a/Core/src/core/bot/Crownicles.ts
+++ b/Core/src/core/bot/Crownicles.ts
@@ -17,9 +17,6 @@ import Player from "../database/game/models/Player";
 import { FightConstants } from "../../../../Lib/src/constants/FightConstants";
 import { PacketUtils } from "../utils/PacketUtils";
 import { makePacket } from "../../../../Lib/src/packets/CrowniclesPacket";
-import { ScheduledReportNotifications } from "../database/game/models/ScheduledReportNotification";
-import { ReachDestinationNotificationPacket } from "../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
-import { MapLocationDataController } from "../../data/MapLocation";
 import { Settings } from "../database/game/models/Setting";
 import { PotionDataController } from "../../data/Potion";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
@@ -45,6 +42,7 @@ import { EnergyFullNotificationPacket } from "../../../../Lib/src/packets/notifi
 import { DailyBonusNotificationPacket } from "../../../../Lib/src/packets/notifications/DailyBonusNotificationPacket";
 import { ScheduledDailyBonusNotifications } from "../database/game/models/ScheduledDailyBonusNotification";
 import { processDueExpeditionNotifications } from "./ExpeditionNotifications";
+import { processDueReportNotifications } from "./ReportNotifications";
 import { CrowniclesDaily } from "./cronJobs/CrowniclesDaily";
 import { CrowniclesSunday } from "./cronJobs/CrowniclesSunday";
 import { CrowniclesMonday } from "./cronJobs/CrowniclesMonday";
@@ -291,15 +289,7 @@ export class Crownicles {
 	static async reportNotifications(): Promise<void> {
 		try {
 			if (PacketUtils.isMqttConnected()) {
-				const notifications = await ScheduledReportNotifications.getNotificationsBeforeDate(new Date());
-				if (notifications.length !== 0) {
-					PacketUtils.sendNotifications(notifications.map(notification => makePacket(ReachDestinationNotificationPacket, {
-						keycloakId: notification.keycloakId,
-						mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
-						mapId: notification.mapId
-					})));
-					await ScheduledReportNotifications.bulkDelete(notifications);
-				}
+				await processDueReportNotifications();
 			}
 			else {
 				CrowniclesLogger.error(`MQTT is not connected, can't do report notifications. Trying again in ${TimeoutFunctionsConstants.REPORT_NOTIFICATIONS} ms`);

--- a/Core/src/core/bot/ReportNotifications.ts
+++ b/Core/src/core/bot/ReportNotifications.ts
@@ -1,0 +1,33 @@
+import { makePacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+import { ReachDestinationNotificationPacket } from "../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
+import { MapLocationDataController } from "../../data/MapLocation";
+import { ScheduledReportNotifications } from "../database/game/models/ScheduledReportNotification";
+import { PacketUtils } from "../utils/PacketUtils";
+
+/**
+ * Dispatch every arrival notification whose scheduled time has passed.
+ *
+ * Each row is claimed (atomically deleted) before being sent: only the caller
+ * that wins the delete is allowed to dispatch, so this poller never sends a
+ * notification that the `Player.afterSave` hook has already sent, and vice
+ * versa (issue #4562).
+ */
+export async function processDueReportNotifications(): Promise<void> {
+	const notifications = await ScheduledReportNotifications.getNotificationsBeforeDate(new Date());
+	if (notifications.length === 0) {
+		return;
+	}
+
+	await Promise.all(notifications.map(async notification => {
+		if (!await ScheduledReportNotifications.claimNotification(notification.playerId)) {
+			return;
+		}
+		PacketUtils.sendNotifications([
+			makePacket(ReachDestinationNotificationPacket, {
+				keycloakId: notification.keycloakId,
+				mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
+				mapId: notification.mapId
+			})
+		]);
+	}));
+}

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -1977,7 +1977,8 @@ export function initModel(sequelize: Sequelize): void {
 	});
 
 	Player.afterSave((instance, options) => {
-		if (!instance.mapLinkId) {
+		if (!instance.mapLinkId || !MapLinkDataController.instance.getById(instance.mapLinkId)) {
+			// No resolvable map link: nothing to notify, and getTravelDataSimplified would throw on the missing link.
 			return;
 		}
 
@@ -1986,30 +1987,37 @@ export function initModel(sequelize: Sequelize): void {
 			const now = new Date();
 			const travelEndDate = new Date(TravelTime.getTravelDataSimplified(instance, now).travelEndTime);
 			const destinationId = instance.getDestinationId();
-			const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(instance.id);
-			if (pendingReportNotification) {
-				await ScheduledReportNotifications.bulkDelete([pendingReportNotification]);
-			}
 
 			if (
 				travelEndDate > now
 				&& destinationId !== null
 			) {
+				// Still travelling: (re)schedule the arrival notification (upsert overwrites any stale row).
 				await ScheduledReportNotifications.scheduleNotification(instance.id, instance.keycloakId, destinationId, travelEndDate);
 				return;
 			}
 
-			if (pendingReportNotification && destinationId === pendingReportNotification.mapId) {
-				const mapLocation = MapLocationDataController.instance.getById(pendingReportNotification.mapId);
-				if (mapLocation) {
-					PacketUtils.sendNotifications([
-						makePacket(ReachDestinationNotificationPacket, {
-							keycloakId: pendingReportNotification.keycloakId,
-							mapType: mapLocation.type,
-							mapId: pendingReportNotification.mapId
-						})
-					]);
-				}
+			/*
+			 * Arrived: claim the pending row atomically. Only the winner of the claim dispatches
+			 * the notification, so the periodic poller can never send a duplicate (issue #4562).
+			 */
+			const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(instance.id);
+			if (!pendingReportNotification) {
+				return;
+			}
+			const claimed = await ScheduledReportNotifications.claimNotification(instance.id);
+			if (!claimed || destinationId !== pendingReportNotification.mapId) {
+				return;
+			}
+			const mapLocation = MapLocationDataController.instance.getById(pendingReportNotification.mapId);
+			if (mapLocation) {
+				PacketUtils.sendNotifications([
+					makePacket(ReachDestinationNotificationPacket, {
+						keycloakId: pendingReportNotification.keycloakId,
+						mapType: mapLocation.type,
+						mapId: pendingReportNotification.mapId
+					})
+				]);
 			}
 		};
 

--- a/Core/src/core/database/game/models/ScheduledReportNotification.ts
+++ b/Core/src/core/database/game/models/ScheduledReportNotification.ts
@@ -37,14 +37,21 @@ export abstract class ScheduledReportNotifications {
 		});
 	}
 
-	static async bulkDelete(notifications: ScheduledReportNotification[]): Promise<void> {
-		await ScheduledReportNotification.destroy({
-			where: {
-				playerId: {
-					[Op.in]: notifications.map(notification => notification.playerId)
-				}
-			}
+	/**
+	 * Atomically claim (delete) the scheduled notification of a player.
+	 *
+	 * The row acts as a single-use token: the DELETE is serialised by the
+	 * database on the primary key, so exactly one of the concurrent callers
+	 * (the periodic poller in {@link processDueReportNotifications} and the
+	 * `Player.afterSave` hook) receives `true` and is allowed to dispatch the
+	 * notification. Every other caller receives `false` and must stay silent.
+	 * This is what prevents the duplicate arrival notification (issue #4562).
+	 */
+	static async claimNotification(playerId: number): Promise<boolean> {
+		const deletedRows = await ScheduledReportNotification.destroy({
+			where: { playerId }
 		});
+		return deletedRows > 0;
 	}
 
 	static async getPendingNotification(playerId: number): Promise<ScheduledReportNotification | null> {


### PR DESCRIPTION
## Problème

Depuis le correctif #4495 (notifications d'arrivée en ville), les joueurs
reçoivent une **double notification d'arrivée** (« vous êtes arrivé... »),
espacées d'environ un cycle de poll (~1–2 min). Signalé sur l'arrivée dans la
ville de résidence après un déménagement.

## Cause

Le commit de #4495 a retiré le garde qui excluait les villes de la
programmation des notifications. Résultat : l'arrivée en ville est désormais
notifiée par **deux mécanismes indépendants et non synchronisés** qui partagent
la même ligne `ScheduledReportNotification` :

1. le poller périodique `Crownicles.reportNotifications()` (toutes les 60 s) ;
2. la branche d'envoi immédiat du hook `Player.afterSave`.

La séquence lecture → envoi → suppression n'étant ni atomique ni verrouillée,
les deux chemins peuvent lire la ligne avant que l'un ne la supprime, et
envoient tous les deux → double DM.

Les logs révèlent aussi un crash lié :
`Cannot read properties of undefined (reading 'tripDuration')` dans
`handleNotifications` → `getTravelDataSimplified`, quand le `mapLinkId` du
joueur ne se résout pas (observé pendant un déménagement).

## Solution

- **Réclamation atomique** : nouvelle méthode `claimNotification(playerId)` qui
  supprime la ligne et renvoie `true` uniquement au gagnant. La ligne devient
  un jeton à usage unique (le DELETE est sérialisé par MariaDB sur la PK), donc
  la notification est envoyée **exactement une fois**, que ce soit le poller ou
  le hook `afterSave` qui gagne.
- Extraction de la logique du poller dans `ReportNotifications.ts`
  (`processDueReportNotifications`), testable, à l'image des expéditions.
- Le hook `afterSave` réclame la ligne avant d'envoyer, et ne fait plus de
  suppression inconditionnelle en tête.
- **Garde** contre un `mapLinkId` non résolu dans `afterSave` pour éviter le
  crash `tripDuration`.
- Test de régression sur la garantie « exactement-une-fois ».

Closes #4562
