### PR TITLE
fix #4597 mort sans raison apparente et changement de classe

### DIFF
--- a/Core/__tests__/core/database/models/PlayerHealthDeath.test.ts
+++ b/Core/__tests__/core/database/models/PlayerHealthDeath.test.ts
@@ -1,0 +1,240 @@
+import {
+	afterEach, beforeEach, describe, expect, it, vi
+} from "vitest";
+import Player from "../../../../src/core/database/game/models/Player";
+import { Crownicles } from "../../../../src/core/bot/Crownicles";
+import { setCrowniclesInstanceForTests } from "../../../../src/app";
+import { TravelTime } from "../../../../src/core/maps/TravelTime";
+import { PlayerActiveObjects } from "../../../../src/core/database/game/models/PlayerActiveObjects";
+import { Effect } from "../../../../../Lib/src/types/Effect";
+import { NumberChangeReason } from "../../../../../Lib/src/constants/LogsConstants";
+import { CrowniclesPacket } from "../../../../../Lib/src/packets/CrowniclesPacket";
+import { PlayerDeathPacket } from "../../../../../Lib/src/packets/events/PlayerDeathPacket";
+
+/**
+ * Build a bare Player instance without going through Sequelize's constructor/DB,
+ * only setting the fields read by the health methods under test.
+ */
+function buildPlayer(params: {
+	level: number;
+	classId: number;
+	health: number;
+	fightPointsLost?: number;
+}): Player {
+	const player = Object.create(Player.prototype) as Player;
+	player.level = params.level;
+	player.class = params.classId;
+	player.health = params.health;
+	player.fightPointsLost = params.fightPointsLost ?? 0;
+	player.effectId = Effect.NO_EFFECT.id;
+	player.keycloakId = "test-keycloak-id";
+	return player;
+}
+
+/**
+ * Active objects without any enchantment, so the max energy only depends on the class
+ */
+const noEnchantmentActiveObjects = {
+	weapon: { itemEnchantmentId: null },
+	armor: { itemEnchantmentId: null }
+} as PlayerActiveObjects;
+
+function countDeathPackets(response: CrowniclesPacket[]): number {
+	return response.filter(packet => packet instanceof PlayerDeathPacket).length;
+}
+
+describe("Player health and death", () => {
+	let applyEffectSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		setCrowniclesInstanceForTests({
+			logsDatabase: {
+				logHealthChange: vi.fn().mockResolvedValue(undefined),
+				logEnergyChange: vi.fn().mockResolvedValue(undefined)
+			}
+		} as unknown as Crownicles);
+		applyEffectSpy = vi.spyOn(TravelTime, "applyEffect")
+			.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		setCrowniclesInstanceForTests(null);
+		vi.restoreAllMocks();
+	});
+
+	describe("addHealth", () => {
+		it("kills the player when the damage empties their health bar", async () => {
+			const player = buildPlayer({
+				level: 10,
+				classId: 0,
+				health: 26
+			});
+			const response: CrowniclesPacket[] = [];
+
+			await player.addHealth({
+				amount: -26,
+				response,
+				reason: NumberChangeReason.SMALL_EVENT
+			});
+
+			expect(player.getHealthValue()).toBe(0);
+			expect(countDeathPackets(response)).toBe(1);
+			expect(applyEffectSpy).toHaveBeenCalledWith(player, Effect.DEAD, 0, expect.any(Date), NumberChangeReason.SMALL_EVENT);
+		});
+
+		it("never lets the health go below 0 and still kills the player on overkill", async () => {
+			const player = buildPlayer({
+				level: 10,
+				classId: 0,
+				health: 3
+			});
+			const response: CrowniclesPacket[] = [];
+
+			await player.addHealth({
+				amount: -100,
+				response,
+				reason: NumberChangeReason.BIG_EVENT
+			});
+
+			expect(player.getHealthValue()).toBe(0);
+			expect(countDeathPackets(response)).toBe(1);
+		});
+
+		it("does not kill the player when some health is left", async () => {
+			const player = buildPlayer({
+				level: 10,
+				classId: 0,
+				health: 26
+			});
+			const response: CrowniclesPacket[] = [];
+
+			await player.addHealth({
+				amount: -25,
+				response,
+				reason: NumberChangeReason.SMALL_EVENT
+			});
+
+			expect(player.getHealthValue()).toBe(1);
+			expect(countDeathPackets(response)).toBe(0);
+			expect(applyEffectSpy).not.toHaveBeenCalled();
+		});
+
+		it("caps the health to the maximum before applying the change", async () => {
+			const player = buildPlayer({
+				level: 10,
+				classId: 0,
+				health: 500
+			});
+			const response: CrowniclesPacket[] = [];
+
+			await player.addHealth({
+				amount: -5,
+				response,
+				reason: NumberChangeReason.SMALL_EVENT
+			});
+
+			// Class 0 tops at 65 + 10 = 75 health at level 10
+			expect(player.getHealthValue()).toBe(70);
+		});
+	});
+
+	describe("killIfNeeded", () => {
+		it("re-applies the dead effect but pushes a single death packet per response", async () => {
+			const player = buildPlayer({
+				level: 10,
+				classId: 0,
+				health: 0
+			});
+			const response: CrowniclesPacket[] = [];
+
+			expect(await player.killIfNeeded(response, NumberChangeReason.BIG_EVENT)).toBe(true);
+
+			// Simulate an outcome effect overwriting the dead effect before the final safety check
+			player.effectId = Effect.OCCUPIED.id;
+
+			expect(await player.killIfNeeded(response, NumberChangeReason.BIG_EVENT)).toBe(true);
+			expect(applyEffectSpy).toHaveBeenCalledTimes(2);
+			expect(countDeathPackets(response)).toBe(1);
+		});
+
+		it("does not re-apply the dead effect when the player is already dead", async () => {
+			const player = buildPlayer({
+				level: 10,
+				classId: 0,
+				health: 0
+			});
+			player.effectId = Effect.DEAD.id;
+			const response: CrowniclesPacket[] = [];
+
+			expect(await player.killIfNeeded(response, NumberChangeReason.BIG_EVENT)).toBe(true);
+			expect(applyEffectSpy).not.toHaveBeenCalled();
+			expect(countDeathPackets(response)).toBe(1);
+		});
+	});
+
+	describe("changeClass", () => {
+		it("keeps the health ratio when switching to a frailer class instead of dropping to 0", async () => {
+			const player = buildPlayer({
+				level: 9,
+				classId: 0,
+				health: 71
+			});
+			const response: CrowniclesPacket[] = [];
+
+			// Class 0 tops at 65 + 9 = 74 health at level 9, class 8 only at 10 + 9 = 19
+			expect(player.getMaxHealth()).toBe(74);
+
+			await player.changeClass(8, noEnchantmentActiveObjects, response);
+
+			expect(player.getMaxHealth()).toBe(19);
+			expect(player.getHealthValue()).toBe(19);
+			expect(countDeathPackets(response)).toBe(0);
+		});
+
+		it("keeps the health ratio when switching to a sturdier class", async () => {
+			const player = buildPlayer({
+				level: 9,
+				classId: 8,
+				health: 10
+			});
+			const response: CrowniclesPacket[] = [];
+
+			await player.changeClass(0, noEnchantmentActiveObjects, response);
+
+			// 10 / 19 of a 74 health bar
+			expect(player.getHealthValue()).toBe(39);
+			expect(countDeathPackets(response)).toBe(0);
+		});
+
+		it("caps the health to the previous maximum before rescaling", async () => {
+			const player = buildPlayer({
+				level: 9,
+				classId: 0,
+				health: 500
+			});
+			const response: CrowniclesPacket[] = [];
+
+			await player.changeClass(8, noEnchantmentActiveObjects, response);
+
+			expect(player.getHealthValue()).toBe(19);
+		});
+
+		it("keeps the lost energy ratio", async () => {
+			const player = buildPlayer({
+				level: 9,
+				classId: 0,
+				health: 74
+			});
+			const response: CrowniclesPacket[] = [];
+			const previousMaxEnergy = player.getMaxCumulativeEnergy(noEnchantmentActiveObjects);
+			const previousEnergyLost = Math.floor(previousMaxEnergy / 2);
+			player.fightPointsLost = previousEnergyLost;
+
+			await player.changeClass(8, noEnchantmentActiveObjects, response);
+
+			const newMaxEnergy = player.getMaxCumulativeEnergy(noEnchantmentActiveObjects);
+			expect(newMaxEnergy).not.toBe(previousMaxEnergy);
+			expect(player.fightPointsLost).toBe(Math.ceil(previousEnergyLost / previousMaxEnergy * newMaxEnergy));
+		});
+	});
+});

