### PR TITLE
Boucles periodiques resilientes et metriques d'etat interne du Core

### DIFF
--- a/Core/__tests__/core/bot/ResilientLoop.test.ts
+++ b/Core/__tests__/core/bot/ResilientLoop.test.ts
@@ -1,0 +1,79 @@
+import {
+	afterEach, beforeEach, describe, expect, it, vi
+} from "vitest";
+import { asMilliseconds } from "../../../../Lib/src/types/TimeTypes";
+
+vi.mock("../../../../Lib/src/logs/CrowniclesLogger", () => ({
+	CrowniclesLogger: {
+		error: vi.fn(),
+		errorWithObj: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/bot/CrowniclesCoreMetrics", () => ({
+	CrowniclesCoreMetrics: { observeLoopRun: vi.fn() }
+}));
+
+const {
+	PERIODIC_LOOPS, startResilientLoop
+} = await import("../../../src/core/bot/ResilientLoop");
+const { CrowniclesCoreMetrics } = await import("../../../src/core/bot/CrowniclesCoreMetrics");
+const { CrowniclesLogger } = await import("../../../../Lib/src/logs/CrowniclesLogger");
+
+const DELAY = asMilliseconds(1000);
+
+describe("startResilientLoop", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("keeps running after an iteration rejects", async () => {
+		const iteration = vi.fn()
+			.mockRejectedValueOnce(new Error("database unavailable"))
+			.mockResolvedValue(undefined);
+
+		startResilientLoop(PERIODIC_LOOPS.ENERGY_REGEN, iteration, DELAY, { startImmediately: true });
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(iteration).toHaveBeenCalledTimes(1);
+		expect(CrowniclesLogger.errorWithObj).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(DELAY);
+		expect(iteration).toHaveBeenCalledTimes(2);
+
+		await vi.advanceTimersByTimeAsync(DELAY);
+		expect(iteration).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not record a heartbeat for a failed iteration but records one for the next success", async () => {
+		const iteration = vi.fn()
+			.mockRejectedValueOnce(new Error("database unavailable"))
+			.mockResolvedValue(undefined);
+
+		startResilientLoop(PERIODIC_LOOPS.REPORT_NOTIFICATIONS, iteration, DELAY, { startImmediately: true });
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(CrowniclesCoreMetrics.observeLoopRun).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(DELAY);
+		expect(CrowniclesCoreMetrics.observeLoopRun).toHaveBeenCalledWith(PERIODIC_LOOPS.REPORT_NOTIFICATIONS);
+	});
+
+	it("waits for a full delay before the first iteration when asked to", async () => {
+		const iteration = vi.fn()
+			.mockResolvedValue(undefined);
+
+		startResilientLoop(PERIODIC_LOOPS.ENERGY_REGEN, iteration, DELAY, { startImmediately: false });
+
+		await vi.advanceTimersByTimeAsync(DELAY - 1);
+		expect(iteration).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(iteration).toHaveBeenCalledTimes(1);
+	});
+});

