### PR TITLE
fix cooking level display #4564

### DIFF
--- a/Core/src/commands/player/GardenCommand.ts
+++ b/Core/src/commands/player/GardenCommand.ts
@@ -105,6 +105,7 @@ async function buildGardenCollectorData(params: GardenCollectorDataParams): Prom
 		home: {
 			owned: {
 				level: params.home.level,
+				cooking: { level: params.player.cookingLevel },
 				features: params.homeLevel.features,
 				garden
 			}

--- a/Core/src/core/report/ReportCityService.ts
+++ b/Core/src/core/report/ReportCityService.ts
@@ -318,6 +318,7 @@ async function buildOwnedHomeData(params: {
 
 	return {
 		level: home.level,
+		cooking: { level: player.cookingLevel },
 		features: homeLevel.features,
 		upgradeStation,
 		chest,
@@ -367,6 +368,7 @@ async function buildRemoteApartmentHomeData(params: {
 
 	return {
 		level: home.level,
+		cooking: { level: player.cookingLevel },
 		isApartment: true,
 		features: remoteFeatures,
 		chest

--- a/Discord/__tests__/home/CookingFeatureHandler.test.ts
+++ b/Discord/__tests__/home/CookingFeatureHandler.test.ts
@@ -109,8 +109,11 @@ import { HomeFeatureHandlerContext } from "../../src/commands/player/report/home
 /**
  * Create home data with cooking configuration.
  */
-function createCookingHomeData(cookingSlots = 2): ReturnType<typeof createHomeData> {
-	const homeData = createHomeData({ garden: undefined });
+function createCookingHomeData(cookingSlots = 2, cookingLevel = 5): ReturnType<typeof createHomeData> {
+	const homeData = createHomeData({
+		garden: undefined,
+		cookingLevel
+	});
 	homeData.features.cookingSlots = cookingSlots;
 	return homeData;
 }
@@ -877,15 +880,13 @@ describe("CookingFeatureHandler", () => {
 	});
 
 	describe("session state management", () => {
-		it("should create fresh state for new user", async () => {
+		it("should initialize the menu option with the player's cooking level", () => {
 			const ctx = createHandlerContext({
-				homeData: createCookingHomeData(2)
+				homeData: createCookingHomeData(2, 14)
 			});
-			// getMenuOption accesses state (cookingLevel, cookingGrade)
 			const option = handler.getMenuOption(ctx);
 			expect(option).not.toBeNull();
-			// Default level is 0
-			expect(option!.description).toContain('"level":0');
+			expect(option!.description).toContain('"level":14');
 		});
 
 		it("should update state after ignite response", async () => {

--- a/Discord/__tests__/home/homeTestUtils.ts
+++ b/Discord/__tests__/home/homeTestUtils.ts
@@ -147,9 +147,11 @@ export function createHomeData(options?: {
 	garden?: ReturnType<typeof createGardenData> | undefined;
 	chest?: HomeFeatureHandlerContext["homeData"]["chest"];
 	upgradeStation?: HomeFeatureHandlerContext["homeData"]["upgradeStation"];
+	cookingLevel?: number;
 }): HomeFeatureHandlerContext["homeData"] {
 	return {
 		level: 3,
+		cooking: { level: options?.cookingLevel ?? 0 },
 		features: {
 			bedHealthRegeneration: 10,
 			gardenEarthQuality: GardenEarthQuality.RICH,

--- a/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
@@ -78,10 +78,11 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 	private getState(ctx: HomeFeatureHandlerContext): CookingSessionState {
 		let state = this.sessions.get(ctx.user.id);
 		if (!state) {
+			const cookingLevel = ctx.homeData.cooking.level;
 			state = {
 				currentSlots: [],
-				cookingGrade: getCookingGrade(0).id,
-				cookingLevel: 0,
+				cookingGrade: getCookingGrade(cookingLevel).id,
+				cookingLevel,
 				craftPending: false,
 				isIgnited: false
 			};

--- a/Lib/src/packets/interaction/ReactionCollectorCity.ts
+++ b/Lib/src/packets/interaction/ReactionCollectorCity.ts
@@ -105,6 +105,9 @@ export class ReactionCollectorCityData extends ReactionCollectorData {
 	home!: {
 		owned?: {
 			level: number;
+			cooking: {
+				level: number;
+			};
 
 			/** True when this `owned` entry describes a remote apartment (logis), not the player's main home. */
 			isApartment?: boolean;


### PR DESCRIPTION
## Problème

Le menu de cuisine initialisait toujours sa session locale au niveau 0, sans recevoir le niveau de cuisine réel du joueur.

## Correction

- transporte le niveau de cuisine dans les données de maison partagées ;
- renseigne ce niveau pour la maison, le logis et le menu du jardin ;
- initialise le niveau et le grade du menu Discord avec cette valeur ;
- ajoute une régression au niveau 14.

## Validations

- eslintFix, ESLint et TypeScript sur Lib, Core et Discord ;
- 580 tests Lib, 1 514 tests Core et 258 tests Discord réussis.

Closes #4564