### PR TITLE
fix: count auto-composted plants for harvest missions (#4608)

### DIFF
--- a/Core/__tests__/core/report/ReportGardenHarvestMissions.test.ts
+++ b/Core/__tests__/core/report/ReportGardenHarvestMissions.test.ts
@@ -1,0 +1,177 @@
+import {
+	beforeEach, describe, expect, it, vi
+} from "vitest";
+
+vi.mock("../../../src/app", () => ({
+	crowniclesInstance: {
+		logsDatabase: { logGardenAction: vi.fn().mockResolvedValue(undefined) }
+	}
+}));
+
+vi.mock("../../../src/core/database/game/models/Player", () => ({
+	Player: class {
+		static lockKey = vi.fn((id: number) => `players:${id}`);
+	},
+	Players: { getByKeycloakId: vi.fn() }
+}));
+
+vi.mock("../../../src/core/database/game/models/Home", () => ({
+	Home: class {
+		static lockKey = vi.fn((id: number) => `homes:${id}`);
+	},
+	Homes: { getOfPlayer: vi.fn() }
+}));
+
+vi.mock("../../../src/core/database/game/models/PlayerMissionsInfo", () => ({
+	default: class {
+		static lockKey = vi.fn((id: number) => `player_missions_info:${id}`);
+	},
+	PlayerMissionsInfos: { getOfPlayer: vi.fn() }
+}));
+
+vi.mock("../../../src/core/database/game/models/HomeGardenSlot", () => ({
+	default: class {},
+	HomeGardenSlots: {
+		getOfHome: vi.fn(),
+		resetGrowthTimer: vi.fn().mockResolvedValue(undefined)
+	}
+}));
+
+vi.mock("../../../src/core/database/game/models/HomePlantStorage", () => ({
+	HomePlantStorages: {
+		getOfHome: vi.fn().mockResolvedValue([]),
+		addPlant: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/database/game/models/PlayerPlantSlot", () => ({
+	default: class {},
+	PlayerPlantSlots: { getOfPlayer: vi.fn() }
+}));
+
+vi.mock("../../../src/core/database/game/models/InventoryInfo", () => ({
+	InventoryInfos: { getOfPlayer: vi.fn() }
+}));
+
+vi.mock("../../../src/core/database/game/models/Material", () => ({
+	Materials: { giveMaterial: vi.fn().mockResolvedValue(undefined) }
+}));
+
+vi.mock("../../../src/core/missions/MissionsController", () => ({
+	MissionsController: { update: vi.fn().mockResolvedValue(undefined) }
+}));
+
+vi.mock("../../../src/core/utils/MaterialLootUtils", () => ({ updateCollectMaterialsMission: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock("../../../../Lib/src/locks/withLockedEntities", () => ({
+	withLockedEntities: vi.fn()
+}));
+
+import { handleGardenHarvest } from "../../../src/core/report/ReportGardenService";
+import { Players } from "../../../src/core/database/game/models/Player";
+import { Homes } from "../../../src/core/database/game/models/Home";
+import { HomeGardenSlots } from "../../../src/core/database/game/models/HomeGardenSlot";
+import { HomePlantStorages } from "../../../src/core/database/game/models/HomePlantStorage";
+import { MissionsController } from "../../../src/core/missions/MissionsController";
+import { withLockedEntities } from "../../../../Lib/src/locks/withLockedEntities";
+import { PlantId } from "../../../../Lib/src/constants/PlantConstants";
+import { CommandReportGardenHarvestReq } from "../../../../Lib/src/packets/commands/CommandReportPacket";
+import { CrowniclesPacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+
+const HOME_ID = 42;
+const READY_SLOT = 0;
+
+function mockedPlayer(): unknown {
+	return {
+		id: 1,
+		keycloakId: "keycloak-id",
+		getCurrentCityId: (): string => "city"
+	};
+}
+
+function mockedHome(): unknown {
+	return {
+		id: HOME_ID,
+		getLevel: (): unknown => ({
+			features: {
+				gardenEarthQuality: 0,
+				gardenPlantStorageCapacity: 4
+			}
+		})
+	};
+}
+
+function mockedReadySlot(): unknown {
+	return {
+		slot: READY_SLOT,
+		plantId: PlantId.COMMON_HERB,
+		isEmpty: (): boolean => false,
+		isReady: (): boolean => true
+	};
+}
+
+async function harvest(): Promise<CrowniclesPacket[]> {
+	const response: CrowniclesPacket[] = [];
+	await handleGardenHarvest("keycloak-id", new CommandReportGardenHarvestReq(), response);
+	return response;
+}
+
+describe("handleGardenHarvest missions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(Players.getByKeycloakId).mockResolvedValue(mockedPlayer() as never);
+		vi.mocked(Homes.getOfPlayer).mockResolvedValue(mockedHome() as never);
+		vi.mocked(HomeGardenSlots.getOfHome).mockResolvedValue([mockedReadySlot()] as never);
+		vi.mocked(HomeGardenSlots.resetGrowthTimer).mockResolvedValue(undefined as never);
+		vi.mocked(HomePlantStorages.getOfHome).mockResolvedValue([] as never);
+		vi.mocked(withLockedEntities).mockImplementation((_keys, body) => (body as (entities: unknown[]) => Promise<CrowniclesPacket>)([mockedPlayer(), mockedHome()]) as never);
+	});
+
+	it("counts a stored plant for the cultivatePlants mission", async () => {
+		vi.mocked(HomePlantStorages.addPlant).mockResolvedValue(0);
+
+		const response = await harvest();
+
+		expect(MissionsController.update).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+			missionId: "cultivatePlants",
+			count: 1
+		});
+		expect(response[0]).toMatchObject({
+			plantsHarvested: 1,
+			plantsComposted: 0,
+			harvestedSlots: [READY_SLOT]
+		});
+	});
+
+	it("counts an auto-composted plant for the cultivatePlants mission when the storage is full", async () => {
+		vi.mocked(HomePlantStorages.addPlant).mockResolvedValue(1);
+
+		const response = await harvest();
+
+		expect(MissionsController.update).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+			missionId: "cultivatePlants",
+			count: 1
+		});
+		expect(response[0]).toMatchObject({
+			plantsHarvested: 0,
+			plantsComposted: 1,
+			harvestedSlots: [READY_SLOT]
+		});
+	});
+
+	it("does not trigger the cultivatePlants mission when nothing is ready", async () => {
+		vi.mocked(HomeGardenSlots.getOfHome).mockResolvedValue([
+			{
+				slot: READY_SLOT,
+				plantId: PlantId.COMMON_HERB,
+				isEmpty: (): boolean => false,
+				isReady: (): boolean => false
+			}
+		] as never);
+		vi.mocked(HomePlantStorages.addPlant).mockResolvedValue(0);
+
+		await harvest();
+
+		expect(MissionsController.update).not.toHaveBeenCalled();
+	});
+});