--- a/Core/__tests__/core/database/models/PlayerHealthDeath.test.ts
+++ b/Core/__tests__/core/database/models/PlayerHealthDeath.test.ts
@@ -226,15 +226,15 @@ describe("Player health and death", () => {
 				health: 74
 			});
 			const response: CrowniclesPacket[] = [];
-			const previousMaxEnergy = player.getMaxCumulativeEnergy(noEnchantmentActiveObjects);
-			const previousEnergyLost = Math.floor(previousMaxEnergy / 2);
-			player.fightPointsLost = previousEnergyLost;
+
+			// Class 0 tops at 351 cumulative energy at level 9, class 8 only at 281
+			expect(player.getMaxCumulativeEnergy(noEnchantmentActiveObjects)).toBe(351);
+			player.fightPointsLost = 175;
 
 			await player.changeClass(8, noEnchantmentActiveObjects, response);
 
-			const newMaxEnergy = player.getMaxCumulativeEnergy(noEnchantmentActiveObjects);
-			expect(newMaxEnergy).not.toBe(previousMaxEnergy);
-			expect(player.fightPointsLost).toBe(Math.ceil(previousEnergyLost / previousMaxEnergy * newMaxEnergy));
+			expect(player.getMaxCumulativeEnergy(noEnchantmentActiveObjects)).toBe(281);
+			expect(player.fightPointsLost).toBe(141);
 		});
 	});
 });

