### PR TITLE
fix guild daily bonus reply timeout #4557

### DIFF
--- a/Discord/__tests__/guild/GuildDailyCommand.test.ts
+++ b/Discord/__tests__/guild/GuildDailyCommand.test.ts
@@ -1,6 +1,33 @@
-import { describe, expect, it } from "vitest";
-import { getCommandGuildDailyRewardPacketString } from "../../src/commands/guild/GuildDailyCommand";
-import { CommandGuildDailyRewardPacket } from "../../../Lib/src/packets/commands/CommandGuildDailyPacket";
+import {
+	describe, expect, it, vi
+} from "vitest";
+import {
+	commandInfo, getCommandGuildDailyRewardPacketString
+} from "../../src/commands/guild/GuildDailyCommand";
+import {
+	CommandGuildDailyPacketReq, CommandGuildDailyRewardPacket
+} from "../../../Lib/src/packets/commands/CommandGuildDailyPacket";
+
+describe("guild daily command packet", () => {
+	it("defers the interaction before returning the packet", async () => {
+		let finishDefer: (() => void) | undefined;
+		const deferReply = vi.fn(() => new Promise<void>(resolve => {
+			finishDefer = resolve;
+		}));
+		const packetPromise = commandInfo.getPacket({ deferReply } as never, {} as never);
+		let packetReturned = false;
+		void Promise.resolve(packetPromise).then(() => {
+			packetReturned = true;
+		});
+
+		expect(deferReply).toHaveBeenCalledOnce();
+		await Promise.resolve();
+		expect(packetReturned).toBe(false);
+
+		finishDefer!();
+		await expect(packetPromise).resolves.toBeInstanceOf(CommandGuildDailyPacketReq);
+	});
+});
 
 describe("getCommandGuildDailyRewardPacketString", () => {
 	it("includes guild points and treasury bonus in French", () => {

--- a/Discord/src/commands/guild/GuildDailyCommand.ts
+++ b/Discord/src/commands/guild/GuildDailyCommand.ts
@@ -14,8 +14,10 @@ import { DisplayUtils } from "../../utils/DisplayUtils";
 import { DiscordCache } from "../../bot/DiscordCache";
 import { CrowniclesEmbed } from "../../messages/CrowniclesEmbed";
 import { StringConstants } from "../../../../Lib/src/constants/StringConstants";
+import { CrowniclesInteraction } from "../../messages/CrowniclesInteraction";
 
-function getPacket(): CommandGuildDailyPacketReq {
+async function getPacket(interaction: CrowniclesInteraction): Promise<CommandGuildDailyPacketReq> {
+	await interaction.deferReply();
 	return makePacket(CommandGuildDailyPacketReq, {});
 }
 


### PR DESCRIPTION
## Problème

`/bonusjournalierguilde` envoyait sa requête au Core sans différer la réponse Discord. Lorsque le traitement dépassait la fenêtre de réponse de l'interaction, le bonus était bien attribué mais le message de résultat ne pouvait plus être envoyé.

## Correction

- diffère l'interaction avant de retourner le paquet envoyé au Core ;
- conserve les réponses existantes via `editReply` pour le succès et les erreurs ;
- ajoute un test de régression vérifiant que le paquet n'est pas retourné avant la fin de `deferReply`.

## Validation

- `pnpm eslintFix` (Discord)
- `pnpm eslint` (Discord)
- test ciblé : 2 tests passés
- `pnpm test` (Discord) : 25 fichiers, 259 tests passés
- `pnpm tsc` (Discord) : échec préexistant `TS2589` dans `src/translations/i18n.ts:104`, fichier inchangé par cette PR et identique à `origin/develop`
- review complète selon la checklist : aucun constat réel ; review manuelle effectuée car l'appel indépendant a été bloqué par le quota mensuel externe

Closes #4557
