### PR TITLE
make player mutations atomic by design #4554

### DIFF
--- a/Core/__tests__-integration/handlers/player-mutations.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/player-mutations.race.integration.test.ts
@@ -1,0 +1,134 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
+import type { DailyMission as DailyMissionType } from "../../src/core/database/game/models/DailyMission";
+import type { CrowniclesPacket } from "../../../Lib/src/packets/CrowniclesPacket";
+import { NumberChangeReason } from "../../../Lib/src/constants/LogsConstants";
+
+type PlayerModelModule = typeof import("../../src/core/database/game/models/Player");
+type PlayerLevelUpPacketModule = typeof import("../../../Lib/src/packets/events/PlayerLevelUpPacket");
+
+describe("Player mutations race", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let PlayerMissionsInfo: ModelStatic<PlayerMissionsInfoType>;
+	let DailyMission: ModelStatic<DailyMissionType>;
+	let playerMod: PlayerModelModule;
+	let playerLevelUpPacketModule: PlayerLevelUpPacketModule;
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("playermutationsrace");
+		Player = env.crownicles.gameDatabase.sequelize.models.Player as ModelStatic<PlayerType>;
+		PlayerMissionsInfo = env.crownicles.gameDatabase.sequelize.models.PlayerMissionsInfo as ModelStatic<PlayerMissionsInfoType>;
+		DailyMission = env.crownicles.gameDatabase.sequelize.models.DailyMission as ModelStatic<DailyMissionType>;
+		playerMod = loadProductionModule<PlayerModelModule>("core/database/game/models/Player");
+		playerLevelUpPacketModule = loadProductionModule<PlayerLevelUpPacketModule>("../../Lib/src/packets/events/PlayerLevelUpPacket");
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await DailyMission.destroy({ truncate: true, force: true });
+			await PlayerMissionsInfo.destroy({ truncate: true, force: true });
+			await Player.destroy({ truncate: true, force: true });
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+		await DailyMission.create({
+			id: 0,
+			missionId: "doReports",
+			missionObjective: 100,
+			missionVariant: 0,
+			gemsToWin: 0,
+			xpToWin: 0,
+			pointsToWin: 0,
+			moneyToWin: 0,
+			lastDate: new Date()
+		});
+	});
+
+	async function loadConcurrentPlayers(playerId: number): Promise<[PlayerType, PlayerType]> {
+		const players = await runAllOrThrow([
+			playerMod.Player.findByPk(playerId),
+			playerMod.Player.findByPk(playerId)
+		]);
+		expect(players.every(Boolean)).toBe(true);
+		return players as [PlayerType, PlayerType];
+	}
+
+	it("preserves concurrent money gain and token spending", async () => {
+		const player = await Player.create({
+			keycloakId: "race-player-money-tokens",
+			money: 1000,
+			tokens: 10
+		});
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		const [moneyPlayer, tokenPlayer] = await loadConcurrentPlayers(player.id);
+
+		await runAllOrThrow([
+			moneyPlayer.addMoney({
+				amount: 100,
+				response: [],
+				reason: NumberChangeReason.TEST,
+				ignoreBlessing: true
+			}),
+			tokenPlayer.useTokens({
+				amount: 3,
+				response: [],
+				reason: NumberChangeReason.TEST
+			})
+		]);
+
+		const fresh = await Player.findByPk(player.id);
+		expect(fresh).toBeTruthy();
+		expect(fresh!.money).toBe(1100);
+		expect(fresh!.tokens).toBe(7);
+	});
+
+	it("preserves concurrent healing and XP while emitting one level", async () => {
+		const player = await Player.create({
+			keycloakId: "race-player-health-experience",
+			level: 10,
+			health: 50
+		});
+		player.experience = player.getExperienceNeededToLevelUp() - 10;
+		await player.save();
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		const [healthPlayer, experiencePlayer] = await loadConcurrentPlayers(player.id);
+		const responses: CrowniclesPacket[][] = [[], []];
+
+		await runAllOrThrow([
+			healthPlayer.addHealth({
+				amount: 20,
+				response: responses[0],
+				reason: NumberChangeReason.TEST
+			}),
+			experiencePlayer.addExperience({
+				amount: 10,
+				response: responses[1],
+				reason: NumberChangeReason.TEST
+			})
+		]);
+
+		const fresh = await Player.findByPk(player.id);
+		expect(fresh).toBeTruthy();
+		expect(fresh!.health).toBe(70);
+		expect(fresh!.level).toBe(11);
+		expect(fresh!.experience).toBe(0);
+		const emittedLevels = responses.flat()
+			.filter(packet => packet instanceof playerLevelUpPacketModule.PlayerLevelUpPacket)
+			.map(packet => (packet as InstanceType<typeof playerLevelUpPacketModule.PlayerLevelUpPacket>).level);
+		expect(emittedLevels).toEqual([11]);
+	});
+});

