### PR TITLE
serialize nested level-up transitions #4552

### DIFF
--- a/Core/__tests__-integration/handlers/player-experience.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/player-experience.race.integration.test.ts
@@ -1,0 +1,94 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
+import type { DailyMission as DailyMissionType } from "../../src/core/database/game/models/DailyMission";
+import type { CrowniclesPacket } from "../../../Lib/src/packets/CrowniclesPacket";
+import { NumberChangeReason } from "../../../Lib/src/constants/LogsConstants";
+
+type PlayerModelModule = typeof import("../../src/core/database/game/models/Player");
+type PlayerLevelUpPacketModule = typeof import("../../../Lib/src/packets/events/PlayerLevelUpPacket");
+
+const EXPERIENCE_DELTA = 10;
+
+describe("Player experience race", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let PlayerMissionsInfo: ModelStatic<PlayerMissionsInfoType>;
+	let DailyMission: ModelStatic<DailyMissionType>;
+	let playerMod: PlayerModelModule;
+	let playerLevelUpPacketModule: PlayerLevelUpPacketModule;
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("playerexperiencerace");
+		Player = env.crownicles.gameDatabase.sequelize.models.Player as ModelStatic<PlayerType>;
+		PlayerMissionsInfo = env.crownicles.gameDatabase.sequelize.models.PlayerMissionsInfo as ModelStatic<PlayerMissionsInfoType>;
+		DailyMission = env.crownicles.gameDatabase.sequelize.models.DailyMission as ModelStatic<DailyMissionType>;
+		playerMod = loadProductionModule<PlayerModelModule>("core/database/game/models/Player");
+		playerLevelUpPacketModule = loadProductionModule<PlayerLevelUpPacketModule>("../../Lib/src/packets/events/PlayerLevelUpPacket");
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await DailyMission.destroy({ truncate: true, force: true });
+			await PlayerMissionsInfo.destroy({ truncate: true, force: true });
+			await Player.destroy({ truncate: true, force: true });
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	});
+
+	it("preserves concurrent XP gains and emits the reached level once", async () => {
+		const player = await Player.create({
+			keycloakId: "race-player-experience",
+			level: 10
+		});
+		player.experience = player.getExperienceNeededToLevelUp() - EXPERIENCE_DELTA;
+		await player.save();
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		await DailyMission.create({
+			id: 0,
+			missionId: "doReports",
+			missionObjective: 100,
+			missionVariant: 0,
+			gemsToWin: 0,
+			xpToWin: 0,
+			pointsToWin: 0,
+			moneyToWin: 0,
+			lastDate: new Date()
+		});
+
+		const responses: CrowniclesPacket[][] = [[], []];
+		const players = await runAllOrThrow([
+			playerMod.Player.findByPk(player.id),
+			playerMod.Player.findByPk(player.id)
+		]);
+		expect(players.every(Boolean)).toBe(true);
+
+		await runAllOrThrow(players.map((concurrentPlayer, index) => concurrentPlayer!.addExperience({
+			amount: EXPERIENCE_DELTA,
+			response: responses[index],
+			reason: NumberChangeReason.TEST
+		})));
+
+		const fresh = await Player.findByPk(player.id);
+		expect(fresh).toBeTruthy();
+		expect(fresh!.level).toBe(11);
+		expect(fresh!.experience).toBe(EXPERIENCE_DELTA);
+		const emittedLevels = responses.flat()
+			.filter(packet => packet instanceof playerLevelUpPacketModule.PlayerLevelUpPacket)
+			.map(packet => (packet as InstanceType<typeof playerLevelUpPacketModule.PlayerLevelUpPacket>).level);
+		expect(emittedLevels).toEqual([11]);
+	});
+});

--- a/Core/__tests__/core/missions/MissionChainStateSync.test.ts
+++ b/Core/__tests__/core/missions/MissionChainStateSync.test.ts
@@ -3,6 +3,7 @@ import {MissionsController} from "../../../src/core/missions/MissionsController"
 import Player from "../../../src/core/database/game/models/Player";
 import {NumberChangeReason} from "../../../../Lib/src/constants/LogsConstants";
 import type {CrowniclesPacket} from "@crownicles/lib";
