### PR TITLE
update CI actions to Node 24 #4542

### DIFF
--- a/.github/workflows/core-module.yml
+++ b/.github/workflows/core-module.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Setup Node.js environment once for all jobs
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -29,7 +29,7 @@ jobs:
 
       # Cache PNPM dependencies for Core module
       - name: Cache Core dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ./Core/node_modules

--- a/.github/workflows/daily-advice.yml
+++ b/.github/workflows/daily-advice.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Send daily advice
       env:

--- a/.github/workflows/discord-module.yml
+++ b/.github/workflows/discord-module.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Setup Node.js environment once for all jobs
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -29,7 +29,7 @@ jobs:
 
       # Cache PNPM dependencies for Discord module
       - name: Cache Discord dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ./Discord/node_modules

--- a/.github/workflows/docker-images-beta.yml
+++ b/.github/workflows/docker-images-beta.yml
@@ -14,22 +14,22 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     -
       name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Get current date
       id: date
       run: echo "date=$(date +'%s')" >> $GITHUB_OUTPUT
     -
       name: Build and push Core
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Core/Dockerfile
@@ -37,7 +37,7 @@ jobs:
         tags: ${{ secrets.DOCKER_HUB_USERNAME }}/core-beta:latest,${{ secrets.DOCKER_HUB_USERNAME }}/core-beta:${{ steps.date.outputs.date }}
     -
       name: Build and push Discord
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Discord/Dockerfile

--- a/.github/workflows/docker-images-master.yml
+++ b/.github/workflows/docker-images-master.yml
@@ -11,22 +11,22 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     -
       name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Get current date
       id: date
       run: echo "date=$(date +'%s')" >> $GITHUB_OUTPUT
     -
       name: Build and push Core
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Core/Dockerfile
@@ -34,7 +34,7 @@ jobs:
         tags: ${{ secrets.DOCKER_HUB_USERNAME }}/core:latest,${{ secrets.DOCKER_HUB_USERNAME }}/core:${{ steps.date.outputs.date }}
     -
       name: Build and push Discord
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Discord/Dockerfile

--- a/.github/workflows/docker-images-pre-release.yml
+++ b/.github/workflows/docker-images-pre-release.yml
@@ -14,22 +14,22 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     -
       name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Get current date
       id: date
       run: echo "date=$(date +'%s')" >> $GITHUB_OUTPUT
     -
       name: Build and push Core
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Core/Dockerfile
@@ -37,7 +37,7 @@ jobs:
         tags: ${{ secrets.DOCKER_HUB_USERNAME }}/core-pre-release:latest,${{ secrets.DOCKER_HUB_USERNAME }}/core-pre-release:${{ steps.date.outputs.date }}
     -
       name: Build and push Discord
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Discord/Dockerfile

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,10 +38,10 @@ jobs:
       TEST_DB_PASSWORD: secret_password
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -52,7 +52,7 @@ jobs:
           corepack prepare pnpm@10.26.0 --activate
 
       - name: Cache PNPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             **/node_modules
@@ -96,7 +96,7 @@ jobs:
         run: pnpm --dir ./Core test:integration
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: core-integration-results

--- a/.github/workflows/lib-module.yml
+++ b/.github/workflows/lib-module.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Setup Node.js environment once for all jobs
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -29,7 +29,7 @@ jobs:
 
       # Cache PNPM dependencies
       - name: Cache PNPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ./Lib/node_modules

--- a/.github/workflows/restws-module.yml
+++ b/.github/workflows/restws-module.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Setup Node.js environment once for all jobs
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -29,7 +29,7 @@ jobs:
 
       # Cache PNPM dependencies for RestWs module
       - name: Cache RestWs dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ./RestWs/node_modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -28,7 +28,7 @@ jobs:
           corepack prepare pnpm@10.26.0 --activate
 
       - name: Cache PNPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             **/node_modules
@@ -46,7 +46,7 @@ jobs:
         run: pnpm --dir ./Lib test
 
       - name: Upload Lib test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: lib-test-results
@@ -60,7 +60,7 @@ jobs:
         run: pnpm --dir ./Discord test
 
       - name: Upload Discord test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: discord-test-results
@@ -74,7 +74,7 @@ jobs:
         run: pnpm --dir ./Core test
 
       - name: Upload Core test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: core-test-results

--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -28,7 +28,7 @@ jobs:
           corepack prepare pnpm@10.26.0 --activate
 
       - name: Cache PNPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             **/node_modules


### PR DESCRIPTION
## Problème

Les workflows utilisaient encore d’anciennes versions d’actions GitHub basées sur Node 16 ou Node 20. Les runners les forçaient désormais à s’exécuter sous Node 24 et affichaient un avertissement de dépréciation à chaque étape de build.

## Correction

- migre `actions/checkout`, `actions/setup-node`, `actions/cache` et `actions/upload-artifact` vers leurs majeures Node 24 ;
- migre les actions Docker de connexion, Buildx et build/push vers leurs majeures Node 24 ;
- couvre les onze workflows, y compris les intégrations et le conseil quotidien.

## Validations

- les onze workflows passent un parse YAML structuré ;
- chaque référence d’action unique a été résolue et son manifeste déclare `node24` ;
- aucune ancienne action Node 16/20 ne subsiste ;
- `git diff --check` et les diagnostics VS Code sont verts ;
- review indépendante sans constat.

Closes #4542