### PR TITLE
fix all channel permission translations #4575

### DIFF
--- a/Discord/__tests__/utils/ChannelPermissionUtils.test.ts
+++ b/Discord/__tests__/utils/ChannelPermissionUtils.test.ts
@@ -5,17 +5,25 @@ import { ChannelType } from "discord.js";
 import i18n from "../../src/translations/i18n";
 import { LANGUAGE } from "../../../Lib/src/Language";
 import {
-	getThreadSendAccessError, THREAD_SEND_ACCESS_ERRORS, ThreadSendAccessError
+	CHANNEL_PERMISSION_ERRORS, getThreadSendAccessError, THREAD_SEND_ACCESS_ERRORS
 } from "../../src/commands/ChannelPermissionUtils";
 
-function expectTranslationExists(error: ThreadSendAccessError | null): void {
+function expectTranslationExists(error: string | null): void {
 	if (error === null) {
-		throw new Error("Expected a thread send access error");
+		throw new Error("Expected a channel permission error");
 	}
 	for (const language of [LANGUAGE.FRENCH, LANGUAGE.ENGLISH]) {
 		expect(i18n.t(error, { lng: language })).not.toBe(error);
 	}
 }
+
+describe("channel permission error translations", () => {
+	it("translates every permission error", () => {
+		for (const error of [...Object.values(CHANNEL_PERMISSION_ERRORS), ...Object.values(THREAD_SEND_ACCESS_ERRORS)]) {
+			expectTranslationExists(error);
+		}
+	});
+});
 
 describe("getThreadSendAccessError", () => {
 	it("allows non-thread channels", () => {

--- a/Discord/src/commands/ChannelPermissionUtils.ts
+++ b/Discord/src/commands/ChannelPermissionUtils.ts
@@ -1,5 +1,14 @@
 import { ChannelType } from "discord.js";
 
+export const CHANNEL_PERMISSION_ERRORS = {
+	NO_CHANNEL_ACCESS: "bot:noChannelAccess",
+	NO_SPEAK_PERMISSION: "bot:noSpeakPermission",
+	NO_REACTION_PERMISSION: "bot:noReacPermission",
+	NO_EMBED_PERMISSION: "bot:noEmbedPermission",
+	NO_FILE_PERMISSION: "bot:noFilePermission",
+	NO_HISTORY_PERMISSION: "bot:noHistoryPermission"
+} as const;
+
 export const THREAD_SEND_ACCESS_ERRORS = {
 	NOT_JOINED: "bot:noThreadMembership",
 	CANNOT_SEND: "bot:noSpeakInThreadPermission"

--- a/Discord/src/commands/CommandsManager.ts
+++ b/Discord/src/commands/CommandsManager.ts
@@ -60,7 +60,9 @@ import {
 	verifyDeletionCode
 } from "../utils/AccountDeletionUtils";
 import { isCommandModuleFile } from "./CommandDiscoveryUtils";
-import { getThreadSendAccessError } from "./ChannelPermissionUtils";
+import {
+	CHANNEL_PERMISSION_ERRORS, getThreadSendAccessError
+} from "./ChannelPermissionUtils";
 
 export class CommandsManager {
 	static commands = new Map<string, ICommand>();
@@ -640,13 +642,13 @@ export class CommandsManager {
 		if (!channel.permissionsFor(crowniclesClient!.user!)
 			?.has(PermissionsBitField.Flags.ViewChannel)) {
 			CrowniclesLogger.error(`No way to access the channel where the command has been executed : ${channel.guildId}/${channel.id}`);
-			return [false, "noChannelAccess"];
+			return [false, CHANNEL_PERMISSION_ERRORS.NO_CHANNEL_ACCESS];
 		}
 
 		if (!channel.permissionsFor(crowniclesClient!.user!)
 			?.has(PermissionsBitField.Flags.SendMessages)) {
 			CrowniclesLogger.error(`No way to send messages in the channel where the command has been executed : ${channel.guildId}/${channel.id}`);
-			return [false, "noSpeakPermission"];
+			return [false, CHANNEL_PERMISSION_ERRORS.NO_SPEAK_PERMISSION];
 		}
 
 		const threadSendAccessError = getThreadSendAccessError(channel);
@@ -658,25 +660,25 @@ export class CommandsManager {
 		if (!channel.permissionsFor(crowniclesClient!.user!)
 			?.has(PermissionsBitField.Flags.AddReactions)) {
 			CrowniclesLogger.error(`No perms to show i can't react in server / channel : ${channel.guildId}/${channel.id}`);
-			return [false, "noReacPermission"];
+			return [false, CHANNEL_PERMISSION_ERRORS.NO_REACTION_PERMISSION];
 		}
 
 		if (!channel.permissionsFor(crowniclesClient!.user!)
 			?.has(PermissionsBitField.Flags.EmbedLinks)) {
 			CrowniclesLogger.error(`No perms to show i can't embed in server / channel : ${channel.guildId}/${channel.id}`);
-			return [false, "noEmbedPermission"];
+			return [false, CHANNEL_PERMISSION_ERRORS.NO_EMBED_PERMISSION];
 		}
 
 		if (!channel.permissionsFor(crowniclesClient!.user!)
 			?.has(PermissionsBitField.Flags.AttachFiles)) {
 			CrowniclesLogger.error(`No perms to show i can't attach files in server / channel : ${channel.guildId}/${channel.id}`);
-			return [false, "noFilePermission"];
+			return [false, CHANNEL_PERMISSION_ERRORS.NO_FILE_PERMISSION];
 		}
 
 		if (!channel.permissionsFor(crowniclesClient!.user!)
 			?.has(PermissionsBitField.Flags.ReadMessageHistory)) {
 			CrowniclesLogger.error(`No perms to show i can't see messages history in server / channel : ${channel.guildId}/${channel.id}`);
-			return [false, "noHistoryPermission"];
+			return [false, CHANNEL_PERMISSION_ERRORS.NO_HISTORY_PERMISSION];
 		}
 
 		return [true, ""];


### PR DESCRIPTION
## Problème

Le premier correctif de #4575 qualifiait uniquement les deux erreurs propres aux threads avec le namespace `bot:`. Les contrôles génériques de permissions pouvaient encore transmettre une clé brute comme `noSpeakPermission` à i18next, laissant l’embed sans explication.

## Solution

- centraliser toutes les clés d’erreur de permissions Discord avec leur namespace `bot:` ;
- utiliser ces constantes dans le gestionnaire de commandes ;
- vérifier en français et en anglais que chaque erreur de permission possède une traduction.

## Validation

- `Discord`: `pnpm eslint` OK
- `Discord`: `pnpm tsc` OK
- `Discord`: `pnpm test` OK (260 tests)

Fixes #4575