--- a/Core/src/core/report/ReportGardenService.ts
+++ b/Core/src/core/report/ReportGardenService.ts
@@ -260,10 +260,23 @@ type CompostResult = {
 };
 
 /**
- * Log the garden harvest action when at least one plant was harvested or composted.
+ * Running totals of a harvest pass over every garden slot.
+ * `harvestedSlots` holds one entry per plant actually picked, whether it ended
+ * up in the plant storage or was auto-composted because the storage was full,
+ * so it is the reference count for the "harvest X plants" missions.
  */
-function logGardenHarvest(player: Player, plantsHarvested: number, compostResults: CompostResult[], harvestedSlots: number[]): void {
-	if (harvestedSlots.length === 0 && compostResults.length === 0) {
+type HarvestAccumulator = {
+	harvestedSlots: number[];
+	compostResults: CompostResult[];
+	plantsStored: number;
+	ancestralHarvestCount: number;
+};
+
+/**
+ * Log the garden harvest action when at least one plant was harvested.
+ */
+function logGardenHarvest(player: Player, accumulator: HarvestAccumulator): void {
+	if (accumulator.harvestedSlots.length === 0) {
 		return;
 	}
 	crowniclesInstance?.logsDatabase.logGardenAction({
@@ -273,27 +286,21 @@ function logGardenHarvest(player: Player, plantsHarvested: number, compostResult
 		plantId: "",
 		slot: 0,
 		cost: 0,
-		quantity: plantsHarvested + compostResults.length
+		quantity: accumulator.harvestedSlots.length
 	}).then();
 }
 
 /**
  * Trigger the harvest-related missions (cultivated plants, ancestral trees, composted materials).
  */
-async function triggerHarvestMissions(params: {
-	player: Player;
-	response: CrowniclesPacket[];
-	plantsHarvested: number;
-	ancestralHarvestCount: number;
-	compostResults: CompostResult[];
-}): Promise<void> {
+async function triggerHarvestMissions(player: Player, response: CrowniclesPacket[], accumulator: HarvestAccumulator): Promise<void> {
 	const {
-		player, response, plantsHarvested, ancestralHarvestCount, compostResults
-	} = params;
-	if (plantsHarvested > 0) {
+		harvestedSlots, ancestralHarvestCount, compostResults
+	} = accumulator;
+	if (harvestedSlots.length > 0) {
 		await MissionsController.update(player, response, {
 			missionId: "cultivatePlants",
-			count: plantsHarvested
+			count: harvestedSlots.length
 		});
 	}
 
@@ -325,21 +332,21 @@ async function runHarvestUnderLock(params: {
 	const gardenSlots = await HomeGardenSlots.getOfHome(home.id);
 	const maxCapacity = homeLevel.features.gardenPlantStorageCapacity;
 
-	let plantsHarvested = 0;
-	const compostResults: CompostResult[] = [];
-	const harvestedSlots: number[] = [];
-	const ancestralHarvest = { count: 0 };
+	const accumulator: HarvestAccumulator = {
+		harvestedSlots: [],
+		compostResults: [],
+		plantsStored: 0,
+		ancestralHarvestCount: 0
+	};
 
 	for (const slot of gardenSlots) {
-		plantsHarvested += await processHarvestSlotUnderLock({
+		await processHarvestSlotUnderLock({
 			slot,
 			earthQuality,
 			homeId: home.id,
 			playerId: player.id,
 			maxCapacity,
-			harvestedSlots,
-			compostResults,
-			ancestralHarvest
+			accumulator
 		});
 	}
 
@@ -352,21 +359,15 @@ async function runHarvestUnderLock(params: {
 			maxCapacity
 		}));
 
-	logGardenHarvest(player, plantsHarvested, compostResults, harvestedSlots);
-	await triggerHarvestMissions({
-		player,
-		response: sideEffects,
-		plantsHarvested,
-		ancestralHarvestCount: ancestralHarvest.count,
-		compostResults
-	});
+	logGardenHarvest(player, accumulator);
+	await triggerHarvestMissions(player, sideEffects, accumulator);
 
 	return makePacket(CommandReportGardenHarvestRes, {
-		plantsHarvested,
-		plantsComposted: compostResults.length,
-		compostResults,
+		plantsHarvested: accumulator.plantsStored,
+		plantsComposted: accumulator.compostResults.length,
+		compostResults: accumulator.compostResults,
 		plantStorage,
-		harvestedSlots
+		harvestedSlots: accumulator.harvestedSlots
 	});
 }
 
@@ -376,48 +377,44 @@ async function processHarvestSlotUnderLock(params: {
 	homeId: number;
 	playerId: number;
 	maxCapacity: number;
-	harvestedSlots: number[];
-	compostResults: CompostResult[];
-	ancestralHarvest: { count: number };
-}): Promise<number> {
+	accumulator: HarvestAccumulator;
+}): Promise<void> {
 	const {
-		slot, earthQuality, homeId, playerId, maxCapacity, harvestedSlots, compostResults, ancestralHarvest
+		slot, earthQuality, homeId, playerId, maxCapacity, accumulator
 	} = params;
 	if (slot.isEmpty()) {
-		return 0;
+		return;
 	}
 
 	const plant = PlantConstants.getPlantById(slot.plantId);
 	if (!plant) {
-		return 0;
+		return;
 	}
 
 	const effectiveGrowthTime = GardenConstants.getEffectiveGrowthTime(plant.growthTimeSeconds, earthQuality);
 	if (!slot.isReady(effectiveGrowthTime)) {
-		return 0;
+		return;
 	}
 
-	harvestedSlots.push(slot.slot);
+	accumulator.harvestedSlots.push(slot.slot);
 	if (plant.id === PlantId.ANCIENT_TREE) {
-		ancestralHarvest.count++;
+		accumulator.ancestralHarvestCount++;
 	}
 
 	const overflow = await HomePlantStorages.addPlant(homeId, slot.plantId, 1, maxCapacity);
-	let harvestedCount = 0;
 
 	if (overflow > 0) {
 		const materialId = await pickAndGiveCompostMaterial(playerId, plant);
-		compostResults.push({
+		accumulator.compostResults.push({
 			plantId: plant.id,
 			materialId
 		});
 	}
 	else {
-		harvestedCount = 1;
+		accumulator.plantsStored++;
 	}
 
 	await HomeGardenSlots.resetGrowthTimer(homeId, slot.slot);
-	return harvestedCount;
 }
 
 /**

--- a/Core/src/core/report/ReportGardenService.ts
+++ b/Core/src/core/report/ReportGardenService.ts
@@ -362,12 +362,16 @@ async function runHarvestUnderLock(params: {
 	logGardenHarvest(player, accumulator);
 	await triggerHarvestMissions(player, sideEffects, accumulator);
 
+	const {
+		plantsStored, compostResults, harvestedSlots
+	} = accumulator;
+
 	return makePacket(CommandReportGardenHarvestRes, {
-		plantsHarvested: accumulator.plantsStored,
-		plantsComposted: accumulator.compostResults.length,
-		compostResults: accumulator.compostResults,
+		plantsHarvested: plantsStored,
+		plantsComposted: compostResults.length,
+		compostResults,
 		plantStorage,
-		harvestedSlots: accumulator.harvestedSlots
+		harvestedSlots
 	});
 }
 


### PR DESCRIPTION
Fixes #4608

## Problème

Quand une plante est récoltée alors que la réserve de ce type de plante est déjà pleine, elle est automatiquement compostée. Dans ce cas, elle n'était **pas** comptabilisée pour la mission « Récolter X plantes » (`cultivatePlants`), que ce soit en quête du jour ou en mission secondaire.

## Cause

Dans `runHarvestUnderLock` / `processHarvestSlotUnderLock` (`Core/src/core/report/ReportGardenService.ts`), le compteur `plantsHarvested` n'était incrémenté que dans la branche « la plante tient dans la réserve ». La branche overflow (compost automatique) retournait `0`, et c'est ce compteur qui alimentait `MissionsController.update({ missionId: "cultivatePlants" })`.

## Correctif

Les totaux d'une passe de récolte sont regroupés dans un `HarvestAccumulator` qui distingue clairement :

- `harvestedSlots` : une entrée par plante réellement cueillie (stockée **ou** compostée) → source de vérité pour la mission `cultivatePlants` et pour la quantité loggée ;
- `plantsStored` : plantes réellement rangées dans la réserve → champ `plantsHarvested` du packet (dont la doc dit déjà « Number of plants successfully stored in the chest ») ;
- `compostResults` : plantes compostées → champ `plantsComposted` + mission de récolte de matériaux.

Le log `GardenActionType.HARVEST` utilise désormais `harvestedSlots.length` (identique à l'ancien `plantsHarvested + compostResults.length`, mais sans risque de double comptage).

Aucun changement côté Discord : le front n'utilise que `harvestedSlots`, `compostResults` et `plantStorage`.

## Tests

Nouveau fichier `Core/__tests__/core/report/ReportGardenHarvestMissions.test.ts` :

- une plante rangée en réserve → mission `cultivatePlants` +1, `plantsHarvested: 1` ;
- une plante compostée pour cause de réserve pleine → mission `cultivatePlants` +1 quand même, `plantsHarvested: 0` / `plantsComposted: 1` (test de non-régression du bug) ;
- aucune plante prête → aucune mise à jour de mission.

`pnpm eslint`, `pnpm tsc --noEmit` et `pnpm test` (1520 tests) passent sur Core.