--- a/Core/__tests__/core/architecture/PlayerMutationContract.test.ts
+++ b/Core/__tests__/core/architecture/PlayerMutationContract.test.ts
@@ -1,0 +1,31 @@
+import {
+	describe, expect, it
+} from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const PLAYER_MODEL_PATH = path.join(__dirname, "../../../src/core/database/game/models/Player.ts");
+
+function countOccurrences(source: string, value: string): number {
+	return source.split(value).length - 1;
+}
+
+describe("Player mutation contract", () => {
+	it("centralizes mission reloads and caller synchronization", () => {
+		const source = fs.readFileSync(PLAYER_MODEL_PATH, "utf8");
+		const contractStart = source.indexOf("private async mutateWithMission(");
+		const contractEnd = source.indexOf("\n\t/**\n\t * Add or remove points", contractStart);
+		const contract = source.slice(contractStart, contractEnd);
+
+		expect(contractStart).toBeGreaterThan(-1);
+		expect(contractEnd).toBeGreaterThan(contractStart);
+		expect(countOccurrences(source, "MissionsController.update(this")).toBe(1);
+		expect(countOccurrences(source, "MissionsController.updateMultiple(this")).toBe(1);
+		expect(countOccurrences(source, "Player.withLocked(this.id")).toBe(1);
+		expect(countOccurrences(source, "Object.assign(this")).toBe(3);
+		expect(contract).toContain("MissionsController.update(this");
+		expect(contract).toContain("MissionsController.updateMultiple(this");
+		expect(contract).toContain("Player.withLocked(this.id");
+		expect(countOccurrences(contract, "Object.assign(this")).toBe(3);
+	});
+});

