### PR TITLE
fix token travel rollback #4567

### DIFF
--- a/Core/__tests__/core/report/ReportTokenTravelRegression.test.ts
+++ b/Core/__tests__/core/report/ReportTokenTravelRegression.test.ts
@@ -1,0 +1,96 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+import type {
+	CrowniclesPacket, PacketContext
+} from "../../../../Lib/src/packets/CrowniclesPacket";
+import { ReactionCollectorAcceptReaction } from "../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
+import {
+	asMinutes, minutesToMilliseconds
+} from "../../../../Lib/src/utils/TimeUtils";
+import type { Player } from "../../../src/core/database/game/models/Player";
+import { PlayerSmallEvents } from "../../../src/core/database/game/models/PlayerSmallEvent";
+import { Maps } from "../../../src/core/maps/Maps";
+import { TravelTime } from "../../../src/core/maps/TravelTime";
+import { createUseTokensCollector } from "../../../src/core/report/ReportTokenHealService";
+import { withLockedPlayerAndMissions } from "../../../src/core/utils/withLockedPlayerAndMissions";
+
+let capturedEndCallback: ((collector: { getFirstReaction: () => unknown }, response: CrowniclesPacket[]) => Promise<void>) | undefined;
+
+const OVERDUE_SMALL_EVENT_MINUTES = 82;
+const TRAVELLED_MINUTES_BEFORE_TOKEN = 92;
+
+vi.mock("../../../src/core/missions/MissionsController", () => ({
+	MissionsController: {
+		update: vi.fn().mockResolvedValue(undefined)
+	}
+}));
+
+vi.mock("../../../src/core/utils/BlockingUtils", () => ({
+	BlockingUtils: {
+		blockPlayer: vi.fn(),
+		unblockPlayer: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/utils/ReactionsCollector", () => ({
+	ReactionCollectorInstance: class {
+		constructor(_collector: unknown, _context: unknown, _options: unknown, endCallback: typeof capturedEndCallback) {
+			capturedEndCallback = endCallback;
+		}
+
+		block(): this {
+			return this;
+		}
+
+		build(): this {
+			return this;
+		}
+	}
+}));
+
+vi.mock("../../../src/core/utils/withLockedPlayerAndMissions", () => ({
+	withLockedPlayerAndMissions: vi.fn()
+}));
+
+describe("report token travel", () => {
+	const player = {
+		id: 1,
+		keycloakId: "token-user",
+		tokens: 10,
+		effectId: "no_effect",
+		effectEndDate: new Date(0),
+		startTravelDate: new Date(0),
+		useTokens: vi.fn().mockResolvedValue(undefined),
+		save: vi.fn().mockResolvedValue(undefined)
+	};
+
+	beforeEach(() => {
+		capturedEndCallback = undefined;
+		vi.clearAllMocks();
+		vi.mocked(withLockedPlayerAndMissions).mockImplementation(async (_playerId, callback) => await callback(player as Player));
+	});
+
+	it("does not move the player backwards when the next small event is overdue", async () => {
+		const now = Date.now();
+		const originalStartTravelTime = now - minutesToMilliseconds(asMinutes(TRAVELLED_MINUTES_BEFORE_TOKEN));
+		player.effectEndDate = new Date(originalStartTravelTime);
+		player.startTravelDate = new Date(originalStartTravelTime);
+		vi.spyOn(TravelTime, "getTravelData").mockResolvedValue({
+			nextSmallEventTime: now - minutesToMilliseconds(asMinutes(OVERDUE_SMALL_EVENT_MINUTES))
+		} as Awaited<ReturnType<typeof TravelTime.getTravelData>>);
+		vi.spyOn(PlayerSmallEvents, "getLastOfPlayer").mockResolvedValue(null);
+		vi.spyOn(Maps, "isArrived").mockReturnValue(false);
+
+		createUseTokensCollector(player as Player, 1, {} as PacketContext, []);
+
+		if (!capturedEndCallback) {
+			throw new Error("Expected use-tokens collector callback to be set");
+		}
+		await capturedEndCallback({
+			getFirstReaction: () => ({ reaction: { type: ReactionCollectorAcceptReaction.name } })
+		}, []);
+
+		expect(player.startTravelDate.valueOf()).toBe(originalStartTravelTime);
+	});
+});

--- a/Core/src/core/report/ReportTokenHealService.ts
+++ b/Core/src/core/report/ReportTokenHealService.ts
@@ -77,11 +77,12 @@ async function acceptUseTokens(
 		// Recalculate travel data AFTER removing the effect to get the correct next small event time
 		const updatedDate = new Date();
 		const updatedTimeData = await TravelTime.getTravelData(lockedPlayer, updatedDate);
+		const timeToNextSmallEvent = Math.max(updatedTimeData.nextSmallEventTime - updatedDate.valueOf(), 0);
 
 		// Make the player time travel to the next small event
 		await TravelTime.timeTravelMilliseconds(
 			lockedPlayer,
-			asMilliseconds(updatedTimeData.nextSmallEventTime - updatedDate.valueOf()),
+			asMilliseconds(timeToNextSmallEvent),
 			NumberChangeReason.REPORT_TOKENS
 		);
 


### PR DESCRIPTION
## Problème

L'utilisation d'un jeton pouvait faire reculer fortement la progression du voyage lorsque le prochain petit événement calculé était déjà dépassé.

## Cause

Le délai transmis au voyage temporel pouvait être négatif. Dans ce cas, l'opération censée avancer jusqu'au prochain événement déplaçait le début du trajet vers le futur.

## Solution

- borne le délai d'avancement à zéro pour qu'un jeton ne puisse jamais faire reculer le trajet ;
- ajoute un test de régression reproduisant un événement dépassé de 82 minutes et vérifiant que la progression acquise reste inchangée ;
- conserve les sauvegardes dans la section critique `withLockedPlayerAndMissions` existante.

## Validations

- `pnpm eslintFix` (Core)
- `pnpm eslint` (Core)
- `pnpm tsc` (Core)
- test ciblé : 1 test passé
- suite Core : 102 fichiers, 1 515 tests passés

Closes #4567
