### PR TITLE
fix Celestrum return destination #4559

### DIFF
--- a/Core/__tests__/PossibilityOutcome.test.ts
+++ b/Core/__tests__/PossibilityOutcome.test.ts
@@ -7,6 +7,9 @@ import {
 } from "../../Lib/src/packets/CrowniclesPacket";
 import Player from "../src/core/database/game/models/Player";
 import { applyPossibilityOutcome } from "../src/data/events/PossibilityOutcome";
+import hermitEvent from "../resources/events/40.json";
+import { MapConstants } from "../../Lib/src/constants/MapConstants";
+import { MapLinkDataController } from "../src/data/MapLink";
 
 vi.mock("../src/core/database/game/models/InventorySlot", () => ({
 	InventorySlots: { getPlayerActiveObjects: vi.fn().mockResolvedValue({}) }
@@ -39,6 +42,48 @@ vi.mock("../src/core/blessings/BlessingManager", () => ({
 }));
 
 describe("applyPossibilityOutcome", () => {
+	it.each([
+		{ originMapId: MapConstants.LOCATIONS_IDS.COCO_VILLAGE, outcomeId: "0" as const },
+		{ originMapId: MapConstants.LOCATIONS_IDS.COCO_VILLAGE, outcomeId: "1" as const },
+		{ originMapId: MapConstants.LOCATIONS_IDS.MOUNT_CELESTRUM, outcomeId: "0" as const },
+		{ originMapId: MapConstants.LOCATIONS_IDS.MOUNT_CELESTRUM, outcomeId: "1" as const }
+	])("returns to the travel origin for Xetrix's go back choice", async ({
+		originMapId, outcomeId
+	}) => {
+		const currentMapLink = MapLinkDataController.instance.getLinkByLocations(
+			originMapId,
+			MapConstants.LOCATIONS_IDS.CELESTRUM_FOREST
+		)!;
+		const player = Object.create(Player.prototype) as Player;
+		Object.assign(player, {
+			id: 1,
+			level: 10,
+			mapLinkId: currentMapLink.id,
+			effectDuration: 0,
+			effectId: "",
+			addEnergy: vi.fn(),
+			addExperience: vi.fn().mockResolvedValue(player),
+			addHealth: vi.fn().mockResolvedValue(undefined),
+			addMoney: vi.fn().mockResolvedValue(player),
+			addScore: vi.fn().mockResolvedValue(undefined),
+			addTokens: vi.fn().mockResolvedValue(undefined),
+			save: vi.fn().mockResolvedValue(player),
+			setLastReportWithEffect: vi.fn().mockResolvedValue(undefined)
+		});
+
+		const nextMapLink = await applyPossibilityOutcome({
+			eventId: 40,
+			possibilityName: "goBack",
+			outcome: [outcomeId, hermitEvent.possibilities.goBack.outcomes[outcomeId]],
+			time: 0
+		}, player, {} as PacketContext, []);
+
+		expect(nextMapLink).toMatchObject({
+			startMap: MapConstants.LOCATIONS_IDS.CELESTRUM_FOREST,
+			endMap: originMapId
+		});
+	});
+
 	it("persists money lost before experience reloads the player", async () => {
 		let persistedMoney = 1000;
 		const player = Object.create(Player.prototype) as Player;

--- a/Core/resources/events/40.json
+++ b/Core/resources/events/40.json
@@ -49,10 +49,12 @@
     "goBack": {
       "outcomes": {
         "0": {
-          "money": 150
+          "money": 150,
+          "returnToPreviousMap": true
         },
         "1": {
-          "money": -250
+          "money": -250,
+          "returnToPreviousMap": true
         }
       }
     }

--- a/Core/src/data/events/PossibilityOutcome.ts
+++ b/Core/src/data/events/PossibilityOutcome.ts
@@ -219,13 +219,19 @@ function applyOutcomeNextEvent(outcome: PossibilityOutcome, player: Player): voi
 	}
 }
 
-function getNextMapLink(outcome: PossibilityOutcome, player: Player): MapLink | null {
+function getFixedMapLink(outcome: PossibilityOutcome, player: Player): MapLink | null {
 	if (outcome.mapLink) {
 		return MapLinkDataController.instance.getById(outcome.mapLink) ?? null;
 	}
+	return outcome.returnToPreviousMap
+		? MapLinkDataController.instance.getInverseLinkOf(player.mapLinkId) ?? null
+		: null;
+}
 
-	if (outcome.returnToPreviousMap) {
-		return MapLinkDataController.instance.getInverseLinkOf(player.mapLinkId) ?? null;
+function getNextMapLink(outcome: PossibilityOutcome, player: Player): MapLink | null {
+	const fixedMapLink = getFixedMapLink(outcome, player);
+	if (fixedMapLink) {
+		return fixedMapLink;
 	}
 
 	if (outcome.mapTypesDestination || outcome.mapTypesExcludeDestination) {

--- a/Core/src/data/events/PossibilityOutcome.ts
+++ b/Core/src/data/events/PossibilityOutcome.ts
@@ -224,6 +224,10 @@ function getNextMapLink(outcome: PossibilityOutcome, player: Player): MapLink | 
 		return MapLinkDataController.instance.getById(outcome.mapLink) ?? null;
 	}
 
+	if (outcome.returnToPreviousMap) {
+		return MapLinkDataController.instance.getInverseLinkOf(player.mapLinkId) ?? null;
+	}
+
 	if (outcome.mapTypesDestination || outcome.mapTypesExcludeDestination) {
 		let allowedMapTypes = Maps.getConnectedMapTypes(player, !outcome.mapTypesDestination);
 		if (outcome.mapTypesDestination) {
@@ -425,6 +429,11 @@ export interface PossibilityOutcome {
 	 * Forced map link
 	 */
 	mapLink?: number;
+
+	/**
+	 * Return to the map where the current travel started
+	 */
+	returnToPreviousMap?: boolean;
 
 	/**
 	 * Force the player to stay in the city after the outcome: the destination


### PR DESCRIPTION
## Problème

Le choix permettant de revenir sur ses pas dans la forêt Celestrum utilisait une destination implicite et pouvait renvoyer au Village Coco même lorsque le voyage venait du Mont Celestrum.

## Correction

- ajoute un résultat d’événement data-driven permettant de revenir sur le maplink précédent ;
- applique ce comportement aux deux résultats du choix concerné ;
- couvre les trajets depuis le Village Coco et le Mont Celestrum.

## Validations

- Core eslintFix, ESLint et TypeScript ;
- 101 fichiers de tests Core, 1 518 tests réussis.

Closes #4559