--- a/Core/__tests__/core/missions/MissionChainStateSync.test.ts
+++ b/Core/__tests__/core/missions/MissionChainStateSync.test.ts
@@ -118,6 +118,7 @@ describe("Mission chain state synchronization", () => {
 			const player = createTestPlayer({ money: 1000 });
 
 			const updateSpy = vi.spyOn(MissionsController, "update").mockResolvedValue(player);
+			vi.spyOn(Player, "withLocked").mockImplementation(async (_id, body) => body(player));
 
 			await player.addMoney({
 				amount: -100,
@@ -164,7 +165,11 @@ describe("Mission chain state synchronization", () => {
 	describe("Player.spendMoney", () => {
 		it("keeps money awarded by the spendMoney mission before applying the debit", async () => {
 			const player = createTestPlayer({ money: 1000 });
-			vi.spyOn(MissionsController, "update").mockResolvedValue(createTestPlayer({ money: 1100 }));
+			vi.spyOn(MissionsController, "update").mockImplementation(async (inputPlayer, _response, opts) => {
+				const rewardedPlayer = createTestPlayer({ money: inputPlayer.money + 100 });
+				opts.applyOnLockedPlayer?.(rewardedPlayer);
+				return rewardedPlayer;
+			});
 
 			await player.spendMoney({
 				amount: 50,
@@ -200,8 +205,9 @@ describe("Mission chain state synchronization", () => {
 			const player = createTestPlayer({ score: 100, experience: 500 });
 			const originalExperience = player.experience;
 
-			vi.spyOn(MissionsController, "update").mockImplementation(async (inputPlayer, _response, opts) => {
-				opts.applyOnLockedPlayer?.(inputPlayer);
+			vi.spyOn(MissionsController, "updateMultiple").mockImplementation(async (inputPlayer, _response, missions) => {
+				expect(missions.map(mission => mission.missionId)).toEqual(["earnPoints", "reachScore"]);
+				missions[0].applyOnLockedPlayer?.(inputPlayer);
 				return createTestPlayer({
 					...inputPlayer,
 					score: inputPlayer.score,
@@ -223,13 +229,13 @@ describe("Mission chain state synchronization", () => {
 			const player = createTestPlayer({ score: 100, weeklyScore: 200 });
 			let persistedWeeklyScore = 0;
 
-			vi.spyOn(MissionsController, "update").mockImplementation(async (inputPlayer, _response, opts) => {
+			vi.spyOn(MissionsController, "updateMultiple").mockImplementation(async (inputPlayer, _response, missions) => {
 				const lockedPlayer = createTestPlayer({
 					...inputPlayer,
 					score: inputPlayer.score,
 					weeklyScore: inputPlayer.weeklyScore
 				});
-				opts.applyOnLockedPlayer?.(lockedPlayer);
+				missions[0].applyOnLockedPlayer?.(lockedPlayer);
 				persistedWeeklyScore = lockedPlayer.weeklyScore;
 				return lockedPlayer;
 			});

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -5,7 +5,9 @@ import InventorySlot, { InventorySlots } from "./InventorySlot";
 import PetEntity from "./PetEntity";
 import MissionSlot from "./MissionSlot";
 import { InventoryInfos } from "./InventoryInfo";
-import { MissionsController } from "../../../missions/MissionsController";
+import {
+	MissionInformations, MissionsController
+} from "../../../missions/MissionsController";
 import { PlayerActiveObjects } from "./PlayerActiveObjects";
 import {
 	asMilliseconds,
@@ -286,6 +288,47 @@ export class Player extends Model {
 	}
 
 	/**
+	 * Apply a gameplay mutation and its mission progress against the same freshly
+	 * locked player, then synchronize this caller instance with the committed state.
+	 */
+	private async mutateWithMission(
+		response: CrowniclesPacket[],
+		mission: Omit<MissionInformations, "applyOnLockedPlayer">,
+		mutate: (lockedPlayer: Player) => void
+	): Promise<void> {
+		const updatedPlayer = await MissionsController.update(this, response, {
+			...mission,
+			applyOnLockedPlayer: mutate
+		});
+		Object.assign(this, updatedPlayer);
+	}
+
+	private async mutateWithMissions(
+		response: CrowniclesPacket[],
+		missions: Omit<MissionInformations, "applyOnLockedPlayer">[],
+		mutate: (lockedPlayer: Player) => void
+	): Promise<void> {
+		const [firstMission, ...otherMissions] = missions;
+		const updatedPlayer = await MissionsController.updateMultiple(this, response, [
+			{
+				...firstMission,
+				applyOnLockedPlayer: mutate
+			},
+			...otherMissions
+		]);
+		Object.assign(this, updatedPlayer);
+	}
+
+	private async mutateLocked(mutate: (lockedPlayer: Player) => void): Promise<void> {
+		const updatedPlayer = await Player.withLocked(this.id, async lockedPlayer => {
+			mutate(lockedPlayer);
+			await lockedPlayer.save();
+			return lockedPlayer;
+		});
+		Object.assign(this, updatedPlayer);
+	}
+
+	/**
 	 * Add or remove points from the score of a player
 	 * @param parameters
 	 */
@@ -294,22 +337,25 @@ export class Player extends Model {
 			parameters.amount = Math.round(parameters.amount * BlessingManager.getInstance().getScoreMultiplier());
 		}
 		const delta = parameters.amount;
-		if (delta > 0) {
-			const newPlayer = await MissionsController.update(this, parameters.response, {
-				missionId: "earnPoints",
-				count: delta,
-				applyOnLockedPlayer: locked => {
-					locked.score += delta;
-					locked.addWeeklyScore(delta);
-				}
-			});
-			Object.assign(this, newPlayer);
-		}
-		else {
-			this.score += delta;
-			this.addWeeklyScore(delta);
-		}
-		await this.setScore(this.score, parameters.response);
+		const scoreMissions: Omit<MissionInformations, "applyOnLockedPlayer">[] = [
+			...delta > 0
+				? [
+					{
+						missionId: "earnPoints",
+						count: delta
+					}
+				]
+				: [],
+			{
+				missionId: "reachScore",
+				count: locked => locked.score,
+				set: true
+			}
+		];
+		await this.mutateWithMissions(parameters.response, scoreMissions, locked => {
+			locked.score = Math.max(0, locked.score + delta);
+			locked.addWeeklyScore(delta);
+		});
 		crowniclesInstance?.logsDatabase.logScoreChange(this.keycloakId, this.score, parameters.reason)
 			.then();
 		return this;
@@ -325,22 +371,17 @@ export class Player extends Model {
 		}
 		const delta = parameters.amount;
 		if (delta > 0) {
-			const newPlayer = await MissionsController.update(this, parameters.response, {
+			await this.mutateWithMission(parameters.response, {
 				missionId: "earnMoney",
-				count: delta,
-				applyOnLockedPlayer: locked => {
-					locked.money += delta;
-				}
+				count: delta
+			}, locked => {
+				locked.money = Math.max(0, locked.money + delta);
 			});
-
-			/*
-			 * Clone the mission entity and player to this player model and the entity instance passed in the parameters
-			 * As the money and experience may have changed, we update the models of the caller
-			 */
-			Object.assign(this, newPlayer);
 		}
 		else {
-			this.money += delta;
+			await this.mutateLocked(locked => {
+				locked.money = Math.max(0, locked.money + delta);
+			});
 		}
 		this.setMoney(this.money);
 		crowniclesInstance?.logsDatabase.logMoneyChange(this.keycloakId, this.money, parameters.reason)
@@ -353,15 +394,16 @@ export class Player extends Model {
 	 * @param parameters
 	 */
 	public async spendMoney(parameters: EditValueParameters): Promise<Player> {
-		const newPlayer = await MissionsController.update(this, parameters.response, {
+		const amount = Math.abs(parameters.amount);
+		await this.mutateWithMission(parameters.response, {
 			missionId: "spendMoney",
-			count: parameters.amount
+			count: amount
+		}, locked => {
+			locked.money = Math.max(0, locked.money - amount);
 		});
-		Object.assign(this, newPlayer);
-		return this.addMoney({
-			...parameters,
-			amount: -parameters.amount
-		});
+		crowniclesInstance?.logsDatabase.logMoneyChange(this.keycloakId, this.money, parameters.reason)
+			.then();
+		return this;
 	}
 
 	/**
@@ -369,46 +411,33 @@ export class Player extends Model {
 	 * @param parameters
 	 */
 	public async addTokens(parameters: EditValueParameters): Promise<Player> {
-		const previousTokens = this.tokens;
-		const newTokens = computeNewTokens(this.tokens, parameters.amount, parameters.reason);
-
-		if (newTokens === previousTokens) {
-			return this;
-		}
-
-		this.setTokens(newTokens);
-		await crowniclesInstance?.logsDatabase.logTokensChange(this.keycloakId, this.tokens, parameters.reason);
-
-		// Track missions for earning tokens
-		const actualChange = newTokens - previousTokens;
-		if (actualChange > 0) {
-			let newPlayer = await MissionsController.update(this, parameters.response, {
-				missionId: "earnTokens",
-				count: actualChange,
-				applyOnLockedPlayer: locked => {
-					/*
-					 * Recompute against the fresh locked value to avoid clobbering
-					 * a concurrent token update that happened between the caller's
-					 * read of `this.tokens` and the lock acquisition.
-					 */
-					locked.tokens = computeNewTokens(locked.tokens, parameters.amount, parameters.reason);
+		if (parameters.amount > 0) {
+			let actualChange = 0;
+			await this.mutateWithMissions(parameters.response, [
+				{
+					missionId: "earnTokens",
+					count: (): number => actualChange
+				},
+				{
+					missionId: "maxTokensReached",
+					count: (locked): number => locked.tokens >= TokensConstants.MAX ? 1 : 0,
+					set: true
 				}
+			], locked => {
+				const previousTokens = locked.tokens;
+				locked.tokens = computeNewTokens(previousTokens, parameters.amount, parameters.reason);
+				actualChange = locked.tokens - previousTokens;
 			});
-
-			/*
-			 * Clone the mission entity and player to this player model and the entity instance passed in the parameters
-			 * As the money and experience may have changed, we update the models of the caller
-			 */
-			Object.assign(this, newPlayer);
-
-			// Check if max tokens reached
-			if (this.tokens >= TokensConstants.MAX) {
-				newPlayer = await MissionsController.update(this, parameters.response, {
-					missionId: "maxTokensReached"
-				});
-				Object.assign(this, newPlayer);
+			if (actualChange === 0) {
+				return this;
 			}
 		}
+		else {
+			await this.mutateLocked(locked => {
+				locked.tokens = computeNewTokens(locked.tokens, parameters.amount, parameters.reason);
+			});
+		}
+		await crowniclesInstance?.logsDatabase.logTokensChange(this.keycloakId, this.tokens, parameters.reason);
 
 		return this;
 	}
@@ -420,15 +449,14 @@ export class Player extends Model {
 	public async useTokens(parameters: EditValueParameters): Promise<Player> {
 		const tokensToUse = Math.abs(parameters.amount);
 
-		// Track missions for spending tokens
-		const newPlayer = await MissionsController.update(this, parameters.response, {
+		await this.mutateWithMission(parameters.response, {
 			missionId: "spendTokens",
 			count: tokensToUse
+		}, locked => {
+			locked.tokens = computeNewTokens(locked.tokens, -tokensToUse, parameters.reason);
 		});
-		Object.assign(this, newPlayer);
-
-		parameters.amount = -tokensToUse;
-		return this.addTokens(parameters);
+		await crowniclesInstance?.logsDatabase.logTokensChange(this.keycloakId, this.tokens, parameters.reason);
+		return this;
 	}
 
 	/**
@@ -508,24 +536,23 @@ export class Player extends Model {
 		}
 
 		let didLevelUp = false;
-		Object.assign(this, await MissionsController.update(this, response, {
+		await this.mutateWithMission(response, {
 			missionId: "reachLevel",
 			count: locked => locked.level,
-			set: true,
-			applyOnLockedPlayer: locked => {
-				/*
-				 * Re-evaluate against the freshly-locked row in case a concurrent
-				 * transaction already advanced the level: only apply the level-up
-				 * if `locked` still has enough XP for its current level.
-				 */
-				if (!locked.needLevelUp()) {
-					return;
-				}
-				locked.experience -= locked.getExperienceNeededToLevelUp();
-				locked.level += 1;
-				didLevelUp = true;
+			set: true
+		}, locked => {
+			/*
+			 * Re-evaluate against the freshly-locked row in case a concurrent
+			 * transaction already advanced the level: only apply the level-up
+			 * if `locked` still has enough XP for its current level.
+			 */
+			if (!locked.needLevelUp()) {
+				return;
 			}
-		}));
+			locked.experience -= locked.getExperienceNeededToLevelUp();
+			locked.level += 1;
+			didLevelUp = true;
+		});
 		if (!didLevelUp) {
 			return;
 		}
@@ -805,22 +832,17 @@ export class Player extends Model {
 	public async addExperience(parameters: EditValueParameters): Promise<Player> {
 		const delta = parameters.amount;
 		if (delta > 0) {
-			const newPlayer = await MissionsController.update(this, parameters.response, {
+			await this.mutateWithMission(parameters.response, {
 				missionId: "earnXP",
-				count: delta,
-				applyOnLockedPlayer: locked => {
-					locked.experience += delta;
-				}
+				count: delta
+			}, locked => {
+				locked.experience += delta;
 			});
-
-			/*
-			 * Clone the mission entity and player to this player model, and the entity instance passed in the parameters
-			 * As the money and experience may have changed, we update the models of the caller
-			 */
-			Object.assign(this, newPlayer);
 		}
 		else {
-			this.experience += delta;
+			await this.mutateLocked(locked => {
+				locked.experience += delta;
+			});
 		}
 		crowniclesInstance?.logsDatabase.logExperienceChange(this.keycloakId, this.experience, parameters.reason)
 			.then();
@@ -1129,7 +1151,7 @@ export class Player extends Model {
 		else {
 			await crowniclesInstance?.logsDatabase.logPlayersAttackGloryPoints(this.keycloakId, gloryPoints, reason, fightId ?? undefined);
 		}
-		Object.assign(this, await MissionsController.update(this, response, {
+		await this.mutateWithMission(response, {
 			missionId: "reachGlory",
 
 			/*
@@ -1138,16 +1160,15 @@ export class Player extends Model {
 			 * update is included rather than overwritten.
 			 */
 			count: locked => locked.attackGloryPoints + locked.defenseGloryPoints,
-			set: true,
-			applyOnLockedPlayer: locked => {
-				if (isDefense) {
-					locked.defenseGloryPoints = gloryPoints;
-				}
-				else {
-					locked.attackGloryPoints = gloryPoints;
-				}
+			set: true
+		}, locked => {
+			if (isDefense) {
+				locked.defenseGloryPoints = gloryPoints;
 			}
-		}));
+			else {
+				locked.attackGloryPoints = gloryPoints;
+			}
+		});
 	}
 
 	/**
@@ -1178,20 +1199,29 @@ export class Player extends Model {
 		const amount = parameters.amount > 0 && BlessingManager.getInstance().isRageAmplified()
 			? parameters.amount * 2
 			: parameters.amount;
-		await this.setRage(this.rage + amount, parameters.reason);
 		if (parameters.amount > 0) {
-			await MissionsController.update(this, parameters.response, {
+			await this.mutateWithMission(parameters.response, {
 				missionId: "gainRage",
 				count: parameters.amount
+			}, locked => {
+				locked.rage += amount;
 			});
 		}
+		else {
+			await this.mutateLocked(locked => {
+				locked.rage += amount;
+			});
+		}
+		crowniclesInstance?.logsDatabase.logRageChange(this.keycloakId, this.rage, parameters.reason)
+			.then();
 	}
 
 	public async setRage(rage: number, reason: NumberChangeReason): Promise<void> {
-		this.rage = rage;
+		await this.mutateLocked(locked => {
+			locked.rage = rage;
+		});
 		crowniclesInstance?.logsDatabase.logRageChange(this.keycloakId, this.rage, reason)
 			.then();
-		await this.save();
 	}
 
 	/**
@@ -1238,25 +1268,6 @@ export class Player extends Model {
 			moneyLost,
 			guildPointsLost: this.hasAGuild() ? guildPointsLost : 0
 		};
-	}
-
-	/**
-	 * Allow to set the score of a player to a specific value this is only called from addScore
-	 * @param score
-	 * @param response
-	 */
-	private async setScore(score: number, response: CrowniclesPacket[]): Promise<void> {
-		await MissionsController.update(this, response, {
-			missionId: "reachScore",
-			count: score,
-			set: true
-		});
-		if (score > 0) {
-			this.score = score;
-		}
-		else {
-			this.score = 0;
-		}
 	}
 
 	/**
@@ -1313,35 +1324,26 @@ export class Player extends Model {
 		overHealCountsForMission: true,
 		shouldPokeMission: true
 	}): Promise<void> {
-		const maxHealth = this.getMaxHealth();
 		const healthDelta = health - this.health;
 		if (healthDelta > 0 && missionHealthParameter.shouldPokeMission) {
 			let lockedDifference = 0;
-			const updatedPlayer = await MissionsController.update(this, response, {
+			await this.mutateWithMission(response, {
 				missionId: "earnLifePoints",
-				count: () => lockedDifference,
-				applyOnLockedPlayer: locked => {
-					const lockedMaxHealth = locked.getMaxHealth();
-					const lockedHealth = Math.min(locked.health, lockedMaxHealth);
-					const requestedHealth = lockedHealth + healthDelta;
-					lockedDifference = (requestedHealth > lockedMaxHealth && !missionHealthParameter.overHealCountsForMission
-						? lockedMaxHealth
-						: requestedHealth < 0 ? 0 : requestedHealth) - lockedHealth;
-					locked.health = MathUtils.clamp(requestedHealth, 0, lockedMaxHealth);
-				}
+				count: () => lockedDifference
+			}, locked => {
+				const lockedMaxHealth = locked.getMaxHealth();
+				const lockedHealth = Math.min(locked.health, lockedMaxHealth);
+				const requestedHealth = lockedHealth + healthDelta;
+				lockedDifference = (requestedHealth > lockedMaxHealth && !missionHealthParameter.overHealCountsForMission
+					? lockedMaxHealth
+					: requestedHealth < 0 ? 0 : requestedHealth) - lockedHealth;
+				locked.health = MathUtils.clamp(requestedHealth, 0, lockedMaxHealth);
 			});
-			Object.assign(this, updatedPlayer);
 			return;
 		}
-		if (health < 0) {
-			this.health = 0;
-		}
-		else if (health > maxHealth) {
-			this.health = maxHealth;
-		}
-		else {
-			this.health = health;
-		}
+		await this.mutateLocked(locked => {
+			locked.health = MathUtils.clamp(locked.health + healthDelta, 0, locked.getMaxHealth());
+		});
 	}
 
 	/**

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -5,9 +5,7 @@ import InventorySlot, { InventorySlots } from "./InventorySlot";
 import PetEntity from "./PetEntity";
 import MissionSlot from "./MissionSlot";
 import { InventoryInfos } from "./InventoryInfo";
-import {
-	MissionInformations, MissionsController
-} from "../../../missions/MissionsController";
+import { MissionsController } from "../../../missions/MissionsController";
 import { PlayerActiveObjects } from "./PlayerActiveObjects";
 import {
 	asMilliseconds,
@@ -95,6 +93,8 @@ type ressourcesLostOnPveFaint = {
 	moneyLost: number;
 	guildPointsLost: number;
 };
+
+type MissionInformations = Parameters<typeof MissionsController.update>[2];
 
 /**
  * Reasons whose token gains are allowed to push the player above the normal

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -40,7 +40,7 @@ import { assertUnderLock } from "../../../../Lib/src/locks/CLSNamespace";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 
 
-export type MissionInformations = {
+type MissionInformations = {
 	missionId: string;
 
 	/**

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -40,7 +40,7 @@ import { assertUnderLock } from "../../../../Lib/src/locks/CLSNamespace";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 
 
-type MissionInformations = {
+export type MissionInformations = {
 	missionId: string;
 
 	/**


### PR DESCRIPTION
## Problème

Les mutateurs `Player` mélangeaient mutations locales, rechargements via les missions et sauvegardes différées. Leur correction dépendait donc de l’ordre des appels et pouvait écraser un état concurrent.

## Correction

- centralise les contrats de mutation avec mission, lot de missions et mutation simple verrouillée ;
- migre argent, score, jetons, expérience, santé, gloire et rage ;
- rend les débits et les progressions de mission atomiques ;
- ajoute un garde d’architecture contre le retour des rechargements dispersés ;
- ajoute des courses MariaDB argent/jetons et santé/XP/niveau.

Les mutations de voyage restent dans le périmètre dédié de #4571.

## Validations

- Core eslintFix, ESLint et TypeScript ;
- 102 fichiers et 1 515 tests unitaires réussis ;
- 2 tests MariaDB de mutations concurrentes réussis.

Closes #4554