--- a/Core/__tests__/core/utils/PacketUtils.test.ts
+++ b/Core/__tests__/core/utils/PacketUtils.test.ts
@@ -1,0 +1,75 @@
+import {
+	afterEach, beforeEach, describe, expect, it, vi
+} from "vitest";
+import { PacketUtils } from "../../../src/core/utils/PacketUtils";
+import { mqttClient } from "../../../src/mqttClient";
+import {
+	CrowniclesPacket, PacketContext, makePacket
+} from "../../../../Lib/src/packets/CrowniclesPacket";
+import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { PlayerDeathPacket } from "../../../../Lib/src/packets/events/PlayerDeathPacket";
+import { PlayerLevelUpPacket } from "../../../../Lib/src/packets/events/PlayerLevelUpPacket";
+
+const context = { discord: { shardId: 0 } } as PacketContext;
+
+function getSentPacketNames(publishSpy: ReturnType<typeof vi.spyOn>): string[] {
+	const payload = JSON.parse(publishSpy.mock.calls[0][1] as string) as {
+		packets: { name: string }[];
+	};
+	return payload.packets.map(packet => packet.name);
+}
+
+describe("PacketUtils.sendPackets", () => {
+	beforeEach(() => {
+		vi.spyOn(CrowniclesLogger, "debug")
+			.mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("sends the death packet last so the narration is not cut in half", () => {
+		const publishSpy = vi.spyOn(mqttClient, "publish")
+			.mockImplementation(() => mqttClient);
+		const packets: CrowniclesPacket[] = [
+			makePacket(PlayerDeathPacket, {}),
+			makePacket(PlayerLevelUpPacket, {
+				level: 2,
+				health: true,
+				energy: true,
+				fightPoints: true,
+				classesTier: undefined
+			})
+		];
+
+		PacketUtils.sendPackets(context, packets);
+
+		expect(getSentPacketNames(publishSpy)).toStrictEqual(["PlayerLevelUpPacket", "PlayerDeathPacket"]);
+	});
+
+	it("keeps the original order when nobody died", () => {
+		const publishSpy = vi.spyOn(mqttClient, "publish")
+			.mockImplementation(() => mqttClient);
+		const packets: CrowniclesPacket[] = [
+			makePacket(PlayerLevelUpPacket, {
+				level: 2,
+				health: true,
+				energy: true,
+				fightPoints: true,
+				classesTier: undefined
+			}),
+			makePacket(PlayerLevelUpPacket, {
+				level: 3,
+				health: true,
+				energy: true,
+				fightPoints: true,
+				classesTier: undefined
+			})
+		];
+
+		PacketUtils.sendPackets(context, packets);
+
+		expect(getSentPacketNames(publishSpy)).toStrictEqual(["PlayerLevelUpPacket", "PlayerLevelUpPacket"]);
+	});
+});

--- a/Core/__tests__/core/utils/PacketUtils.test.ts
+++ b/Core/__tests__/core/utils/PacketUtils.test.ts
@@ -4,11 +4,12 @@ import {
 import { PacketUtils } from "../../../src/core/utils/PacketUtils";
 import { mqttClient } from "../../../src/mqttClient";
 import {
-	CrowniclesPacket, PacketContext, makePacket
+	CrowniclesPacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { PlayerDeathPacket } from "../../../../Lib/src/packets/events/PlayerDeathPacket";
 import { PlayerLevelUpPacket } from "../../../../Lib/src/packets/events/PlayerLevelUpPacket";
+import { PlayerLeavePveIslandPacket } from "../../../../Lib/src/packets/events/PlayerLeavePveIslandPacket";
 
 const context = { discord: { shardId: 0 } } as PacketContext;
 
@@ -33,14 +34,8 @@ describe("PacketUtils.sendPackets", () => {
 		const publishSpy = vi.spyOn(mqttClient, "publish")
 			.mockImplementation(() => mqttClient);
 		const packets: CrowniclesPacket[] = [
-			makePacket(PlayerDeathPacket, {}),
-			makePacket(PlayerLevelUpPacket, {
-				level: 2,
-				health: true,
-				energy: true,
-				fightPoints: true,
-				classesTier: undefined
-			})
+			new PlayerDeathPacket(),
+			new PlayerLevelUpPacket()
 		];
 
 		PacketUtils.sendPackets(context, packets);
@@ -52,24 +47,12 @@ describe("PacketUtils.sendPackets", () => {
 		const publishSpy = vi.spyOn(mqttClient, "publish")
 			.mockImplementation(() => mqttClient);
 		const packets: CrowniclesPacket[] = [
-			makePacket(PlayerLevelUpPacket, {
-				level: 2,
-				health: true,
-				energy: true,
-				fightPoints: true,
-				classesTier: undefined
-			}),
-			makePacket(PlayerLevelUpPacket, {
-				level: 3,
-				health: true,
-				energy: true,
-				fightPoints: true,
-				classesTier: undefined
-			})
+			new PlayerLevelUpPacket(),
+			new PlayerLeavePveIslandPacket()
 		];
 
 		PacketUtils.sendPackets(context, packets);
 
-		expect(getSentPacketNames(publishSpy)).toStrictEqual(["PlayerLevelUpPacket", "PlayerLevelUpPacket"]);
+		expect(getSentPacketNames(publishSpy)).toStrictEqual(["PlayerLevelUpPacket", "PlayerLeavePveIslandPacket"]);
 	});
 });

--- a/Core/src/commands/player/ClassesCommand.ts
+++ b/Core/src/commands/player/ClassesCommand.ts
@@ -23,7 +23,6 @@ import {
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorChangeClass";
 import { BlockingUtils } from "../../core/utils/BlockingUtils";
 import { ReactionCollectorRefuseReaction } from "../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
-import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
 import { MissionsController } from "../../core/missions/MissionsController";
 import { crowniclesInstance } from "../../app";
 import { WhereAllowed } from "../../../../Lib/src/types/WhereAllowed";
@@ -44,31 +43,15 @@ function getEndCallback(player: Player) {
 
 			await withLockedPlayerAndMissionsSafe(player, "class change", async lockedPlayer => {
 				const selectedClass = (firstReaction.reaction.data as ReactionCollectorChangeClassReaction).classId;
-				const oldClass = ClassDataController.instance.getById(lockedPlayer.class);
 				const newClass = ClassDataController.instance.getById(selectedClass);
-				const level = lockedPlayer.level;
 
-				if (!oldClass || !newClass) {
+				if (!newClass) {
 					response.push(makePacket(CommandClassesCancelErrorPacket, {}));
 					return;
 				}
 
-				lockedPlayer.class = selectedClass;
 				const playerActiveObjects = await InventorySlots.getPlayerActiveObjects(lockedPlayer.id);
-				await lockedPlayer.addHealth({
-					amount: Math.ceil(
-						lockedPlayer.getHealthValue() / oldClass.getMaxHealthValue(level) * newClass.getMaxHealthValue(level)
-					) - lockedPlayer.getHealthValue(),
-					response,
-					reason: NumberChangeReason.CLASS,
-					missionHealthParameter: {
-						shouldPokeMission: false,
-						overHealCountsForMission: false
-					}
-				});
-				lockedPlayer.setEnergyLost(Math.ceil(
-					lockedPlayer.fightPointsLost / oldClass.getMaxCumulativeEnergyValue(level) * newClass.getMaxCumulativeEnergyValue(level)
-				), NumberChangeReason.CLASS, playerActiveObjects);
+				await lockedPlayer.changeClass(selectedClass, playerActiveObjects, response);
 				await lockedPlayer.save();
 				await MissionsController.update(lockedPlayer, response, { missionId: "chooseClass" });
 				await MissionsController.update(lockedPlayer, response, {

--- a/Core/src/core/database/game/migrations/068-fix-zombie-players-health.ts
+++ b/Core/src/core/database/game/migrations/068-fix-zombie-players-health.ts
@@ -1,0 +1,21 @@
+import { QueryInterface } from "sequelize";
+
+export async function up({ context }: { context: QueryInterface }): Promise<void> {
+	/*
+	 * Between the "cities2" merge and the fix of #4597, `addHealth` stopped calling `killIfNeeded`: every damage
+	 * source outside of big events (small events, class change, ...) could leave a player alive with 0 health.
+	 * Those "zombies" would then die at their next big event, seemingly without any reason.
+	 * Give them back 10 health so they are not killed by the restored death check. Players who are actually dead
+	 * (waiting for a respawn) keep their 0 health.
+	 */
+	await context.sequelize.query(`
+		UPDATE players
+		SET health = 10
+		WHERE health <= 0
+		  AND effectId <> 'dead'
+	`);
+}
+
+export async function down(): Promise<void> {
+	// No rollback: putting those players back at 0 health would recreate the bug.
+}

--- a/Core/src/core/database/game/migrations/068-fix-zombie-players-health.ts
+++ b/Core/src/core/database/game/migrations/068-fix-zombie-players-health.ts
@@ -7,6 +7,8 @@ export async function up({ context }: { context: QueryInterface }): Promise<void
 	 * Those "zombies" would then die at their next big event, seemingly without any reason.
 	 * Give them back 10 health so they are not killed by the restored death check. Players who are actually dead
 	 * (waiting for a respawn) keep their 0 health.
+	 * The 'dead' effect id is inlined on purpose: a migration must keep describing the schema as it was when it ran,
+	 * even if `Effect.DEAD` is renamed later.
 	 */
 	await context.sequelize.query(`
 		UPDATE players

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -554,16 +554,23 @@ export class Player extends Model {
 
 	/**
 	 * Check if we need to kill the player (mouahaha)
+	 * Idempotent: the death effect is (re)applied as long as the player has no health left, but a single
+	 * {@link PlayerDeathPacket} is pushed per response, even when several health changes reach 0 in the same flow
+	 * (e.g. a big event outcome that damages the player and then overwrites their effect).
 	 * @param response
 	 * @param reason
+	 * @returns true if the player is dead
 	 */
 	public async killIfNeeded(response: CrowniclesPacket[], reason: NumberChangeReason): Promise<boolean> {
 		if (this.health > 0) {
 			return false;
 		}
-		await TravelTime.applyEffect(this, Effect.DEAD, 0, new Date(), reason);
-		const packet = makePacket(PlayerDeathPacket, {});
-		response.push(packet);
+		if (this.effectId !== Effect.DEAD.id) {
+			await TravelTime.applyEffect(this, Effect.DEAD, 0, new Date(), reason);
+		}
+		if (!response.some(packet => packet instanceof PlayerDeathPacket)) {
+			response.push(makePacket(PlayerDeathPacket, {}));
+		}
 		return true;
 	}
 
@@ -962,23 +969,55 @@ export class Player extends Model {
 
 	/**
 	 * Add health to the player
+	 * Note: this method automatically calls {@link killIfNeeded} after updating the health, so no code path can
+	 * leave the player alive with 0 health (#4597)
 	 * @param parameters - Object containing amount, response, reason and optional missionHealthParameter
 	 */
-	public async addHealth(parameters: HealthEditValueParameters): Promise<boolean> {
+	public async addHealth(parameters: HealthEditValueParameters): Promise<void> {
 		const missionParam: MissionHealthParameter = parameters.missionHealthParameter ?? {
 			overHealCountsForMission: true,
 			shouldPokeMission: true
 		};
 
-		const maxHealth = this.getMaxHealth();
-		if (this.health > maxHealth) {
-			this.health = maxHealth;
-		}
-		await this.setHealth(this.health + parameters.amount, parameters.response, missionParam);
+		await this.setHealth(this.getHealth() + parameters.amount, parameters.response, missionParam);
 
 		crowniclesInstance?.logsDatabase.logHealthChange(this.keycloakId, this.health, parameters.reason)
 			.then();
-		return this.health > 0;
+		await this.killIfNeeded(parameters.response, parameters.reason);
+	}
+
+	/**
+	 * Change the class of the player, rescaling their health and energy so they keep the same ratios.
+	 *
+	 * Both maximums depend on the class, so they have to be read before the class actually changes: computing the
+	 * health target on the old scale while {@link addHealth} applies the delta on the new one made the difference be
+	 * subtracted twice and dropped players to 0 health (#4597).
+	 * @param newClassId
+	 * @param playerActiveObjects
+	 * @param response
+	 */
+	public async changeClass(newClassId: number, playerActiveObjects: PlayerActiveObjects, response: CrowniclesPacket[]): Promise<void> {
+		const previousMaxHealth = this.getMaxHealth();
+		const previousHealth = Math.min(this.getHealthValue(), previousMaxHealth);
+		const previousEnergyLostRatio = this.fightPointsLost / this.getMaxCumulativeEnergy(playerActiveObjects);
+
+		this.class = newClassId;
+
+		const targetHealth = Math.ceil(previousHealth / previousMaxHealth * this.getMaxHealth());
+		await this.addHealth({
+			amount: targetHealth - this.getHealth(),
+			response,
+			reason: NumberChangeReason.CLASS,
+			missionHealthParameter: {
+				shouldPokeMission: false,
+				overHealCountsForMission: false
+			}
+		});
+		this.setEnergyLost(
+			Math.ceil(previousEnergyLostRatio * this.getMaxCumulativeEnergy(playerActiveObjects)),
+			NumberChangeReason.CLASS,
+			playerActiveObjects
+		);
 	}
 
 	/**

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -970,7 +970,8 @@ export class Player extends Model {
 	/**
 	 * Add health to the player
 	 * Note: this method automatically calls {@link killIfNeeded} after updating the health, so no code path can
-	 * leave the player alive with 0 health (#4597)
+	 * leave the player alive with 0 health (#4597). A lethal change therefore persists the player through
+	 * {@link TravelTime.applyEffect}: callers must hold the player lock.
 	 * @param parameters - Object containing amount, response, reason and optional missionHealthParameter
 	 */
 	public async addHealth(parameters: HealthEditValueParameters): Promise<void> {

--- a/Core/src/core/utils/PacketUtils.ts
+++ b/Core/src/core/utils/PacketUtils.ts
@@ -18,13 +18,14 @@ export abstract class PacketUtils {
 	 * @param packets
 	 */
 	private static moveDeathPacketsLast(packets: CrowniclesPacket[]): CrowniclesPacket[] {
-		if (!packets.some(packet => packet instanceof PlayerDeathPacket)) {
+		const deathPackets = packets.filter(packet => packet instanceof PlayerDeathPacket);
+		if (deathPackets.length === 0) {
 			return packets;
 		}
 
 		return [
 			...packets.filter(packet => !(packet instanceof PlayerDeathPacket)),
-			...packets.filter(packet => packet instanceof PlayerDeathPacket)
+			...deathPackets
 		];
 	}
 

--- a/Core/src/core/utils/PacketUtils.ts
+++ b/Core/src/core/utils/PacketUtils.ts
@@ -6,17 +6,36 @@ import { mqttClient } from "../../mqttClient";
 import { AnnouncementPacket } from "../../../../Lib/src/packets/announcements/AnnouncementPacket";
 import { NotificationPacket } from "../../../../Lib/src/packets/notifications/NotificationPacket";
 import { NotificationsSerializedPacket } from "../../../../Lib/src/packets/notifications/NotificationsSerializedPacket";
+import { PlayerDeathPacket } from "../../../../Lib/src/packets/events/PlayerDeathPacket";
 import { MqttTopicUtils } from "../../../../Lib/src/utils/MqttTopicUtils";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 
 export abstract class PacketUtils {
+	/**
+	 * The death of a player is detected as soon as their health reaches 0, which can happen in the middle of a flow
+	 * (e.g. before the outcome of a big event has been described). Sending the death packets last keeps the kill
+	 * check on the only chokepoint that cannot be forgotten while preserving a readable order for the player.
+	 * @param packets
+	 */
+	private static moveDeathPacketsLast(packets: CrowniclesPacket[]): CrowniclesPacket[] {
+		if (!packets.some(packet => packet instanceof PlayerDeathPacket)) {
+			return packets;
+		}
+
+		return [
+			...packets.filter(packet => !(packet instanceof PlayerDeathPacket)),
+			...packets.filter(packet => packet instanceof PlayerDeathPacket)
+		];
+	}
+
 	static sendPackets(context: PacketContext, packets: CrowniclesPacket[]): void {
 		const responsePacket = {
 			context,
-			packets: packets.map(responsePacket => ({
-				name: responsePacket.constructor.name,
-				packet: responsePacket
-			}))
+			packets: PacketUtils.moveDeathPacketsLast(packets)
+				.map(responsePacket => ({
+					name: responsePacket.constructor.name,
+					packet: responsePacket
+				}))
 		};
 
 		const response = JSON.stringify(responsePacket);


### PR DESCRIPTION
Fixes #4597

## Contexte

Deux régressions apparues pendant la v6 (merge `0db4000bf`, branche `cities2`) provoquaient des morts « sans raison apparente ».

### Bug A — plus aucune vérification de mort en dehors des gros événements

`Player.addHealth` se terminait par `return this.health > 0;` : l'appel à `killIfNeeded` avait disparu. En v6, `killIfNeeded` n'avait plus qu'un seul appelant, `ReportBigEventService`.

Conséquence : tous les autres chemins de dégâts (petits événements `bigBad`, `smallBad`, jeu des gobelets, sorcière, Limoges, familier, île PVE, changement de classe, `/test kill`) laissaient le joueur **vivant avec 0 point de vie**. La mort ne se déclenchait qu'au gros événement suivant, sans rapport avec ce qui l'avait réellement tué.

### Bug B — le changement de classe pouvait vider la barre de vie

`ClassesCommand` calculait le delta de vie sur la valeur **non plafonnée**, alors que `addHealth` commençait par plafonner à la **nouvelle** max (la classe ayant déjà été changée). La différence était donc soustraite deux fois, jusqu'à tomber à 0 en passant à une classe plus fragile.

## Changements

- `Player.addHealth` rappelle `killIfNeeded` : plus aucun chemin ne peut laisser un joueur vivant à 0 PV. Elle retourne désormais `void` (aucun appelant ne lisait la valeur, et sa sémantique était ambiguë).
- `Player.killIfNeeded` devient idempotent : l'effet `DEAD` est réappliqué tant que la vie est à 0 (utile quand `applyOutcomeEffect` l'écrase), mais un seul `PlayerDeathPacket` est poussé par réponse. Cela corrige au passage un double message de mort latent depuis la v5.
- Nouvelle méthode `Player.changeClass` qui encapsule le changement de classe et le rescale de la vie **et** de l'énergie. Les deux maximums sont lus avant la bascule, ce qui rend l'erreur d'ordre impossible depuis l'extérieur. `ClassesCommand` se réduit à un appel.
- `PacketUtils.sendPackets` déplace les `PlayerDeathPacket` en fin de lot. Le message KO clôt donc toujours la narration, quel que soit le moment où les dégâts sont appliqués. C'est plus robuste que la v6, dont l'ordre n'était correct que parce que le gros événement poussait la mort manuellement à la fin.
- Simplification du plafonnement dans `addHealth` (`getHealth()` le faisait déjà).
- Migration `068-fix-zombie-players-health` : les joueurs bloqués à 0 PV **sans** l'effet `dead` (136 en production) repassent à 10 PV. Les joueurs réellement morts, en attente de `/respawn` (327), ne sont pas touchés.

## Tests

Deux nouveaux fichiers, 8 tests :

- `PlayerHealthDeath.test.ts` : létalité, overkill, non-mort, idempotence de `killIfNeeded`, rescale de classe dans les deux sens, ratio d'énergie conservé.
- `PacketUtils.test.ts` : l'ordre réellement publié sur MQTT est vérifié en parsant le JSON.

`pnpm test` (1529 tests), `pnpm tsc --noEmit` et `pnpm eslint` sont verts.
