### PR TITLE
fix private thread error translation #4575

### DIFF
--- a/Discord/__tests__/utils/ChannelPermissionUtils.test.ts
+++ b/Discord/__tests__/utils/ChannelPermissionUtils.test.ts
@@ -2,6 +2,8 @@ import {
 	describe, expect, it
 } from "vitest";
 import { ChannelType } from "discord.js";
+import i18n from "../../src/translations/i18n";
+import { LANGUAGE } from "../../../Lib/src/Language";
 import {
 	getThreadSendAccessError, THREAD_SEND_ACCESS_ERRORS
 } from "../../src/commands/ChannelPermissionUtils";
@@ -19,13 +21,20 @@ describe("getThreadSendAccessError", () => {
 	});
 
 	it("reports when the bot has not joined a private thread", () => {
-		expect(getThreadSendAccessError({
+		const error = getThreadSendAccessError({
 			isThread: () => true,
 			sendable: false,
 			type: ChannelType.PrivateThread,
 			joined: false,
 			manageable: false
-		})).toBe(THREAD_SEND_ACCESS_ERRORS.NOT_JOINED);
+		});
+
+		expect(error).toBe(THREAD_SEND_ACCESS_ERRORS.NOT_JOINED);
+		if (error === null) {
+			throw new Error("Expected a private thread membership error");
+		}
+		expect(i18n.t(error, { lng: LANGUAGE.FRENCH })).not.toBe(error);
+		expect(i18n.t(error, { lng: LANGUAGE.ENGLISH })).not.toBe(error);
 	});
 
 	it("keeps the permission error for other inaccessible threads", () => {

--- a/Discord/__tests__/utils/ChannelPermissionUtils.test.ts
+++ b/Discord/__tests__/utils/ChannelPermissionUtils.test.ts
@@ -5,8 +5,17 @@ import { ChannelType } from "discord.js";
 import i18n from "../../src/translations/i18n";
 import { LANGUAGE } from "../../../Lib/src/Language";
 import {
-	getThreadSendAccessError, THREAD_SEND_ACCESS_ERRORS
+	getThreadSendAccessError, THREAD_SEND_ACCESS_ERRORS, ThreadSendAccessError
 } from "../../src/commands/ChannelPermissionUtils";
+
+function expectTranslationExists(error: ThreadSendAccessError | null): void {
+	if (error === null) {
+		throw new Error("Expected a thread send access error");
+	}
+	for (const language of [LANGUAGE.FRENCH, LANGUAGE.ENGLISH]) {
+		expect(i18n.t(error, { lng: language })).not.toBe(error);
+	}
+}
 
 describe("getThreadSendAccessError", () => {
 	it("allows non-thread channels", () => {
@@ -30,17 +39,16 @@ describe("getThreadSendAccessError", () => {
 		});
 
 		expect(error).toBe(THREAD_SEND_ACCESS_ERRORS.NOT_JOINED);
-		if (error === null) {
-			throw new Error("Expected a private thread membership error");
-		}
-		expect(i18n.t(error, { lng: LANGUAGE.FRENCH })).not.toBe(error);
-		expect(i18n.t(error, { lng: LANGUAGE.ENGLISH })).not.toBe(error);
+		expectTranslationExists(error);
 	});
 
 	it("keeps the permission error for other inaccessible threads", () => {
-		expect(getThreadSendAccessError({
+		const error = getThreadSendAccessError({
 			isThread: () => true,
 			sendable: false
-		})).toBe(THREAD_SEND_ACCESS_ERRORS.CANNOT_SEND);
+		});
+
+		expect(error).toBe(THREAD_SEND_ACCESS_ERRORS.CANNOT_SEND);
+		expectTranslationExists(error);
 	});
 });

--- a/Discord/src/commands/ChannelPermissionUtils.ts
+++ b/Discord/src/commands/ChannelPermissionUtils.ts
@@ -1,8 +1,8 @@
 import { ChannelType } from "discord.js";
 
 export const THREAD_SEND_ACCESS_ERRORS = {
-	NOT_JOINED: "noThreadMembership",
-	CANNOT_SEND: "noSpeakInThreadPermission"
+	NOT_JOINED: "bot:noThreadMembership",
+	CANNOT_SEND: "bot:noSpeakInThreadPermission"
 } as const;
 
 export type ThreadSendAccessError = typeof THREAD_SEND_ACCESS_ERRORS[keyof typeof THREAD_SEND_ACCESS_ERRORS];


### PR DESCRIPTION
## Problème

Dans un fil privé auquel Crownicles n'avait pas encore été ajouté, l'erreur éphémère affichait la clé `noThreadMembership` au lieu de son explication localisée.

## Cause

Les erreurs de permission de fil étaient transmises à i18next sans le namespace `bot`, alors que les fichiers `bot.json` sont chargés comme un namespace dédié.

## Correctif

- qualifie les deux clés d'erreur de fil avec le namespace `bot` ;
- ajoute un test de régression qui résout réellement l'erreur de fil privé en français et en anglais.

## Validation

- `pnpm eslintFix`
- `pnpm eslint`
- `pnpm test` (25 fichiers, 258 tests)
- test ciblé `ChannelPermissionUtils.test.ts` (4 tests)
- `pnpm tsc` tenté ; échec sur `TS2589` dans `src/translations/i18n.ts:104`, ligne inchangée depuis avril et hors du diff

Closes #4575
