### PR TITLE
fix Halloween event maplinks #4556

### DIFF
--- a/Core/__tests__/core/data/events/HalloweenEvents.test.ts
+++ b/Core/__tests__/core/data/events/HalloweenEvents.test.ts
@@ -1,0 +1,39 @@
+import {
+	describe, expect, it
+} from "vitest";
+import hauntedPathEvent from "../../../../resources/events/80.json";
+import hauntedHouseEvent from "../../../../resources/events/81.json";
+import hauntedPathLink from "../../../../resources/mapLinks/97.json";
+import hauntedHouseToMirageLakeLink from "../../../../resources/mapLinks/98.json";
+import hauntedHouseToWonderRoadLink from "../../../../resources/mapLinks/99.json";
+
+describe("Halloween events", () => {
+	it("uses the seasonal path to enter the haunted house", () => {
+		expect(hauntedPathEvent.possibilities.followPath.outcomes["0"].mapLink).toBe(97);
+		expect(hauntedPathEvent.possibilities.end.outcomes["0"].mapLink).toBe(97);
+		expect(hauntedPathLink).toMatchObject({
+			startMap: 39,
+			endMap: 40,
+			forcedImage: "halloween_map"
+		});
+	});
+
+	it("uses the seasonal exits from the haunted house", () => {
+		const mirageLakeOutcomes = [
+			hauntedHouseEvent.possibilities.end.outcomes["0"],
+			hauntedHouseEvent.possibilities.randomRoom.outcomes["4"],
+			hauntedHouseEvent.possibilities.visitBasement.outcomes["2"],
+			hauntedHouseEvent.possibilities.visitLobby.outcomes["4"]
+		];
+		const wonderRoadOutcomes = [
+			hauntedHouseEvent.possibilities.randomRoom.outcomes["3"],
+			hauntedHouseEvent.possibilities.visitBasement.outcomes["1"],
+			hauntedHouseEvent.possibilities.visitLobby.outcomes["3"]
+		];
+
+		expect(mirageLakeOutcomes.every(outcome => outcome.mapLink === 98)).toBe(true);
+		expect(wonderRoadOutcomes.every(outcome => outcome.mapLink === 99)).toBe(true);
+		expect(hauntedHouseToMirageLakeLink).toMatchObject({ startMap: 40, endMap: 14 });
+		expect(hauntedHouseToWonderRoadLink).toMatchObject({ startMap: 40, endMap: 21 });
+	});
+});

--- a/Core/resources/events/80.json
+++ b/Core/resources/events/80.json
@@ -3,7 +3,7 @@
     "followPath": {
       "outcomes": {
         "0": {
-          "mapLink": 100
+          "mapLink": 97
         }
       }
     },
@@ -25,7 +25,7 @@
     "end": {
       "outcomes": {
         "0": {
-          "mapLink": 100
+          "mapLink": 97
         }
       }
     }

--- a/Core/resources/events/81.json
+++ b/Core/resources/events/81.json
@@ -4,7 +4,7 @@
       "outcomes": {
         "0": {
           "health": -5,
-          "mapLink": 101
+          "mapLink": 98
         }
       }
     },
@@ -42,14 +42,14 @@
           },
           "effect": "freezing",
           "health": -80,
-          "mapLink": 102
+          "mapLink": 99
         },
         "4": {
           "condition": {
             "canAcceptPet": true
           },
           "oneshot": true,
-          "mapLink": 101
+          "mapLink": 98
         }
       }
     },
@@ -75,13 +75,13 @@
             ]
           },
           "health": -20,
-          "mapLink": 102
+          "mapLink": 99
         },
         "2": {
           "health": -35,
           "effect": "confounded",
           "money": -200,
-          "mapLink": 101
+          "mapLink": 98
         },
         "3": {
           "randomItem": {
@@ -144,7 +144,7 @@
         "3": {
           "health": -15,
           "effect": "feetHurt",
-          "mapLink": 102
+          "mapLink": 99
         },
         "4": {
           "condition": {
@@ -152,7 +152,7 @@
           },
           "health": -120,
           "effect": "injured",
-          "mapLink": 101
+          "mapLink": 98
         }
       }
     }


### PR DESCRIPTION
## Problème

Les événements d’Halloween 80 et 81 utilisaient encore les anciens maplinks 100 à 102, supprimés ou réaffectés lors du refacto des villes.

## Correction

- remplace les références obsolètes par les maplinks saisonniers existants 97 à 99 ;
- conserve les destinations maison hantée, Lac Mirage et Route des Merveilles ;
- ajoute des tests de cohérence des entrées et sorties de l’événement.

## Validations

- Core eslintFix, ESLint et TypeScript ;
- 102 fichiers de tests Core, 1 516 tests réussis.

Closes #4556