--- a/Core/__tests__/core/utils/SpaceUtils.test.ts
+++ b/Core/__tests__/core/utils/SpaceUtils.test.ts
@@ -5,7 +5,28 @@ import {
 
 vi.mock("https", () => ({ get: vi.fn() }));
 
+vi.mock("../../../../Lib/src/logs/CrowniclesLogger", () => ({
+	CrowniclesLogger: {
+		error: vi.fn(),
+		errorWithObj: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/bot/CrowniclesCoreMetrics", async () => {
+	const actual = await vi.importActual<typeof import("../../../src/core/bot/CrowniclesCoreMetrics")>("../../../src/core/bot/CrowniclesCoreMetrics");
+	return {
+		...actual,
+		CrowniclesCoreMetrics: {
+			incrementExternalApiCall: vi.fn(),
+			incrementExternalApiFailure: vi.fn()
+		}
+	};
+});
+
 const { get } = await import("https");
+const {
+	CrowniclesCoreMetrics, EXTERNAL_API_FAILURE_REASONS, EXTERNAL_APIS
+} = await import("../../../src/core/bot/CrowniclesCoreMetrics");
 const { SpaceUtils } = await import("../../../src/core/utils/SpaceUtils");
 
 type FakeResponse = EventEmitter & {
@@ -62,11 +83,28 @@ describe("SpaceUtils.getNeoWSFeed", () => {
 		response.emit("end");
 
 		await expect(feed).rejects.toThrow();
+		expect(CrowniclesCoreMetrics.incrementExternalApiFailure).toHaveBeenCalledWith(
+			EXTERNAL_APIS.NEO_WS,
+			EXTERNAL_API_FAILURE_REASONS.INVALID_RESPONSE
+		);
 	});
 
 	it("rejects when the feed answers with an error status", async () => {
 		mockNeoWsAnswer(503);
 
 		await expect(SpaceUtils.getNeoWSFeed()).rejects.toThrow("HTTP status 503");
+		expect(CrowniclesCoreMetrics.incrementExternalApiFailure).toHaveBeenCalledWith(
+			EXTERNAL_APIS.NEO_WS,
+			EXTERNAL_API_FAILURE_REASONS.HTTP_STATUS
+		);
+	});
+
+	it("counts each outgoing call exactly once", async () => {
+		mockNeoWsAnswer(503);
+
+		await expect(SpaceUtils.getNeoWSFeed()).rejects.toThrow();
+
+		expect(CrowniclesCoreMetrics.incrementExternalApiCall).toHaveBeenCalledTimes(1);
+		expect(CrowniclesCoreMetrics.incrementExternalApiFailure).toHaveBeenCalledTimes(1);
 	});
 });

--- a/Core/__tests__/core/utils/SpaceUtils.test.ts
+++ b/Core/__tests__/core/utils/SpaceUtils.test.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from "events";
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+
+vi.mock("https", () => ({ get: vi.fn() }));
+
+const { get } = await import("https");
+const { SpaceUtils } = await import("../../../src/core/utils/SpaceUtils");
+
+type FakeResponse = EventEmitter & {
+	statusCode: number;
+	resume: () => void;
+};
+
+type FakeRequest = EventEmitter & {
+	setTimeout: (ms: number, callback: () => void) => void;
+	destroy: (error?: Error) => void;
+};
+
+/*
+ * The `https.get` overloads cannot be expressed as a single mockable signature,
+ * hence the cast to the only shape SpaceUtils actually relies on.
+ */
+const httpsGet = get as unknown as ReturnType<typeof vi.fn<(url: string, callback: (res: FakeResponse) => void) => FakeRequest>>;
+
+function buildFakeResponse(statusCode: number): FakeResponse {
+	return Object.assign(new EventEmitter(), {
+		statusCode,
+		resume: (): void => {
+			// Nothing to drain in a fake response
+		}
+	});
+}
+
+function mockNeoWsAnswer(statusCode: number): FakeResponse {
+	const response = buildFakeResponse(statusCode);
+	httpsGet.mockImplementation((_url, callback) => {
+		callback(response);
+		return Object.assign(new EventEmitter(), {
+			setTimeout: (): void => {
+				// The timeout is never triggered in these tests
+			},
+			destroy: (): void => {
+				// Nothing to destroy in a fake request
+			}
+		});
+	});
+	return response;
+}
+
+describe("SpaceUtils.getNeoWSFeed", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("rejects instead of hanging forever when the feed answers with an unparsable body", async () => {
+		const response = mockNeoWsAnswer(200);
+
+		const feed = SpaceUtils.getNeoWSFeed();
+		response.emit("data", "<html>service unavailable</html>");
+		response.emit("end");
+
+		await expect(feed).rejects.toThrow();
+	});
+
+	it("rejects when the feed answers with an error status", async () => {
+		mockNeoWsAnswer(503);
+
+		await expect(SpaceUtils.getNeoWSFeed()).rejects.toThrow("HTTP status 503");
+	});
+});

--- a/Core/src/core/bot/Crownicles.ts
+++ b/Core/src/core/bot/Crownicles.ts
@@ -10,6 +10,7 @@ import {
 	asDays, asWeeks, daysToMilliseconds, minutesToMilliseconds, weeksToMilliseconds
 } from "../../../../Lib/src/utils/TimeUtils";
 import { TimeoutFunctionsConstants } from "../../../../Lib/src/constants/TimeoutFunctionsConstants";
+import { asMilliseconds } from "../../../../Lib/src/types/TimeTypes";
 import { MapCache } from "../maps/MapCache";
 import { registerAllPacketHandlers } from "../packetHandlers/PacketHandler";
 import { CommandsTest } from "../CommandsTest";
@@ -51,6 +52,9 @@ import { CrowniclesMonday } from "./cronJobs/CrowniclesMonday";
 import { CrowniclesEach10Minutes } from "./cronJobs/CrowniclesEach10Minutes";
 import { CrowniclesChristmas } from "./cronJobs/CrowniclesChristmas";
 import { ReleaseGift } from "./ReleaseGift";
+import {
+	PERIODIC_LOOPS, startResilientLoop
+} from "./ResilientLoop";
 
 export class Crownicles {
 	public readonly packetListener: PacketListenerServer;
@@ -245,7 +249,7 @@ export class Crownicles {
 			})));
 		}
 