+import {RecipeDiscoveryService} from "../../../src/core/cooking/RecipeDiscoveryService";
 
 // Mock crowniclesInstance with all required logsDatabase methods
 vi.mock("../../../src/app", () => ({
@@ -192,6 +193,40 @@ describe("Mission chain state synchronization", () => {
 			await player.levelUpIfNeeded(response);
 
 			expect(player.addLevelUpPacket).not.toHaveBeenCalled();
+		});
+
+		it("emits nested mission reward levels once and in ascending order", async () => {
+			const player = createTestPlayer({ level: 10, experience: 150 });
+			player.getExperienceNeededToLevelUp = vi.fn().mockReturnValue(100);
+			player.needLevelUp = vi.fn(function(this: Player) {
+				return this.experience >= this.getExperienceNeededToLevelUp();
+			});
+			const levelEffects: string[] = [];
+			player.addLevelUpPacket = vi.fn(async (_response, level) => {
+				levelEffects.push(`packet:${level}`);
+			});
+			vi.spyOn(RecipeDiscoveryService, "discoverFromSource").mockImplementation(async currentPlayer => {
+				levelEffects.push(`recipe:${currentPlayer.level}`);
+				return null;
+			});
+
+			vi.spyOn(MissionsController, "update").mockImplementation(async (inputPlayer, missionResponse, opts) => {
+				opts.applyOnLockedPlayer?.(inputPlayer);
+				if (inputPlayer.level === 11) {
+					inputPlayer.experience += 50;
+					await inputPlayer.levelUpIfNeeded(missionResponse);
+				}
+				return inputPlayer;
+			});
+
+			await player.levelUpIfNeeded(response);
+
+			expect(levelEffects).toEqual([
+				"recipe:11",
+				"packet:11",
+				"recipe:12",
+				"packet:12"
+			]);
 		});
 	});
 

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -42,6 +42,7 @@ import {
 import {
 	LockKey, withLockedEntities
 } from "../../../../../../Lib/src/locks/withLockedEntities";
+import { getCrowniclesNamespace } from "../../../../../../Lib/src/locks/CLSNamespace";
 import {
 	League, LeagueDataController
 } from "../../../../data/League";
@@ -103,6 +104,8 @@ const OVER_CAP_TOKEN_REASONS: ReadonlySet<NumberChangeReason> = new Set([
 	NumberChangeReason.EXPEDITION,
 	NumberChangeReason.BIG_EVENT
 ]);
+
+const PLAYERS_LEVELING_UP_CONTEXT_KEY = "playersLevelingUp" as const;
 
 /**
  * Compute the new token count after applying `amount` to `currentTokens`, honoring
@@ -503,6 +506,21 @@ export class Player extends Model {
 	 * @param response
 	 */
 	public async levelUpIfNeeded(response: CrowniclesPacket[]): Promise<void> {
+		const namespace = getCrowniclesNamespace();
+		const playersLevelingUp = namespace.get(PLAYERS_LEVELING_UP_CONTEXT_KEY) as ReadonlySet<number> | undefined;
+		if (playersLevelingUp?.has(this.id)) {
+			return;
+		}
+		await namespace.runPromise(async () => {
+			namespace.set(PLAYERS_LEVELING_UP_CONTEXT_KEY, new Set([
+				...playersLevelingUp ?? [],
+				this.id
+			]));
+			await this.processLevelUps(response);
+		});
+	}
+
+	private async processLevelUps(response: CrowniclesPacket[]): Promise<void> {
 		if (!this.needLevelUp()) {
 			return;
 		}
@@ -538,7 +556,7 @@ export class Player extends Model {
 
 		await this.addLevelUpPacket(response, this.level);
 
-		await this.levelUpIfNeeded(response);
+		await this.processLevelUps(response);
 	}
 
 	/**


### PR DESCRIPTION
## Problème

Une mission `reachLevel` pouvait attribuer de l’expérience pendant une montée de niveau et réentrer dans le traitement avant l’émission des effets du niveau courant.

## Correction

- sérialise les transitions imbriquées dans le contexte asynchrone courant ;
- conserve les appels concurrents indépendants sous verrou MariaDB ;
- vérifie l’ordre recette puis paquet pour chaque niveau ;
- ajoute une course réelle entre deux gains d’expérience.

## Validations

- Core eslintFix, ESLint et TypeScript ;
- 101 fichiers et 1 515 tests unitaires réussis ;
- test MariaDB de gains d’XP concurrents réussi.

Closes #4552