-		Player.update(
+		await Player.update(
 			{
 				fightPointsLost: Sequelize.literal(
 					`CASE WHEN fightPointsLost - ${regenAmount} < 0 THEN 0 ELSE fightPointsLost - ${regenAmount} END`
@@ -257,11 +261,6 @@ export class Crownicles {
 					mapLinkId: { [Op.in]: MapCache.regenEnergyMapLinks }
 				}
 			}
-		)
-			.finally(() => null);
-		setTimeout(
-			Crownicles.fightPowerRegenerationLoop,
-			minutesToMilliseconds(FightConstants.POINTS_REGEN_MINUTES)
 		);
 	}
 
@@ -289,68 +288,41 @@ export class Crownicles {
 	}
 
 	static async reportNotifications(): Promise<void> {
-		try {
-			if (PacketUtils.isMqttConnected()) {
-				const notifications = await ScheduledReportNotifications.getNotificationsBeforeDate(new Date());
-				if (notifications.length !== 0) {
-					PacketUtils.sendNotifications(notifications.map(notification => makePacket(ReachDestinationNotificationPacket, {
-						keycloakId: notification.keycloakId,
-						mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
-						mapId: notification.mapId
-					})));
-					await ScheduledReportNotifications.bulkDelete(notifications);
-				}
-			}
-			else {
-				CrowniclesLogger.error(`MQTT is not connected, can't do report notifications. Trying again in ${TimeoutFunctionsConstants.REPORT_NOTIFICATIONS} ms`);
-			}
+		if (!PacketUtils.isMqttConnected()) {
+			CrowniclesLogger.error(`MQTT is not connected, can't do report notifications. Trying again in ${TimeoutFunctionsConstants.REPORT_NOTIFICATIONS} ms`);
+			return;
 		}
-		catch (error) {
-			CrowniclesLogger.errorWithObj("Error while dispatching report notifications", error);
-		}
-		finally {
-			setTimeout(Crownicles.reportNotifications, TimeoutFunctionsConstants.REPORT_NOTIFICATIONS);
+		const notifications = await ScheduledReportNotifications.getNotificationsBeforeDate(new Date());
+		if (notifications.length !== 0) {
+			PacketUtils.sendNotifications(notifications.map(notification => makePacket(ReachDestinationNotificationPacket, {
+				keycloakId: notification.keycloakId,
+				mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
+				mapId: notification.mapId
+			})));
+			await ScheduledReportNotifications.bulkDelete(notifications);
 		}
 	}
 
 	static async dailyBonusNotifications(): Promise<void> {
-		try {
-			if (PacketUtils.isMqttConnected()) {
-				const notifications = await ScheduledDailyBonusNotifications.getNotificationsBeforeDate(new Date());
-				if (notifications.length !== 0) {
-					PacketUtils.sendNotifications(notifications.map(notification => makePacket(DailyBonusNotificationPacket, {
-						keycloakId: notification.keycloakId
-					})));
-					await ScheduledDailyBonusNotifications.bulkDelete(notifications);
-				}
-			}
-			else {
-				CrowniclesLogger.error(`MQTT is not connected, can't do daily bonus notifications. Trying again in ${TimeoutFunctionsConstants.DAILY_TIMEOUT} ms`);
-			}
+		if (!PacketUtils.isMqttConnected()) {
+			CrowniclesLogger.error(`MQTT is not connected, can't do daily bonus notifications. Trying again in ${TimeoutFunctionsConstants.DAILY_TIMEOUT} ms`);
+			return;
 		}
-		catch (error) {
-			CrowniclesLogger.errorWithObj("Error while dispatching daily bonus notifications", error);
-		}
-		finally {
-			setTimeout(Crownicles.dailyBonusNotifications, TimeoutFunctionsConstants.DAILY_TIMEOUT);
+		const notifications = await ScheduledDailyBonusNotifications.getNotificationsBeforeDate(new Date());
+		if (notifications.length !== 0) {
+			PacketUtils.sendNotifications(notifications.map(notification => makePacket(DailyBonusNotificationPacket, {
+				keycloakId: notification.keycloakId
+			})));
+			await ScheduledDailyBonusNotifications.bulkDelete(notifications);
 		}
 	}
 
 	static async expeditionNotifications(): Promise<void> {
-		try {
-			if (PacketUtils.isMqttConnected()) {
-				await processDueExpeditionNotifications();
-			}
-			else {
-				CrowniclesLogger.error(`MQTT is not connected, can't do expedition notifications. Trying again in ${TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS} ms`);
-			}
+		if (!PacketUtils.isMqttConnected()) {
+			CrowniclesLogger.error(`MQTT is not connected, can't do expedition notifications. Trying again in ${TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS} ms`);
+			return;
 		}
-		catch (error) {
-			CrowniclesLogger.errorWithObj("Error while dispatching expedition notifications", error);
-		}
-		finally {
-			setTimeout(Crownicles.expeditionNotifications, TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS);
-		}
+		await processDueExpeditionNotifications();
 	}
 
 	/**
@@ -465,21 +437,35 @@ export class Crownicles {
 		await CrowniclesEach10Minutes.programCronJob();
 		await CrowniclesChristmas.programCronJob();
 
-		Crownicles.reportNotifications()
-			.then();
+		startResilientLoop(
+			PERIODIC_LOOPS.REPORT_NOTIFICATIONS,
+			Crownicles.reportNotifications,
+			asMilliseconds(TimeoutFunctionsConstants.REPORT_NOTIFICATIONS),
+			{ startImmediately: true }
+		);
 
-		Crownicles.dailyBonusNotifications()
-			.then();
+		startResilientLoop(
+			PERIODIC_LOOPS.DAILY_BONUS_NOTIFICATIONS,
+			Crownicles.dailyBonusNotifications,
+			asMilliseconds(TimeoutFunctionsConstants.DAILY_TIMEOUT),
+			{ startImmediately: true }
+		);
 
-		Crownicles.expeditionNotifications()
-			.then();
+		startResilientLoop(
+			PERIODIC_LOOPS.EXPEDITION_NOTIFICATIONS,
+			Crownicles.expeditionNotifications,
+			asMilliseconds(TimeoutFunctionsConstants.EXPEDITION_NOTIFICATIONS),
+			{ startImmediately: true }
+		);
 
 		ReleaseGift.apply()
 			.then();
 
-		setTimeout(
+		startResilientLoop(
+			PERIODIC_LOOPS.ENERGY_REGEN,
 			Crownicles.fightPowerRegenerationLoop,
-			minutesToMilliseconds(FightConstants.POINTS_REGEN_MINUTES)
+			minutesToMilliseconds(FightConstants.POINTS_REGEN_MINUTES),
+			{ startImmediately: false }
 		);
 	}
 }

--- a/Core/src/core/bot/CrowniclesCoreMetrics.ts
+++ b/Core/src/core/bot/CrowniclesCoreMetrics.ts
@@ -21,6 +21,19 @@ type SequelizePoolStats = {
 // Sequelize 6 does not type `connectionManager.pool`, which only exists at runtime.
 type ConnectionManagerWithPool = Sequelize["connectionManager"] & { pool?: SequelizePoolStats };
 
+export const EXTERNAL_APIS = { NEO_WS: "neows" } as const;
+
+export type ExternalApiName = typeof EXTERNAL_APIS[keyof typeof EXTERNAL_APIS];
+
+export const EXTERNAL_API_FAILURE_REASONS = {
+	HTTP_STATUS: "http_status",
+	NETWORK: "network",
+	TIMEOUT: "timeout",
+	INVALID_RESPONSE: "invalid_response"
+} as const;
+
+export type ExternalApiFailureReason = typeof EXTERNAL_API_FAILURE_REASONS[keyof typeof EXTERNAL_API_FAILURE_REASONS];
+
 export abstract class CrowniclesCoreMetrics {
 	private static packetsTimeHistogram = new client.Histogram({
 		name: "crownicles_packets_time",
@@ -97,6 +110,20 @@ export abstract class CrowniclesCoreMetrics {
 		registers: [crowniclesMetricsRegistry]
 	});
 
+	private static externalApiCallsCount = new client.Counter({
+		name: "crownicles_external_api_calls_count",
+		help: "Count of calls made to external APIs",
+		labelNames: ["api"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
+	private static externalApiFailuresCount = new client.Counter({
+		name: "crownicles_external_api_failures_count",
+		help: "Count of failed calls to external APIs",
+		labelNames: ["api", "reason"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
 	static observePacketTime(packetName: string, time: number): void {
 		this.packetsTimeHistogram.labels(packetName)
 			.observe(time);
@@ -115,6 +142,16 @@ export abstract class CrowniclesCoreMetrics {
 	static observeLoopRun(loop: PeriodicLoopName): void {
 		this.loopLastRunTimestamp.labels(loop)
 			.set(Math.floor(Date.now() / 1000));
+	}
+
+	static incrementExternalApiCall(api: ExternalApiName): void {
+		this.externalApiCallsCount.labels(api)
+			.inc();
+	}
+
+	static incrementExternalApiFailure(api: ExternalApiName, reason: ExternalApiFailureReason): void {
+		this.externalApiFailuresCount.labels(api, reason)
+			.inc();
 	}
 
 	static computeSporadicMetrics(databases: MonitoredDatabase[], isInMaintenance: boolean): void {

--- a/Core/src/core/bot/CrowniclesCoreMetrics.ts
+++ b/Core/src/core/bot/CrowniclesCoreMetrics.ts
@@ -1,8 +1,25 @@
 // skipcq: JS-C1003 - prom-client does not expose itself as an ES Module.
 import * as client from "prom-client";
+import { Sequelize } from "sequelize";
 import { BlockingUtils } from "../utils/BlockingUtils";
+import { PeriodicLoopName } from "./ResilientLoop";
 
 export const crowniclesMetricsRegistry = new client.Registry();
+
+export type MonitoredDatabase = {
+	name: string;
+	sequelize: Sequelize;
+};
+
+type SequelizePoolStats = {
+	size: number;
+	available: number;
+	using: number;
+	waiting: number;
+};
+
+// Sequelize 6 does not type `connectionManager.pool`, which only exists at runtime.
+type ConnectionManagerWithPool = Sequelize["connectionManager"] & { pool?: SequelizePoolStats };
 
 export abstract class CrowniclesCoreMetrics {
 	private static packetsTimeHistogram = new client.Histogram({
@@ -39,6 +56,47 @@ export abstract class CrowniclesCoreMetrics {
 		registers: [crowniclesMetricsRegistry]
 	});
 
+	private static dbPoolSize = new client.Gauge({
+		name: "crownicles_db_pool_size",
+		help: "Number of connections in the Sequelize pool",
+		labelNames: ["database"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
+	private static dbPoolAvailable = new client.Gauge({
+		name: "crownicles_db_pool_available",
+		help: "Number of idle connections in the Sequelize pool",
+		labelNames: ["database"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
+	private static dbPoolUsing = new client.Gauge({
+		name: "crownicles_db_pool_using",
+		help: "Number of connections currently in use in the Sequelize pool",
+		labelNames: ["database"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
+	private static dbPoolWaiting = new client.Gauge({
+		name: "crownicles_db_pool_waiting",
+		help: "Number of queries waiting for a connection from the Sequelize pool",
+		labelNames: ["database"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
+	private static maintenanceMode = new client.Gauge({
+		name: "crownicles_maintenance_mode",
+		help: "1 when the bot is in maintenance mode, 0 otherwise",
+		registers: [crowniclesMetricsRegistry]
+	});
+
+	private static loopLastRunTimestamp = new client.Gauge({
+		name: "crownicles_loop_last_run_timestamp",
+		help: "Unix timestamp in seconds of the last successful run of a periodic loop",
+		labelNames: ["loop"],
+		registers: [crowniclesMetricsRegistry]
+	});
+
 	static observePacketTime(packetName: string, time: number): void {
 		this.packetsTimeHistogram.labels(packetName)
 			.observe(time);
@@ -54,7 +112,12 @@ export abstract class CrowniclesCoreMetrics {
 			.inc();
 	}
 
-	static computeSporadicMetrics(): void {
+	static observeLoopRun(loop: PeriodicLoopName): void {
+		this.loopLastRunTimestamp.labels(loop)
+			.set(Math.floor(Date.now() / 1000));
+	}
+
+	static computeSporadicMetrics(databases: MonitoredDatabase[], isInMaintenance: boolean): void {
 		// Blocked players count
 		this.blockedPlayersCount.set(BlockingUtils.getBlockedPlayersCount());
 
@@ -67,6 +130,23 @@ export abstract class CrowniclesCoreMetrics {
 					.set(now - block.startTimestamp);
 			});
 		});
+
+		this.maintenanceMode.set(isInMaintenance ? 1 : 0);
+
+		for (const database of databases) {
+			const pool = (database.sequelize.connectionManager as ConnectionManagerWithPool).pool;
+			if (!pool) {
+				continue;
+			}
+			this.dbPoolSize.labels(database.name)
+				.set(pool.size);
+			this.dbPoolAvailable.labels(database.name)
+				.set(pool.available);
+			this.dbPoolUsing.labels(database.name)
+				.set(pool.using);
+			this.dbPoolWaiting.labels(database.name)
+				.set(pool.waiting);
+		}
 	}
 }
 

--- a/Core/src/core/bot/CrowniclesCoreMetrics.ts
+++ b/Core/src/core/bot/CrowniclesCoreMetrics.ts
@@ -3,11 +3,20 @@ import * as client from "prom-client";
 import { Sequelize } from "sequelize";
 import { BlockingUtils } from "../utils/BlockingUtils";
 import { PeriodicLoopName } from "./ResilientLoop";
+import { asMilliseconds } from "../../../../Lib/src/types/TimeTypes";
+import { millisecondsToSeconds } from "../../../../Lib/src/utils/TimeUtils";
 
 export const crowniclesMetricsRegistry = new client.Registry();
 
+export const MONITORED_DATABASES = {
+	GAME: "game",
+	LOGS: "logs"
+} as const;
+
+export type MonitoredDatabaseName = typeof MONITORED_DATABASES[keyof typeof MONITORED_DATABASES];
+
 export type MonitoredDatabase = {
-	name: string;
+	name: MonitoredDatabaseName;
 	sequelize: Sequelize;
 };
 
@@ -141,7 +150,7 @@ export abstract class CrowniclesCoreMetrics {
 
 	static observeLoopRun(loop: PeriodicLoopName): void {
 		this.loopLastRunTimestamp.labels(loop)
-			.set(Math.floor(Date.now() / 1000));
+			.set(Math.floor(millisecondsToSeconds(asMilliseconds(Date.now()))));
 	}
 
 	static incrementExternalApiCall(api: ExternalApiName): void {

--- a/Core/src/core/bot/CrowniclesCoreWebServer.ts
+++ b/Core/src/core/bot/CrowniclesCoreWebServer.ts
@@ -5,7 +5,7 @@ import { botConfig } from "../../bootstrap";
 import { crowniclesInstance } from "../../app";
 import { mqttClient } from "../../mqttClient";
 import {
-	CrowniclesCoreMetrics, crowniclesMetricsRegistry
+	CrowniclesCoreMetrics, crowniclesMetricsRegistry, MONITORED_DATABASES
 } from "./CrowniclesCoreMetrics";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { BlockingUtils } from "../utils/BlockingUtils";
@@ -39,11 +39,11 @@ export abstract class CrowniclesCoreWebServer {
 			CrowniclesCoreMetrics.computeSporadicMetrics(
 				[
 					{
-						name: "game",
+						name: MONITORED_DATABASES.GAME,
 						sequelize: crowniclesInstance!.gameDatabase.sequelize
 					},
 					{
-						name: "logs",
+						name: MONITORED_DATABASES.LOGS,
 						sequelize: crowniclesInstance!.logsDatabase.sequelize
 					}
 				],

--- a/Core/src/core/bot/CrowniclesCoreWebServer.ts
+++ b/Core/src/core/bot/CrowniclesCoreWebServer.ts
@@ -36,7 +36,19 @@ export abstract class CrowniclesCoreWebServer {
 		});
 
 		app.get("/metrics", async (_req: Request, res: Response) => {
-			CrowniclesCoreMetrics.computeSporadicMetrics();
+			CrowniclesCoreMetrics.computeSporadicMetrics(
+				[
+					{
+						name: "game",
+						sequelize: crowniclesInstance!.gameDatabase.sequelize
+					},
+					{
+						name: "logs",
+						sequelize: crowniclesInstance!.logsDatabase.sequelize
+					}
+				],
+				botConfig.MODE_MAINTENANCE
+			);
 			res.setHeader("Content-Type", crowniclesMetricsRegistry.contentType);
 			res.end(await crowniclesMetricsRegistry.metrics());
 		});

--- a/Core/src/core/bot/ResilientLoop.ts
+++ b/Core/src/core/bot/ResilientLoop.ts
@@ -1,0 +1,55 @@
+import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { Millisecond } from "../../../../Lib/src/types/TimeTypes";
+import { CrowniclesCoreMetrics } from "./CrowniclesCoreMetrics";
+
+export const PERIODIC_LOOPS = {
+	ENERGY_REGEN: "energy_regen",
+	REPORT_NOTIFICATIONS: "report_notifications",
+	DAILY_BONUS_NOTIFICATIONS: "daily_bonus_notifications",
+	EXPEDITION_NOTIFICATIONS: "expedition_notifications"
+} as const;
+
+export type PeriodicLoopName = typeof PERIODIC_LOOPS[keyof typeof PERIODIC_LOOPS];
+
+export type ResilientLoopOptions = {
+
+	/**
+	 * When false, the first iteration runs after `delay` instead of right away
+	 */
+	startImmediately: boolean;
+};
+
+/**
+ * Runs `iteration` every `delay`, forever.
+ *
+ * The rescheduling lives in a `finally` block: a rejected iteration can never kill the loop.
+ * Loops that rescheduled themselves as their last statement silently died for good whenever the
+ * database was briefly unavailable, leaving game mechanics stopped until the next Core restart.
+ */
+export function startResilientLoop(
+	loop: PeriodicLoopName,
+	iteration: () => Promise<void>,
+	delay: Millisecond,
+	options: ResilientLoopOptions
+): void {
+	const tick = async (): Promise<void> => {
+		try {
+			await iteration();
+			CrowniclesCoreMetrics.observeLoopRun(loop);
+		}
+		catch (error) {
+			CrowniclesLogger.errorWithObj(`Error in periodic loop ${loop}`, error);
+		}
+		finally {
+			setTimeout(() => {
+				tick()
+					.then();
+			}, delay);
+		}
+	};
+
+	setTimeout(() => {
+		tick()
+			.then();
+	}, options.startImmediately ? 0 : delay);
+}

--- a/Core/src/core/utils/SpaceUtils.ts
+++ b/Core/src/core/utils/SpaceUtils.ts
@@ -3,6 +3,10 @@ import {
 	asSeconds, Millisecond
 } from "../../../../Lib/src/types/TimeTypes";
 import { secondsToMilliseconds } from "../../../../Lib/src/utils/TimeUtils";
+import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import {
+	CrowniclesCoreMetrics, EXTERNAL_API_FAILURE_REASONS, EXTERNAL_APIS, ExternalApiFailureReason
+} from "../bot/CrowniclesCoreMetrics";
 
 const HTTP_STATUS_OK = 200;
 
@@ -66,17 +70,34 @@ export abstract class SpaceUtils {
 			return Promise.resolve(this.cachedNeoFeed);
 		}
 		return new Promise((resolve, reject) => {
+			CrowniclesCoreMetrics.incrementExternalApiCall(EXTERNAL_APIS.NEO_WS);
+
+			// The caller silently falls back to an empty feed, so a failure is only visible through logs and metrics
+			let settled = false;
+			const fail = (reason: ExternalApiFailureReason, error: Error): void => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				CrowniclesCoreMetrics.incrementExternalApiFailure(EXTERNAL_APIS.NEO_WS, reason);
+				CrowniclesLogger.errorWithObj(`NeoWS feed call failed (${reason})`, error);
+				reject(error);
+			};
+
+			let timedOut = false;
 			const request = get(SpaceUtils.NEO_WS_FEED_URL, res => {
 				if (res.statusCode !== HTTP_STATUS_OK) {
 					res.resume();
-					reject(new Error(`NeoWS feed answered with HTTP status ${res.statusCode}`));
+					fail(EXTERNAL_API_FAILURE_REASONS.HTTP_STATUS, new Error(`NeoWS feed answered with HTTP status ${res.statusCode}`));
 					return;
 				}
 				let data = "";
 				res.on("data", chunk => {
 					data += chunk;
 				});
-				res.on("error", reject);
+				res.on("error", error => {
+					fail(EXTERNAL_API_FAILURE_REASONS.NETWORK, error);
+				});
 				res.on("end", () => {
 					/*
 					 * Everything that can throw must stay inside this try: an exception escaping here would
@@ -89,15 +110,19 @@ export abstract class SpaceUtils {
 						}
 						this.cachedNeoFeedDate = today;
 						this.cachedNeoFeed = parsedAnswer.near_earth_objects;
+						settled = true;
 						resolve(parsedAnswer.near_earth_objects);
 					}
 					catch (e) {
-						reject(e);
+						fail(EXTERNAL_API_FAILURE_REASONS.INVALID_RESPONSE, e instanceof Error ? e : new Error(String(e)));
 					}
 				});
 			});
-			request.on("error", reject);
+			request.on("error", error => {
+				fail(timedOut ? EXTERNAL_API_FAILURE_REASONS.TIMEOUT : EXTERNAL_API_FAILURE_REASONS.NETWORK, error);
+			});
 			request.setTimeout(SpaceUtils.NEO_WS_REQUEST_TIMEOUT, () => {
+				timedOut = true;
 				request.destroy(new Error("NeoWS feed request timed out"));
 			});
 		});

--- a/Core/src/core/utils/SpaceUtils.ts
+++ b/Core/src/core/utils/SpaceUtils.ts
@@ -1,4 +1,5 @@
 import { get } from "https";
+import { IncomingMessage } from "http";
 import {
 	asSeconds, Millisecond
 } from "../../../../Lib/src/types/TimeTypes";
@@ -10,9 +11,12 @@ import {
 
 const HTTP_STATUS_OK = 200;
 
-// External library connections, naming conventions can't be easily applied
-/* eslint-disable camelcase */
+type NeoWSCallHandlers = {
+	succeed: (feed: NearEarthObject[]) => void;
+	fail: (reason: ExternalApiFailureReason, error: unknown) => void;
+};
 
+// External library connections, naming conventions can't be easily applied
 export interface NearEarthObjectApproachData {
 	close_approach_date: string;
 	close_approach_date_full: string;
@@ -69,57 +73,71 @@ export abstract class SpaceUtils {
 		if (today === this.cachedNeoFeedDate && this.cachedNeoFeed) {
 			return Promise.resolve(this.cachedNeoFeed);
 		}
-		return new Promise((resolve, reject) => {
-			CrowniclesCoreMetrics.incrementExternalApiCall(EXTERNAL_APIS.NEO_WS);
+		return this.fetchNeoWSFeed(today);
+	}
 
-			// The caller silently falls back to an empty feed, so a failure is only visible through logs and metrics
+	private static parseNeoWSFeed(rawAnswer: string, day: string): NearEarthObject[] {
+		const objectsByDay = JSON.parse(rawAnswer).near_earth_objects;
+		return objectsByDay[day] ? objectsByDay[day] : objectsByDay;
+	}
+
+	private static readNeoWSResponse(res: IncomingMessage, day: string, handlers: NeoWSCallHandlers): void {
+		if (res.statusCode !== HTTP_STATUS_OK) {
+			res.resume();
+			handlers.fail(EXTERNAL_API_FAILURE_REASONS.HTTP_STATUS, new Error(`NeoWS feed answered with HTTP status ${res.statusCode}`));
+			return;
+		}
+		let data = "";
+		res.on("data", chunk => {
+			data += chunk;
+		});
+		res.on("error", error => {
+			handlers.fail(EXTERNAL_API_FAILURE_REASONS.NETWORK, error);
+		});
+		res.on("end", () => {
+			/*
+			 * Everything that can throw must stay inside this try: an exception escaping here would
+			 * leave the promise forever pending, and its caller stuck holding a database transaction
+			 */
+			try {
+				handlers.succeed(SpaceUtils.parseNeoWSFeed(data, day));
+			}
+			catch (e) {
+				handlers.fail(EXTERNAL_API_FAILURE_REASONS.INVALID_RESPONSE, e);
+			}
+		});
+	}
+
+	private static fetchNeoWSFeed(day: string): Promise<NearEarthObject[]> {
+		CrowniclesCoreMetrics.incrementExternalApiCall(EXTERNAL_APIS.NEO_WS);
+		return new Promise((resolve, reject) => {
 			let settled = false;
-			const fail = (reason: ExternalApiFailureReason, error: Error): void => {
-				if (settled) {
-					return;
+			const handlers: NeoWSCallHandlers = {
+				succeed: feed => {
+					settled = true;
+					this.cachedNeoFeedDate = day;
+					this.cachedNeoFeed = feed;
+					resolve(feed);
+				},
+
+				// The caller silently falls back to an empty feed, so a failure is only visible through logs and metrics
+				fail: (reason, error) => {
+					if (settled) {
+						return;
+					}
+					settled = true;
+					CrowniclesCoreMetrics.incrementExternalApiFailure(EXTERNAL_APIS.NEO_WS, reason);
+					CrowniclesLogger.errorWithObj(`NeoWS feed call failed (${reason})`, error);
+					reject(error);
 				}
-				settled = true;
-				CrowniclesCoreMetrics.incrementExternalApiFailure(EXTERNAL_APIS.NEO_WS, reason);
-				CrowniclesLogger.errorWithObj(`NeoWS feed call failed (${reason})`, error);
-				reject(error);
 			};
 
 			let timedOut = false;
 			const request = get(SpaceUtils.NEO_WS_FEED_URL, res => {
-				if (res.statusCode !== HTTP_STATUS_OK) {
-					res.resume();
-					fail(EXTERNAL_API_FAILURE_REASONS.HTTP_STATUS, new Error(`NeoWS feed answered with HTTP status ${res.statusCode}`));
-					return;
-				}
-				let data = "";
-				res.on("data", chunk => {
-					data += chunk;
-				});
-				res.on("error", error => {
-					fail(EXTERNAL_API_FAILURE_REASONS.NETWORK, error);
-				});
-				res.on("end", () => {
-					/*
-					 * Everything that can throw must stay inside this try: an exception escaping here would
-					 * leave the promise forever pending, and its caller stuck holding a database transaction
-					 */
-					try {
-						const parsedAnswer = JSON.parse(data);
-						if (parsedAnswer.near_earth_objects[today]) {
-							parsedAnswer.near_earth_objects = parsedAnswer.near_earth_objects[today];
-						}
-						this.cachedNeoFeedDate = today;
-						this.cachedNeoFeed = parsedAnswer.near_earth_objects;
-						settled = true;
-						resolve(parsedAnswer.near_earth_objects);
-					}
-					catch (e) {
-						fail(EXTERNAL_API_FAILURE_REASONS.INVALID_RESPONSE, e instanceof Error ? e : new Error(String(e)));
-					}
-				});
+				SpaceUtils.readNeoWSResponse(res, day, handlers);
 			});
 			request.on("error", error => {
-				fail(timedOut ? EXTERNAL_API_FAILURE_REASONS.TIMEOUT : EXTERNAL_API_FAILURE_REASONS.NETWORK, error);
+				handlers.fail(timedOut ? EXTERNAL_API_FAILURE_REASONS.TIMEOUT : EXTERNAL_API_FAILURE_REASONS.NETWORK, error);
 			});
 			request.setTimeout(SpaceUtils.NEO_WS_REQUEST_TIMEOUT, () => {
 				timedOut = true;

--- a/Core/src/core/utils/SpaceUtils.ts
+++ b/Core/src/core/utils/SpaceUtils.ts
@@ -1,4 +1,10 @@
 import { get } from "https";
+import {
+	asSeconds, Millisecond
+} from "../../../../Lib/src/types/TimeTypes";
+import { secondsToMilliseconds } from "../../../../Lib/src/utils/TimeUtils";
+
+const HTTP_STATUS_OK = 200;
 
 // External library connections, naming conventions can't be easily applied
 /* eslint-disable camelcase */
@@ -45,6 +51,10 @@ export interface NearEarthObject {
 }
 
 export abstract class SpaceUtils {
+	private static readonly NEO_WS_FEED_URL = "https://www.neowsapp.com/rest/v1/feed/today";
+
+	private static readonly NEO_WS_REQUEST_TIMEOUT: Millisecond = secondsToMilliseconds(asSeconds(10));
+
 	private static cachedNeoFeed: NearEarthObject[] | undefined = undefined;
 
 	private static cachedNeoFeedDate: string | undefined = undefined;
@@ -56,14 +66,24 @@ export abstract class SpaceUtils {
 			return Promise.resolve(this.cachedNeoFeed);
 		}
 		return new Promise((resolve, reject) => {
-			get("https://www.neowsapp.com/rest/v1/feed/today", res => {
+			const request = get(SpaceUtils.NEO_WS_FEED_URL, res => {
+				if (res.statusCode !== HTTP_STATUS_OK) {
+					res.resume();
+					reject(new Error(`NeoWS feed answered with HTTP status ${res.statusCode}`));
+					return;
+				}
 				let data = "";
 				res.on("data", chunk => {
 					data += chunk;
 				});
+				res.on("error", reject);
 				res.on("end", () => {
-					const parsedAnswer = JSON.parse(data);
+					/*
+					 * Everything that can throw must stay inside this try: an exception escaping here would
+					 * leave the promise forever pending, and its caller stuck holding a database transaction
+					 */
 					try {
+						const parsedAnswer = JSON.parse(data);
 						if (parsedAnswer.near_earth_objects[today]) {
 							parsedAnswer.near_earth_objects = parsedAnswer.near_earth_objects[today];
 						}
@@ -75,6 +95,10 @@ export abstract class SpaceUtils {
 						reject(e);
 					}
 				});
+			});
+			request.on("error", reject);
+			request.setTimeout(SpaceUtils.NEO_WS_REQUEST_TIMEOUT, () => {
+				request.destroy(new Error("NeoWS feed request timed out"));
 			});
 		});
 	}


### PR DESCRIPTION
## Contexte

Le 30 juillet 2026, le bot est resté indisponible pendant ~5h30 puis ~4h. La cause racine était un `JSON.parse` placé **hors** du `try` dans `SpaceUtils.getNeoWSFeed()` : l'exception remontait de façon synchrone depuis un callback d'`EventEmitter`, la promesse n'était donc **jamais résolue ni rejetée**, et l'appelant (le small event `space`) restait bloqué indéfiniment en gardant une transaction Sequelize ouverte. Le dump horaire de MariaDB s'est mis en attente derrière cette transaction, ce qui a saturé le pool de connexions.

Séquelle découverte après coup : la boucle de régénération d'énergie s'est **arrêtée définitivement** pendant l'incident et n'est jamais repartie (plus de 12 h sans régénération, dont 7 h après le retour de la base). Elle se reprogrammait via un `setTimeout` en **dernière instruction**, sans `try/catch/finally` : le rejet de `Player.findAll` a suffi à la tuer pour de bon.

Fixes #4599
Fixes #4600

## Changements

### `SpaceUtils` (#4599)

- `JSON.parse` déplacé **dans** le `try` : plus aucune promesse en suspens éternel.
- Ajout de `request.on("error", reject)` et de `res.on("error", reject)`.
- Ajout d'un timeout de requête (10 s) qui détruit la requête et rejette.
- Vérification du `statusCode` : une réponse non-200 rejette au lieu de tenter de parser une page d'erreur HTML.
- URL et timeout extraits en constantes nommées.
- Chaque échec est désormais **loggé et compté** : l'appelant (`neoWS()` dans le small event `space`) avale silencieusement l'exception et retombe sur un feed vide, donc une API cassée était totalement invisible.

### Boucles périodiques résilientes (#4599)

Nouveau helper `Core/src/core/bot/ResilientLoop.ts` :

- `startResilientLoop(loop, iteration, delay, options)` reprogramme l'itération suivante dans un bloc `finally`, donc **une itération qui échoue ne peut plus tuer la boucle**.
- Les quatre boucles (`energy_regen`, `report_notifications`, `daily_bonus_notifications`, `expedition_notifications`) passent par ce helper et perdent leur `try/catch/finally` dupliqué.
- Le `Player.update(...).finally(() => null)` de la régénération d'énergie devient un `await` : l'échec est désormais visible dans les logs au lieu d'être avalé.
- Le comportement de démarrage est conservé : les trois boucles de notification démarrent immédiatement, la régénération d'énergie après un premier délai.

### Métriques Core (#4600)

- `crownicles_loop_last_run_timestamp{loop}` : timestamp Unix de la dernière itération réussie de chaque boucle. Permet une alerte du type `time() - crownicles_loop_last_run_timestamp > 3 * <periode>` qui aurait détecté la boucle morte en quelques minutes.
- `crownicles_db_pool_size` / `_available` / `_using` / `_waiting`, labellisées par base (`game`, `logs`) : `_waiting > 0` de façon durable est le signal direct de la saturation observée pendant l'incident.
- `crownicles_maintenance_mode` : 0/1, nécessaire côté serveur pour déclencher automatiquement une maintenance planifiée sur la page de statut.
- `crownicles_external_api_calls_count{api}` et `crownicles_external_api_failures_count{api,reason}` : suivi des appels aux API externes (`neows` pour l'instant), avec la raison de l'échec (`http_status`, `network`, `timeout`, `invalid_response`). Permet un taux d'échec `rate(failures) / rate(calls)` et une alerte sur une API tierce dégradée, même quand cela ne fait plus tomber le bot.
- `computeSporadicMetrics` reçoit désormais les bases et l'état de maintenance depuis le serveur web, ce qui évite d'introduire une dépendance circulaire vers `app`/`bootstrap` dans le module de métriques.

## Tests

- `Core/__tests__/core/bot/ResilientLoop.test.ts` : une itération qui rejette n'empêche pas les suivantes, pas de heartbeat sur échec, respect du démarrage différé.
- `Core/__tests__/core/utils/SpaceUtils.test.ts` : régression sur le bug d'origine — une réponse illisible ou un statut d'erreur rejettent au lieu de rester en suspens, et chaque échec incrémente le compteur avec la bonne raison, une seule fois par appel.

`pnpm eslint`, `pnpm tsc` et `pnpm test` (1520 tests) sont verts sur Core.
