### PR TITLE
Corrige les recettes de cuisine jamais obtenues ni annoncees

### DIFF
--- a/Core/__tests__/core/cooking/RecipeDiscoveryProgression.test.ts
+++ b/Core/__tests__/core/cooking/RecipeDiscoveryProgression.test.ts
@@ -33,7 +33,7 @@ describe("RecipeDiscoveryService progression unlocks", () => {
 		source, milestones
 	}) => {
 		const unlocks = RecipeDiscoveryService.getProgressionUnlocks(source);
-		const levels = unlocks.map(unlock => CookingRecipeDataController.instance.getById(unlock.recipeId)!.level);
+		const levels = unlocks.map(unlock => unlock.recipe.level);
 
 		expect(unlocks.map(unlock => unlock.requiredProgress)).toEqual([...milestones]);
 		expect(levels).toEqual([...levels].sort((a, b) => a - b));

--- a/Core/__tests__/core/cooking/RecipeDiscoveryProgression.test.ts
+++ b/Core/__tests__/core/cooking/RecipeDiscoveryProgression.test.ts
@@ -1,0 +1,46 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { RecipeDiscoveryService } from "../../../src/core/cooking/RecipeDiscoveryService";
+import {
+	CAMPAIGN_RECIPE_MILESTONES, PLAYER_LEVEL_RECIPE_MILESTONES, RecipeDiscoverySource
+} from "../../../../Lib/src/constants/CookingConstants";
+import { CookingRecipeDataController } from "../../../src/data/CookingRecipeData";
+
+const PROGRESSION_SOURCES = [
+	{
+		source: RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE,
+		milestones: PLAYER_LEVEL_RECIPE_MILESTONES
+	},
+	{
+		source: RecipeDiscoverySource.CAMPAIGN_MILESTONE,
+		milestones: CAMPAIGN_RECIPE_MILESTONES
+	}
+] as const;
+
+describe("RecipeDiscoveryService progression unlocks", () => {
+	it.each(PROGRESSION_SOURCES)("should define exactly one milestone per $source recipe", ({
+		source, milestones
+	}) => {
+		const sourceRecipes = CookingRecipeDataController.instance.getAll()
+			.filter(recipe => !recipe.discoveredByDefault && recipe.discoverySource === source);
+
+		expect(milestones).toHaveLength(sourceRecipes.length);
+		expect(RecipeDiscoveryService.getProgressionUnlocks(source)).toHaveLength(sourceRecipes.length);
+	});
+
+	it.each(PROGRESSION_SOURCES)("should order $source unlocks by increasing recipe level and progression", ({
+		source, milestones
+	}) => {
+		const unlocks = RecipeDiscoveryService.getProgressionUnlocks(source);
+		const levels = unlocks.map(unlock => CookingRecipeDataController.instance.getById(unlock.recipeId)!.level);
+
+		expect(unlocks.map(unlock => unlock.requiredProgress)).toEqual([...milestones]);
+		expect(levels).toEqual([...levels].sort((a, b) => a - b));
+	});
+
+	it("should be stable across calls so the retroactive backfill matches the runtime order", () => {
+		expect(RecipeDiscoveryService.getProgressionUnlocks(RecipeDiscoverySource.CAMPAIGN_MILESTONE))
+			.toEqual(RecipeDiscoveryService.getProgressionUnlocks(RecipeDiscoverySource.CAMPAIGN_MILESTONE));
+	});
+});

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -38,7 +38,7 @@ import {
 	isRecipeSecret
 } from "./CookingSlotRotation";
 import {
-	CookingSlotData, RecipeSlotData, PinnedRecipeInfo, RecipeIngredients
+	CookingSlotData, RecipeSlotData, PinnedRecipeInfo, RecipeIngredients, RecipeDisplayInfo
 } from "../../../../Lib/src/types/CookingTypes";
 import { RecipeDiscoveryService } from "./RecipeDiscoveryService";
 import {
@@ -63,7 +63,7 @@ export interface CraftResult {
 	levelUp: boolean;
 	newLevel?: number;
 	newGrade?: string;
-	discoveredRecipeIds: string[];
+	discoveredRecipes: RecipeDisplayInfo[];
 	bonusOutput: boolean;
 }
 
@@ -447,7 +447,7 @@ export class CookingService {
 		});
 
 		// Discover cooking-level recipes on level up
-		const discoveredRecipeIds = levelResult.levelUp
+		const discoveredRecipes = levelResult.levelUp
 			? await RecipeDiscoveryService.discoverCookingLevelRecipes(player)
 			: [];
 
@@ -456,7 +456,7 @@ export class CookingService {
 			xpGained: xp,
 			materialSaved,
 			...levelResult,
-			discoveredRecipeIds,
+			discoveredRecipes,
 			bonusOutput
 		};
 	}

--- a/Core/src/core/cooking/CookingService.ts
+++ b/Core/src/core/cooking/CookingService.ts
@@ -448,7 +448,7 @@ export class CookingService {
 
 		// Discover cooking-level recipes on level up
 		const discoveredRecipeIds = levelResult.levelUp
-			? (await RecipeDiscoveryService.discoverCookingLevelRecipes(player)).map(r => r.id)
+			? await RecipeDiscoveryService.discoverCookingLevelRecipes(player)
 			: [];
 
 		return {

--- a/Core/src/core/cooking/RecipeDiscoveryService.ts
+++ b/Core/src/core/cooking/RecipeDiscoveryService.ts
@@ -5,6 +5,7 @@ import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 import PlayerCookingRecipe from "../database/game/models/PlayerCookingRecipe";
 import Player from "../database/game/models/Player";
 import { CookingRecipe } from "../../../../Lib/src/types/CookingRecipe";
+import { RecipeDisplayInfo } from "../../../../Lib/src/types/CookingTypes";
 import { ItemNature } from "../../../../Lib/src/constants/ItemConstants";
 import { CrowniclesPacket } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
@@ -15,7 +16,7 @@ export interface RecipeDiscoveryOffer {
 }
 
 export interface ProgressionRecipeUnlock {
-	recipeId: string;
+	recipe: CookingRecipe;
 	requiredProgress: number;
 }
 
@@ -47,6 +48,17 @@ const POTION_NATURE_TO_RECIPE_TYPE: Partial<Record<ItemNature, RecipeType>> = {
 
 export class RecipeDiscoveryService {
 	/**
+	 * Keep only what the front needs to render a recipe: its name, icon and required level.
+	 */
+	static toDisplayInfo(recipe: CookingRecipe): RecipeDisplayInfo {
+		return {
+			recipeId: recipe.id,
+			level: recipe.level,
+			recipeType: recipe.recipeType
+		};
+	}
+
+	/**
 	 * Find and discover the first undiscovered recipe from a sorted list of candidates.
 	 * Returns the discovered recipe or null if all candidates are already known.
 	 */
@@ -71,14 +83,14 @@ export class RecipeDiscoveryService {
 	}
 
 	/**
-	 * Discover every given recipe the player does not know yet, and return the newly discovered ids.
+	 * Discover every given recipe the player does not know yet, and return the newly discovered ones.
 	 */
-	private static async discoverRecipeIds(player: Player, recipeIds: string[]): Promise<string[]> {
-		const discovered: string[] = [];
-		for (const recipeId of recipeIds) {
-			if (!await PlayerCookingRecipe.isRecipeDiscovered(player, recipeId)) {
-				await PlayerCookingRecipe.discoverRecipe(player, recipeId);
-				discovered.push(recipeId);
+	private static async discoverAll(player: Player, recipes: CookingRecipe[]): Promise<RecipeDisplayInfo[]> {
+		const discovered: RecipeDisplayInfo[] = [];
+		for (const recipe of recipes) {
+			if (!await PlayerCookingRecipe.isRecipeDiscovered(player, recipe.id)) {
+				await PlayerCookingRecipe.discoverRecipe(player, recipe.id);
+				discovered.push(RecipeDiscoveryService.toDisplayInfo(recipe));
 			}
 		}
 		return discovered;
@@ -95,7 +107,7 @@ export class RecipeDiscoveryService {
 		)
 			.slice(0, milestones.length)
 			.map((recipe, index) => ({
-				recipeId: recipe.id,
+				recipe,
 				requiredProgress: milestones[index]
 			}));
 	}
@@ -104,11 +116,11 @@ export class RecipeDiscoveryService {
 	 * Grant every recipe the player's current progression entitles them to and return the newly
 	 * learned ones. Safe to call repeatedly: already known recipes are skipped.
 	 */
-	static async syncProgressionRecipes(player: Player, source: ProgressionRecipeSource, progress: number): Promise<string[]> {
-		const entitledRecipeIds = RecipeDiscoveryService.getProgressionUnlocks(source)
+	static async syncProgressionRecipes(player: Player, source: ProgressionRecipeSource, progress: number): Promise<RecipeDisplayInfo[]> {
+		const entitledRecipes = RecipeDiscoveryService.getProgressionUnlocks(source)
 			.filter(unlock => progress >= unlock.requiredProgress)
-			.map(unlock => unlock.recipeId);
-		return await RecipeDiscoveryService.discoverRecipeIds(player, entitledRecipeIds);
+			.map(unlock => unlock.recipe);
+		return await RecipeDiscoveryService.discoverAll(player, entitledRecipes);
 	}
 
 	/**
@@ -173,15 +185,15 @@ export class RecipeDiscoveryService {
 
 	/**
 	 * Discover all COOKING_LEVEL recipes up to the player's current cooking level.
-	 * Returns the ids of all newly discovered recipes.
+	 * Returns all newly discovered recipes.
 	 */
-	static discoverCookingLevelRecipes(player: Player): Promise<string[]> {
+	static discoverCookingLevelRecipes(player: Player): Promise<RecipeDisplayInfo[]> {
 		const candidates = RecipeDiscoveryService.getSortedCandidates(
 			r => !r.discoveredByDefault
 				&& r.discoverySource === RecipeDiscoverySource.COOKING_LEVEL
 				&& r.level <= player.cookingLevel
 		);
-		return RecipeDiscoveryService.discoverRecipeIds(player, candidates.map(recipe => recipe.id));
+		return RecipeDiscoveryService.discoverAll(player, candidates);
 	}
 
 	/**

--- a/Core/src/core/cooking/RecipeDiscoveryService.ts
+++ b/Core/src/core/cooking/RecipeDiscoveryService.ts
@@ -1,5 +1,5 @@
 import {
-	RecipeDiscoverySource, RecipeType
+	CAMPAIGN_RECIPE_MILESTONES, PLAYER_LEVEL_RECIPE_MILESTONES, RecipeDiscoverySource, RecipeType
 } from "../../../../Lib/src/constants/CookingConstants";
 import { CookingRecipeDataController } from "../../data/CookingRecipeData";
 import PlayerCookingRecipe from "../database/game/models/PlayerCookingRecipe";
@@ -13,6 +13,25 @@ export interface RecipeDiscoveryOffer {
 	recipe: CookingRecipe;
 	cost: number;
 }
+
+export interface ProgressionRecipeUnlock {
+	recipeId: string;
+	requiredProgress: number;
+}
+
+/**
+ * Sources whose recipes are granted by a progression counter (player level, campaign
+ * missions completed) instead of a one-off event: the n-th recipe of the source, recipes
+ * being ordered by level, is unlocked once the n-th milestone is reached. Ordering by
+ * progression instead of counting events makes the grant idempotent and self-healing —
+ * a player who advanced before the feature existed catches up on their next progression.
+ */
+const PROGRESSION_RECIPE_MILESTONES = {
+	[RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE]: PLAYER_LEVEL_RECIPE_MILESTONES,
+	[RecipeDiscoverySource.CAMPAIGN_MILESTONE]: CAMPAIGN_RECIPE_MILESTONES
+} as const;
+
+export type ProgressionRecipeSource = keyof typeof PROGRESSION_RECIPE_MILESTONES;
 
 /**
  * Maps ItemNature (potion nature) to the corresponding RecipeType
@@ -42,12 +61,54 @@ export class RecipeDiscoveryService {
 	}
 
 	/**
-	 * Get sorted candidates for a given filter predicate
+	 * Get sorted candidates for a given filter predicate. The id is used as a tie-breaker so
+	 * the discovery order never depends on the order the recipe files happen to be read in.
 	 */
 	private static getSortedCandidates(filter: (r: CookingRecipe) => boolean): CookingRecipe[] {
 		return CookingRecipeDataController.instance.getAll()
 			.filter(filter)
-			.sort((a, b) => a.level - b.level);
+			.sort((a, b) => a.level - b.level || a.id.localeCompare(b.id));
+	}
+
+	/**
+	 * Discover every given recipe the player does not know yet, and return the newly discovered ids.
+	 */
+	private static async discoverRecipeIds(player: Player, recipeIds: string[]): Promise<string[]> {
+		const discovered: string[] = [];
+		for (const recipeId of recipeIds) {
+			if (!await PlayerCookingRecipe.isRecipeDiscovered(player, recipeId)) {
+				await PlayerCookingRecipe.discoverRecipe(player, recipeId);
+				discovered.push(recipeId);
+			}
+		}
+		return discovered;
+	}
+
+	/**
+	 * Get every recipe of a progression source paired with the progression value unlocking it.
+	 * Shared with the retroactive migration so both use the exact same ordering.
+	 */
+	static getProgressionUnlocks(source: ProgressionRecipeSource): ProgressionRecipeUnlock[] {
+		const milestones = PROGRESSION_RECIPE_MILESTONES[source];
+		return RecipeDiscoveryService.getSortedCandidates(
+			r => !r.discoveredByDefault && r.discoverySource === source
+		)
+			.slice(0, milestones.length)
+			.map((recipe, index) => ({
+				recipeId: recipe.id,
+				requiredProgress: milestones[index]
+			}));
+	}
+
+	/**
+	 * Grant every recipe the player's current progression entitles them to and return the newly
+	 * learned ones. Safe to call repeatedly: already known recipes are skipped.
+	 */
+	static async syncProgressionRecipes(player: Player, source: ProgressionRecipeSource, progress: number): Promise<string[]> {
+		const entitledRecipeIds = RecipeDiscoveryService.getProgressionUnlocks(source)
+			.filter(unlock => progress >= unlock.requiredProgress)
+			.map(unlock => unlock.recipeId);
+		return await RecipeDiscoveryService.discoverRecipeIds(player, entitledRecipeIds);
 	}
 
 	/**
@@ -112,23 +173,15 @@ export class RecipeDiscoveryService {
 
 	/**
 	 * Discover all COOKING_LEVEL recipes up to the player's current cooking level.
-	 * Returns all newly discovered recipes.
+	 * Returns the ids of all newly discovered recipes.
 	 */
-	static async discoverCookingLevelRecipes(player: Player): Promise<CookingRecipe[]> {
-		const discovered: CookingRecipe[] = [];
+	static discoverCookingLevelRecipes(player: Player): Promise<string[]> {
 		const candidates = RecipeDiscoveryService.getSortedCandidates(
 			r => !r.discoveredByDefault
 				&& r.discoverySource === RecipeDiscoverySource.COOKING_LEVEL
 				&& r.level <= player.cookingLevel
 		);
-
-		for (const recipe of candidates) {
-			if (!await PlayerCookingRecipe.isRecipeDiscovered(player, recipe.id)) {
-				await PlayerCookingRecipe.discoverRecipe(player, recipe.id);
-				discovered.push(recipe);
-			}
-		}
-		return discovered;
+		return RecipeDiscoveryService.discoverRecipeIds(player, candidates.map(recipe => recipe.id));
 	}
 
 	/**

--- a/Core/src/core/database/game/migrations/068-backfill-progression-cooking-recipes.ts
+++ b/Core/src/core/database/game/migrations/068-backfill-progression-cooking-recipes.ts
@@ -16,7 +16,12 @@ export async function up({ context }: { context: QueryInterface }): Promise<void
 			SELECT p.id, :recipeId, NULL
 			FROM players p
 			WHERE p.level >= :requiredProgress
-		`, { replacements: { ...unlock } });
+		`, {
+			replacements: {
+				recipeId: unlock.recipe.id,
+				requiredProgress: unlock.requiredProgress
+			}
+		});
 	}
 
 	for (const unlock of RecipeDiscoveryService.getProgressionUnlocks(RecipeDiscoverySource.CAMPAIGN_MILESTONE)) {
@@ -25,7 +30,12 @@ export async function up({ context }: { context: QueryInterface }): Promise<void
 			SELECT pmi.playerId, :recipeId, NULL
 			FROM player_missions_info pmi
 			WHERE LENGTH(pmi.campaignBlob) - LENGTH(REPLACE(pmi.campaignBlob, '1', '')) >= :requiredProgress
-		`, { replacements: { ...unlock } });
+		`, {
+			replacements: {
+				recipeId: unlock.recipe.id,
+				requiredProgress: unlock.requiredProgress
+			}
+		});
 	}
 }
 

--- a/Core/src/core/database/game/migrations/068-backfill-progression-cooking-recipes.ts
+++ b/Core/src/core/database/game/migrations/068-backfill-progression-cooking-recipes.ts
@@ -1,0 +1,34 @@
+import { QueryInterface } from "sequelize";
+import { RecipeDiscoveryService } from "../../../cooking/RecipeDiscoveryService";
+import { RecipeDiscoverySource } from "../../../../../../Lib/src/constants/CookingConstants";
+
+/**
+ * Progression-based cooking recipes used to be granted one per event (one per level up, one
+ * per completed campaign mission) starting the day the feature shipped. Players who had
+ * already progressed never received them, and a player who finished the campaign could never
+ * get its recipes at all. Recipes are now tied to progression milestones, so backfill every
+ * recipe the players are already entitled to.
+ */
+export async function up({ context }: { context: QueryInterface }): Promise<void> {
+	for (const unlock of RecipeDiscoveryService.getProgressionUnlocks(RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE)) {
+		await context.sequelize.query(`
+			INSERT IGNORE INTO player_cooking_recipes (playerId, recipeId, sourceMapId)
+			SELECT p.id, :recipeId, NULL
+			FROM players p
+			WHERE p.level >= :requiredProgress
+		`, { replacements: { ...unlock } });
+	}
+
+	for (const unlock of RecipeDiscoveryService.getProgressionUnlocks(RecipeDiscoverySource.CAMPAIGN_MILESTONE)) {
+		await context.sequelize.query(`
+			INSERT IGNORE INTO player_cooking_recipes (playerId, recipeId, sourceMapId)
+			SELECT pmi.playerId, :recipeId, NULL
+			FROM player_missions_info pmi
+			WHERE LENGTH(pmi.campaignBlob) - LENGTH(REPLACE(pmi.campaignBlob, '1', '')) >= :requiredProgress
+		`, { replacements: { ...unlock } });
+	}
+}
+
+export async function down(): Promise<void> {
+	// No rollback: revoking learned recipes would be worse than keeping them.
+}

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -79,6 +79,7 @@ import { BlessingManager } from "../../../blessings/BlessingManager";
 import { Homes } from "./Home";
 import { getSlotCountForCategory } from "../../../../../../Lib/src/types/HomeFeatures";
 import { RecipeDiscoveryService } from "../../../cooking/RecipeDiscoveryService";
+import { RecipeDisplayInfo } from "../../../../../../Lib/src/types/CookingTypes";
 import { RecipeDiscoverySource } from "../../../../../../Lib/src/constants/CookingConstants";
 import { buildNewItemSlotData } from "../../../utils/ItemSlotUtils";
 
@@ -464,7 +465,7 @@ export class Player extends Model {
 	 * @param response
 	 * @param newLevel
 	 */
-	public async addLevelUpPacket(response: CrowniclesPacket[], newLevel: number, discoveredRecipeIds: string[]): Promise<void> {
+	public async addLevelUpPacket(response: CrowniclesPacket[], newLevel: number, discoveredRecipes: RecipeDisplayInfo[]): Promise<void> {
 		const healthRestored = newLevel % 10 === 0;
 
 		const packet = makePacket(PlayerLevelUpPacket, {
@@ -481,7 +482,7 @@ export class Player extends Model {
 			missionSlotUnlocked: Player.isMissionSlotUnlockedAtLevel(newLevel),
 			pveUnlocked: newLevel === PVEConstants.MIN_LEVEL,
 			statsIncreased: true,
-			...discoveredRecipeIds.length > 0 ? { discoveredRecipeIds } : {}
+			...discoveredRecipes.length > 0 ? { discoveredRecipes } : {}
 		});
 
 		if (healthRestored) {
@@ -535,9 +536,9 @@ export class Player extends Model {
 		crowniclesInstance?.logsDatabase.logLevelChange(this.keycloakId, this.level)
 			.then();
 
-		const discoveredRecipeIds = await RecipeDiscoveryService.syncProgressionRecipes(this, RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE, this.level);
+		const discoveredRecipes = await RecipeDiscoveryService.syncProgressionRecipes(this, RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE, this.level);
 
-		await this.addLevelUpPacket(response, this.level, discoveredRecipeIds);
+		await this.addLevelUpPacket(response, this.level, discoveredRecipes);
 
 		await this.levelUpIfNeeded(response);
 	}

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -464,7 +464,7 @@ export class Player extends Model {
 	 * @param response
 	 * @param newLevel
 	 */
-	public async addLevelUpPacket(response: CrowniclesPacket[], newLevel: number): Promise<void> {
+	public async addLevelUpPacket(response: CrowniclesPacket[], newLevel: number, discoveredRecipeIds: string[]): Promise<void> {
 		const healthRestored = newLevel % 10 === 0;
 
 		const packet = makePacket(PlayerLevelUpPacket, {
@@ -480,7 +480,8 @@ export class Player extends Model {
 			classesTier5Unlocked: newLevel === ClassConstants.GROUP4LEVEL,
 			missionSlotUnlocked: Player.isMissionSlotUnlockedAtLevel(newLevel),
 			pveUnlocked: newLevel === PVEConstants.MIN_LEVEL,
-			statsIncreased: true
+			statsIncreased: true,
+			...discoveredRecipeIds.length > 0 ? { discoveredRecipeIds } : {}
 		});
 
 		if (healthRestored) {
@@ -534,9 +535,9 @@ export class Player extends Model {
 		crowniclesInstance?.logsDatabase.logLevelChange(this.keycloakId, this.level)
 			.then();
 
-		await RecipeDiscoveryService.discoverFromSource(this, RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE);
+		const discoveredRecipeIds = await RecipeDiscoveryService.syncProgressionRecipes(this, RecipeDiscoverySource.PLAYER_LEVEL_MILESTONE, this.level);
 
-		await this.addLevelUpPacket(response, this.level);
+		await this.addLevelUpPacket(response, this.level, discoveredRecipeIds);
 
 		await this.levelUpIfNeeded(response);
 	}

--- a/Core/src/core/database/game/models/PlayerMissionsInfo.ts
+++ b/Core/src/core/database/game/models/PlayerMissionsInfo.ts
@@ -68,6 +68,14 @@ export class PlayerMissionsInfo extends Model {
 		return this.lastDailyMissionCompleted && datesAreOnSameDay(this.lastDailyMissionCompleted, new Date());
 	}
 
+	/**
+	 * The column is nullable in database and only defaulted in memory by
+	 * {@link PlayerMissionsInfos.getOfPlayer}, so a freshly locked row can still hold NULL.
+	 */
+	public getCampaignBlob(): string {
+		return this.campaignBlob || Campaign.getDefaultCampaignBlob();
+	}
+
 	public async addGems(amount: number, keycloakId: string, reason: NumberChangeReason): Promise<void> {
 		this.gems += amount;
 		await this.save();

--- a/Core/src/core/missions/Campaign.ts
+++ b/Core/src/core/missions/Campaign.ts
@@ -8,8 +8,6 @@ import { CampaignData } from "../../data/Campaign";
 import {
 	CompletedMission, MissionType
 } from "../../../../Lib/src/types/CompletedMission";
-import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
-import { RecipeDiscoverySource } from "../../../../Lib/src/constants/CookingConstants";
 
 export class Campaign {
 	private static maxCampaignCache = -1;
@@ -87,11 +85,7 @@ export class Campaign {
 		const campaign = await MissionSlots.getCampaignOfPlayer(player.id);
 		const missionsInfo = await PlayerMissionsInfos.getOfPlayer(player.id);
 		if (Campaign.hasNextCampaign(missionsInfo.campaignBlob)) {
-			const completedMissions = await this.completeCampaignMissions(player, missionsInfo, completedCampaign, campaign);
-			if (completedMissions.length > 0) {
-				await RecipeDiscoveryService.discoverFromSource(player, RecipeDiscoverySource.CAMPAIGN_MILESTONE);
-			}
-			return completedMissions;
+			return this.completeCampaignMissions(player, missionsInfo, completedCampaign, campaign);
 		}
 		return [];
 	}

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -38,6 +38,8 @@ import {
 } from "../../../../Lib/src/locks/withLockedEntities";
 import { assertUnderLock } from "../../../../Lib/src/locks/CLSNamespace";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
+import { RecipeDiscoverySource } from "../../../../Lib/src/constants/CookingConstants";
 
 
 type MissionInformations = {
@@ -131,13 +133,19 @@ export abstract class MissionsController {
 		if (completedMissions.length === 0) {
 			return player;
 		}
+		const discoveredRecipeIds = await RecipeDiscoveryService.syncProgressionRecipes(
+			player,
+			RecipeDiscoverySource.CAMPAIGN_MILESTONE,
+			Campaign.getAmountOfCampaignCompleted(missionInfo.campaignBlob)
+		);
 		player = await MissionsController.updatePlayerStats(player, missionInfo, completedMissions, response);
 		MissionsController.applyBlessingsToCompletedMissions(completedMissions);
 		const nextCampaignMission = await MissionsController.getNextCampaignMission(player, completedMissions);
 		response.push(makePacket(MissionsCompletedPacket, {
 			missions: MissionsController.prepareBaseMissions(completedMissions),
 			keycloakId: player.keycloakId,
-			...nextCampaignMission ? { nextCampaignMission } : {}
+			...nextCampaignMission ? { nextCampaignMission } : {},
+			...discoveredRecipeIds.length > 0 ? { discoveredRecipeIds } : {}
 		}));
 		await MissionsController.giveCampaignPetRewards(completedMissions, player, response);
 		return player;

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -133,7 +133,7 @@ export abstract class MissionsController {
 		if (completedMissions.length === 0) {
 			return player;
 		}
-		const discoveredRecipeIds = await RecipeDiscoveryService.syncProgressionRecipes(
+		const discoveredRecipes = await RecipeDiscoveryService.syncProgressionRecipes(
 			player,
 			RecipeDiscoverySource.CAMPAIGN_MILESTONE,
 			Campaign.getAmountOfCampaignCompleted(missionInfo.campaignBlob)
@@ -145,7 +145,7 @@ export abstract class MissionsController {
 			missions: MissionsController.prepareBaseMissions(completedMissions),
 			keycloakId: player.keycloakId,
 			...nextCampaignMission ? { nextCampaignMission } : {},
-			...discoveredRecipeIds.length > 0 ? { discoveredRecipeIds } : {}
+			...discoveredRecipes.length > 0 ? { discoveredRecipes } : {}
 		}));
 		await MissionsController.giveCampaignPetRewards(completedMissions, player, response);
 		return player;

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -136,7 +136,7 @@ export abstract class MissionsController {
 		const discoveredRecipes = await RecipeDiscoveryService.syncProgressionRecipes(
 			player,
 			RecipeDiscoverySource.CAMPAIGN_MILESTONE,
-			Campaign.getAmountOfCampaignCompleted(missionInfo.campaignBlob)
+			Campaign.getAmountOfCampaignCompleted(missionInfo.getCampaignBlob())
 		);
 		player = await MissionsController.updatePlayerStats(player, missionInfo, completedMissions, response);
 		MissionsController.applyBlessingsToCompletedMissions(completedMissions);

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -802,7 +802,7 @@ function buildCookingCraftResponsePacket({
 		newCookingGrade: result.newGrade,
 		materialSaved: result.materialSaved,
 		bonusOutput: result.bonusOutput && (bonusHonored ?? false),
-		discoveredRecipeIds: result.discoveredRecipeIds,
+		discoveredRecipes: result.discoveredRecipes,
 		menu
 	});
 }

--- a/Core/src/core/report/ReportPveService.ts
+++ b/Core/src/core/report/ReportPveService.ts
@@ -45,6 +45,7 @@ import { InventorySlots } from "../database/game/models/InventorySlot";
 import { PlayerActiveObjects } from "../database/game/models/PlayerActiveObjects";
 import { chooseDestination } from "./ReportDestinationService";
 import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
+import { RecipeDisplayInfo } from "../../../../Lib/src/types/CookingTypes";
 import {
 	applyMaterialLoot, generateBossLoot, updateCollectMaterialsMission
 } from "../utils/MaterialLootUtils";
@@ -195,7 +196,7 @@ function sendMonsterRewardPacket(
 	fight: FightController,
 	loot: {
 		materialLoot?: MaterialQuantity[];
-		discoveredRecipeId?: string;
+		discoveredRecipe?: RecipeDisplayInfo;
 	}
 ): void {
 	endFightResponse.push(makePacket(CommandReportMonsterRewardRes, {
@@ -213,7 +214,7 @@ function sendMonsterRewardPacket(
 			}
 			: undefined,
 		...loot.materialLoot && loot.materialLoot.length > 0 ? { materialLoot: loot.materialLoot } : {},
-		...loot.discoveredRecipeId ? { discoveredRecipeId: loot.discoveredRecipeId } : {}
+		...loot.discoveredRecipe ? { discoveredRecipe: loot.discoveredRecipe } : {}
 	}));
 }
 
@@ -255,7 +256,7 @@ async function applyPveBossWinRewards(ctx: ApplyPveBossWinRewardsCtx): Promise<v
 
 	sendMonsterRewardPacket(endFightResponse, rewards, result, fight, {
 		materialLoot,
-		...bossRecipe ? { discoveredRecipeId: bossRecipe.id } : {}
+		...bossRecipe ? { discoveredRecipe: RecipeDiscoveryService.toDisplayInfo(bossRecipe) } : {}
 	});
 	await MissionsController.update(player, endFightResponse, {
 		missionId: PVE_BOSS_MISSION_IDS.WIN_BOSS satisfies PveBossMissionId

--- a/Core/src/core/report/ReportPveService.ts
+++ b/Core/src/core/report/ReportPveService.ts
@@ -193,7 +193,10 @@ function sendMonsterRewardPacket(
 	rewards: PveFightRewards,
 	guildResult: GuildRewardsResult,
 	fight: FightController,
-	materialLoot?: MaterialQuantity[]
+	loot: {
+		materialLoot?: MaterialQuantity[];
+		discoveredRecipeId?: string;
+	}
 ): void {
 	endFightResponse.push(makePacket(CommandReportMonsterRewardRes, {
 		money: BlessingManager.getInstance().applyMoneyBlessing(rewards.money),
@@ -209,7 +212,8 @@ function sendMonsterRewardPacket(
 				petNickname: fight.petReactionData.petNickname
 			}
 			: undefined,
-		...materialLoot && materialLoot.length > 0 ? { materialLoot } : {}
+		...loot.materialLoot && loot.materialLoot.length > 0 ? { materialLoot: loot.materialLoot } : {},
+		...loot.discoveredRecipeId ? { discoveredRecipeId: loot.discoveredRecipeId } : {}
 	}));
 }
 
@@ -246,7 +250,13 @@ async function applyPveBossWinRewards(ctx: ApplyPveBossWinRewardsCtx): Promise<v
 		await updateCollectMaterialsMission(player, endFightResponse, materialLoot);
 	}
 
-	sendMonsterRewardPacket(endFightResponse, rewards, result, fight, materialLoot);
+	const isFinalBoss = Maps.isAtFinalPveBoss(player);
+	const bossRecipe = isFinalBoss ? await RecipeDiscoveryService.discoverFromBoss(player, mapId) : null;
+
+	sendMonsterRewardPacket(endFightResponse, rewards, result, fight, {
+		materialLoot,
+		...bossRecipe ? { discoveredRecipeId: bossRecipe.id } : {}
+	});
 	await MissionsController.update(player, endFightResponse, {
 		missionId: PVE_BOSS_MISSION_IDS.WIN_BOSS satisfies PveBossMissionId
 	});
@@ -256,14 +266,11 @@ async function applyPveBossWinRewards(ctx: ApplyPveBossWinRewardsCtx): Promise<v
 	});
 
 	// Only count final island bosses for the different classes mission
-	if (Maps.isAtFinalPveBoss(player)) {
+	if (isFinalBoss) {
 		await MissionsController.update(player, endFightResponse, {
 			missionId: PVE_BOSS_MISSION_IDS.WIN_BOSS_WITH_DIFFERENT_CLASSES satisfies PveBossMissionId,
 			params: { classId: player.class }
 		});
-
-		// Discover an island boss cooking recipe
-		await RecipeDiscoveryService.discoverFromBoss(player, mapId);
 	}
 }
 

--- a/Core/src/core/smallEvents/recipeShopOffer.ts
+++ b/Core/src/core/smallEvents/recipeShopOffer.ts
@@ -49,7 +49,7 @@ function getRecipeShopEndCallback(player: Player, source: RecipeShopSource, offe
 			}
 			response.push(makePacket(SmallEventRecipeShopAcceptedPacket, {
 				source,
-				recipeId: offer.recipe.id,
+				recipe: RecipeDiscoveryService.toDisplayInfo(offer.recipe),
 				recipeCost: offer.cost
 			}));
 		});
@@ -71,7 +71,7 @@ export function openRecipeShopOffer(params: {
 }): void {
 	const collector = new ReactionCollectorRecipeShopSmallEvent({
 		source: params.source,
-		recipeId: params.offer.recipe.id,
+		recipe: RecipeDiscoveryService.toDisplayInfo(params.offer.recipe),
 		recipeCost: params.offer.cost,
 		...params.farmer ? { farmer: params.farmer } : {},
 		...params.ultimateFoodMerchant ? { ultimateFoodMerchant: params.ultimateFoodMerchant } : {}

--- a/Core/src/core/smallEvents/witch.ts
+++ b/Core/src/core/smallEvents/witch.ts
@@ -32,6 +32,7 @@ import { WitchActionOutcomeType } from "../../../../Lib/src/types/WitchActionOut
 import { Effect } from "../../../../Lib/src/types/Effect";
 import { ClassConstants } from "../../../../Lib/src/constants/ClassConstants";
 import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
+import { RecipeDisplayInfo } from "../../../../Lib/src/types/CookingTypes";
 import { withLockedPlayerAndMissionsSafe } from "../utils/withLockedPlayerAndMissionsSafe";
 
 
@@ -94,7 +95,7 @@ async function givePotion(context: PacketContext, player: Player, potionToGive: 
  * @param player
  * @param response
  */
-async function applyOutcome(outcome: WitchActionOutcomeType, selectedEvent: WitchAction, context: PacketContext, player: Player, response: CrowniclesPacket[]): Promise<string | undefined> {
+async function applyOutcome(outcome: WitchActionOutcomeType, selectedEvent: WitchAction, context: PacketContext, player: Player, response: CrowniclesPacket[]): Promise<RecipeDisplayInfo | undefined> {
 	if (selectedEvent.forceEffect || outcome === WitchActionOutcomeType.EFFECT) {
 		await selectedEvent.giveEffect(player);
 	}
@@ -120,7 +121,7 @@ async function applyOutcome(outcome: WitchActionOutcomeType, selectedEvent: Witc
 		const discovered = await RecipeDiscoveryService.discoverWitchRecipe(player, potionNature);
 		if (discovered) {
 			await player.save();
-			return discovered.id;
+			return RecipeDiscoveryService.toDisplayInfo(discovered);
 		}
 	}
 	await player.save();
@@ -173,9 +174,9 @@ async function runWitchEndCallbackUnderLock(
 		return;
 	}
 
-	const discoveredRecipeId = await applyOutcome(outcome, selectedEvent, collector.context, player, response);
-	if (discoveredRecipeId) {
-		resultPacket.discoveredRecipeId = discoveredRecipeId;
+	const discoveredRecipe = await applyOutcome(outcome, selectedEvent, collector.context, player, response);
+	if (discoveredRecipe) {
+		resultPacket.discoveredRecipe = discoveredRecipe;
 	}
 
 	response.push(resultPacket);

--- a/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
@@ -1032,7 +1032,7 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 	 * Build the discovered recipes message
 	 */
 	private buildDiscoveredRecipesMessage(response: CommandReportCookingCraftRes, ctx: HomeFeatureHandlerContext): string {
-		const message = buildRecipeDiscoveryMessage(response.discoveredRecipeIds ?? [], ctx.lng);
+		const message = buildRecipeDiscoveryMessage(response.discoveredRecipes ?? [], ctx.lng);
 		return message === "" ? "" : `\n${message}`;
 	}
 

--- a/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
@@ -46,6 +46,7 @@ import { CrowniclesEmbed } from "../../../../../messages/CrowniclesEmbed";
 import { PacketUtils } from "../../../../../utils/PacketUtils";
 import { DiscordCollectorUtils } from "../../../../../utils/DiscordCollectorUtils";
 import { buildCustomId } from "../../../../../utils/CustomIdUtils";
+import { buildRecipeDiscoveryMessage } from "../../../../../utils/CookingDisplayUtils";
 import { ReactionCollectorRefuseReaction } from "../../../../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
 
 /**
@@ -1031,24 +1032,8 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 	 * Build the discovered recipes message
 	 */
 	private buildDiscoveredRecipesMessage(response: CommandReportCookingCraftRes, ctx: HomeFeatureHandlerContext): string {
-		if (!response.discoveredRecipeIds || response.discoveredRecipeIds.length === 0) {
-			return "";
-		}
-
-		if (response.discoveredRecipeIds.length === 1) {
-			return `\n${i18n.t("commands:report.city.homes.cooking.recipeDiscovered", {
-				lng: ctx.lng,
-				recipe: i18n.t(`models:cooking.recipes.${response.discoveredRecipeIds[0]}`, { lng: ctx.lng })
-			})}`;
-		}
-
-		const recipeNames = response.discoveredRecipeIds
-			.map(id => `**${i18n.t(`models:cooking.recipes.${id}`, { lng: ctx.lng })}**`)
-			.join(", ");
-		return `\n${i18n.t("commands:report.city.homes.cooking.recipesDiscovered", {
-			lng: ctx.lng,
-			recipes: recipeNames
-		})}`;
+		const message = buildRecipeDiscoveryMessage(response.discoveredRecipeIds ?? [], ctx.lng);
+		return message === "" ? "" : `\n${message}`;
 	}
 
 	/**

--- a/Discord/src/commands/player/report/pveFight/PveFightHandlers.ts
+++ b/Discord/src/commands/player/report/pveFight/PveFightHandlers.ts
@@ -119,8 +119,8 @@ export async function displayMonsterReward(
 		descriptionParts.push(`\n${materialLootText}`);
 	}
 
-	if (packet.discoveredRecipeId) {
-		descriptionParts.push(`\n${buildRecipeDiscoveryMessage([packet.discoveredRecipeId], lng)}`);
+	if (packet.discoveredRecipe) {
+		descriptionParts.push(`\n${buildRecipeDiscoveryMessage([packet.discoveredRecipe], lng)}`);
 	}
 
 	const embed = new CrowniclesEmbed()

--- a/Discord/src/commands/player/report/pveFight/PveFightHandlers.ts
+++ b/Discord/src/commands/player/report/pveFight/PveFightHandlers.ts
@@ -13,6 +13,7 @@ import i18n from "../../../../translations/i18n";
 import { ReactionCollectorReturnTypeOrNull } from "../../../../packetHandlers/handlers/ReactionCollectorHandlers";
 import { DiscordCollectorUtils } from "../../../../utils/DiscordCollectorUtils";
 import { formatMaterialLoot } from "../../../../utils/MaterialLootDisplayUtils";
+import { buildRecipeDiscoveryMessage } from "../../../../utils/CookingDisplayUtils";
 import { PetUtils } from "../../../../utils/PetUtils";
 import {
 	escapeUsername, StringUtils
@@ -116,6 +117,10 @@ export async function displayMonsterReward(
 	const materialLootText = formatMaterialLoot(packet.materialLoot, lng);
 	if (materialLootText) {
 		descriptionParts.push(`\n${materialLootText}`);
+	}
+
+	if (packet.discoveredRecipeId) {
+		descriptionParts.push(`\n${buildRecipeDiscoveryMessage([packet.discoveredRecipeId], lng)}`);
 	}
 
 	const embed = new CrowniclesEmbed()

--- a/Discord/src/packetHandlers/handlers/EventsHandlers.ts
+++ b/Discord/src/packetHandlers/handlers/EventsHandlers.ts
@@ -238,10 +238,7 @@ export default class EventsHandlers {
 			});
 		}
 		if (packet.discoveredRecipeIds) {
-			completedMissionsEmbed.addFields({
-				name: i18n.t("models:cooking.recipeDiscoveryTitle", { lng }),
-				value: buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng)
-			});
+			completedMissionsEmbed.setDescription(buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng));
 		}
 		await interaction.channel.send({ embeds: [completedMissionsEmbed] });
 	}
@@ -409,14 +406,11 @@ export default class EventsHandlers {
 			}
 		}
 
-		embed.setDescription(desc);
-
 		if (packet.discoveredRecipeIds) {
-			embed.addFields({
-				name: i18n.t("models:cooking.recipeDiscoveryTitle", { lng }),
-				value: buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng)
-			});
+			desc += `\n${buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng)}`;
 		}
+
+		embed.setDescription(desc);
 
 		await interaction.channel.send({
 			embeds: [embed]

--- a/Discord/src/packetHandlers/handlers/EventsHandlers.ts
+++ b/Discord/src/packetHandlers/handlers/EventsHandlers.ts
@@ -19,6 +19,8 @@ import { PlayerDeathPacket } from "../../../../Lib/src/packets/events/PlayerDeat
 import { PlayerLeavePveIslandPacket } from "../../../../Lib/src/packets/events/PlayerLeavePveIslandPacket";
 import { PlayerLevelUpPacket } from "../../../../Lib/src/packets/events/PlayerLevelUpPacket";
 import { PlayerReceivePetPacket } from "../../../../Lib/src/packets/events/PlayerReceivePetPacket";
+import { buildRecipeDiscoveryMessage } from "../../utils/CookingDisplayUtils";
+
 import { GiveFoodToGuildPacket } from "../../../../Lib/src/packets/utils/GiveFoodToGuildPacket";
 import { NoFoodSpaceInGuildPacket } from "../../../../Lib/src/packets/utils/NoFoodSpaceInGuildPacket";
 import { MissionUtils } from "../../utils/MissionUtils";
@@ -93,6 +95,31 @@ function buildTotalRewardsLines(totals: MissionRewardTotals, lng: Language): str
 	return lines.length === 0
 		? [i18n.t("notifications:missions.completed.noRewards", { lng })]
 		: lines;
+}
+
+/**
+ * Build a notification embed authored by the target player, falling back to a plain title
+ * when their Discord user is not cached. Returns null when the Keycloak user is gone.
+ */
+async function buildPlayerNotificationEmbed(
+	keycloakId: string,
+	notificationName: string,
+	buildTitle: (pseudo: string) => string
+): Promise<CrowniclesEmbed | null> {
+	const getUser = await KeycloakUtils.getUserByKeycloakId(keycloakConfig, keycloakId);
+	if (getUser.isError) {
+		// User may have been deleted from Keycloak, skip this notification
+		CrowniclesLogger.warn(`Keycloak user with id ${keycloakId} not found, skipping ${notificationName} notification`);
+		return null;
+	}
+	const user = getUser.payload.user;
+	const discordId = user.attributes.discordId?.[0] ?? null;
+	const discordUser = discordId ? crowniclesClient.users.cache.get(discordId) : null;
+	const titleText = buildTitle(escapeUsername(user.attributes.gameUsername[0]));
+
+	return discordUser
+		? new CrowniclesEmbed().formatAuthor(titleText, discordUser)
+		: new CrowniclesEmbed().setTitle(titleText);
 }
 
 export default class EventsHandlers {
@@ -174,25 +201,16 @@ export default class EventsHandlers {
 		if (!interaction) {
 			return;
 		}
-		const getUser = await KeycloakUtils.getUserByKeycloakId(keycloakConfig, packet.keycloakId!);
-		if (getUser.isError) {
-			// User may have been deleted from Keycloak, skip this notification
-			CrowniclesLogger.warn(`Keycloak user with id ${packet.keycloakId} not found, skipping missions completed notification`);
-			return;
-		}
-		const user = getUser.payload.user;
-		const discordId = user.attributes.discordId?.[0] ? user.attributes.discordId[0] : null;
-		const discordUser = discordId ? crowniclesClient.users.cache.get(discordId) : null;
 
 		const lng = interaction.userLanguage;
-		const titleText = i18n.t("notifications:missions.completed.title", {
+		const completedMissionsEmbed = await buildPlayerNotificationEmbed(packet.keycloakId!, "missions completed", pseudo => i18n.t("notifications:missions.completed.title", {
 			lng,
 			count: packet.missions.length,
-			pseudo: escapeUsername(user.attributes.gameUsername[0])
-		});
-		const completedMissionsEmbed = discordUser
-			? new CrowniclesEmbed().formatAuthor(titleText, discordUser)
-			: new CrowniclesEmbed().setTitle(titleText);
+			pseudo
+		}));
+		if (!completedMissionsEmbed) {
+			return;
+		}
 
 		const {
 			missionLists, totals
@@ -219,6 +237,12 @@ export default class EventsHandlers {
 				value: MissionUtils.formatBaseMission(packet.nextCampaignMission, lng)
 			});
 		}
+		if (packet.discoveredRecipeIds) {
+			completedMissionsEmbed.addFields({
+				name: i18n.t("models:cooking.recipeDiscoveryTitle", { lng }),
+				value: buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng)
+			});
+		}
 		await interaction.channel.send({ embeds: [completedMissionsEmbed] });
 	}
 
@@ -228,30 +252,22 @@ export default class EventsHandlers {
 		if (!interaction) {
 			return;
 		}
-		const getUser = await KeycloakUtils.getUserByKeycloakId(keycloakConfig, packet.keycloakId!);
-		if (getUser.isError) {
-			// User may have been deleted from Keycloak, skip this notification
-			CrowniclesLogger.warn(`Keycloak user with id ${packet.keycloakId} not found, skipping missions expired notification`);
-			return;
-		}
-		const user = getUser.payload.user;
-		const discordId = user.attributes.discordId?.[0] ? user.attributes.discordId[0] : null;
-		const discordUser = discordId ? crowniclesClient.users.cache.get(discordId) : null;
 
 		const lng = interaction.userLanguage;
+		const embed = await buildPlayerNotificationEmbed(packet.keycloakId!, "missions expired", pseudo => i18n.t("notifications:missions.expired.title", {
+			count: packet.missions.length,
+			lng,
+			pseudo
+		}));
+		if (!embed) {
+			return;
+		}
+
 		let missionsExpiredDescription = "";
 		for (const mission of packet.missions) {
 			missionsExpiredDescription += `- ${MissionUtils.formatBaseMission(mission, lng)} (${mission.numberDone}/${mission.missionObjective})\n`;
 		}
 
-		const titleText = i18n.t("notifications:missions.expired.title", {
-			count: packet.missions.length,
-			lng,
-			pseudo: escapeUsername(user.attributes.gameUsername[0])
-		});
-		const embed = discordUser
-			? new CrowniclesEmbed().formatAuthor(titleText, discordUser)
-			: new CrowniclesEmbed().setTitle(titleText);
 		embed.setDescription(i18n.t("notifications:missions.expired.description", {
 			lng,
 			count: packet.missions.length,
@@ -337,20 +353,17 @@ export default class EventsHandlers {
 			return;
 		}
 
-		const getUser = await KeycloakUtils.getUserByKeycloakId(keycloakConfig, packet.keycloakId!);
-		if (getUser.isError) {
-			// User may have been deleted from Keycloak, skip this notification
-			CrowniclesLogger.warn(`Keycloak user with id ${packet.keycloakId} not found, skipping level up notification`);
+		const lng = interaction.userLanguage;
+		const embed = await buildPlayerNotificationEmbed(packet.keycloakId!, "level up", pseudo => i18n.t("models:players.levelUp.title", {
+			lng,
+			pseudo
+		}));
+		if (!embed) {
 			return;
 		}
-		const user = getUser.payload.user;
-		const discordId = user.attributes.discordId?.[0] ? user.attributes.discordId[0] : null;
-		const discordUser = discordId ? crowniclesClient.users.cache.get(discordId) : null;
-
-		const lng = interaction.userLanguage;
 
 		const rewards: {
-			[key in keyof Omit<PlayerLevelUpPacket, "level" | "keycloakId">]: {
+			[key in keyof Omit<PlayerLevelUpPacket, "level" | "keycloakId" | "discoveredRecipeIds">]: {
 				tr: string; replacements?: object;
 			}
 		} = {
@@ -396,14 +409,14 @@ export default class EventsHandlers {
 			}
 		}
 
-		const titleText = i18n.t("models:players.levelUp.title", {
-			lng,
-			pseudo: escapeUsername(user.attributes.gameUsername[0])
-		});
-		const embed = discordUser
-			? new CrowniclesEmbed().formatAuthor(titleText, discordUser)
-			: new CrowniclesEmbed().setTitle(titleText);
 		embed.setDescription(desc);
+
+		if (packet.discoveredRecipeIds) {
+			embed.addFields({
+				name: i18n.t("models:cooking.recipeDiscoveryTitle", { lng }),
+				value: buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng)
+			});
+		}
 
 		await interaction.channel.send({
 			embeds: [embed]

--- a/Discord/src/packetHandlers/handlers/EventsHandlers.ts
+++ b/Discord/src/packetHandlers/handlers/EventsHandlers.ts
@@ -237,8 +237,8 @@ export default class EventsHandlers {
 				value: MissionUtils.formatBaseMission(packet.nextCampaignMission, lng)
 			});
 		}
-		if (packet.discoveredRecipeIds) {
-			completedMissionsEmbed.setDescription(buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng));
+		if (packet.discoveredRecipes) {
+			completedMissionsEmbed.setDescription(buildRecipeDiscoveryMessage(packet.discoveredRecipes, lng));
 		}
 		await interaction.channel.send({ embeds: [completedMissionsEmbed] });
 	}
@@ -406,8 +406,8 @@ export default class EventsHandlers {
 			}
 		}
 
-		if (packet.discoveredRecipeIds) {
-			desc += `\n${buildRecipeDiscoveryMessage(packet.discoveredRecipeIds, lng)}`;
+		if (packet.discoveredRecipes) {
+			desc += `\n${buildRecipeDiscoveryMessage(packet.discoveredRecipes, lng)}`;
 		}
 
 		embed.setDescription(desc);

--- a/Discord/src/packetHandlers/handlers/smallEvents/recipeShop.ts
+++ b/Discord/src/packetHandlers/handlers/smallEvents/recipeShop.ts
@@ -16,7 +16,7 @@ export default class RecipeShopSmallEventHandler {
 		await recipeShopOutcomeHandler(
 			context,
 			packet.source,
-			buildRecipePurchasedMessage(packet.recipeId, packet.recipeCost, context.discord!.language)
+			buildRecipePurchasedMessage(packet.recipe, packet.recipeCost, context.discord!.language)
 		);
 	}
 

--- a/Discord/src/smallEvents/recipeShop.ts
+++ b/Discord/src/smallEvents/recipeShop.ts
@@ -9,9 +9,12 @@ import { CrowniclesSmallEventEmbed } from "../messages/CrowniclesSmallEventEmbed
 import { CrowniclesIcons } from "../../../Lib/src/CrowniclesIcons";
 import i18n from "../translations/i18n";
 import { Language } from "../../../Lib/src/Language";
+import { RecipeDisplayInfo } from "../../../Lib/src/types/CookingTypes";
 import { ReactionCollectorReturnTypeOrNull } from "../packetHandlers/handlers/ReactionCollectorHandlers";
 import { DiscordCollectorUtils } from "../utils/DiscordCollectorUtils";
-import { buildRecipeDiscoveryMessage } from "../utils/CookingDisplayUtils";
+import {
+	buildRecipeDiscoveryMessage, formatRecipe
+} from "../utils/CookingDisplayUtils";
 import { buildFarmerDescription } from "../packetHandlers/handlers/smallEvents/farmer";
 import { buildUltimateFoodMerchantDescription } from "../packetHandlers/handlers/smallEvents/ultimateFoodMerchant";
 
@@ -42,7 +45,7 @@ function buildBaseDescription(data: ReactionCollectorRecipeShopSmallEventData, l
 function buildOfferDescription(data: ReactionCollectorRecipeShopSmallEventData, lng: Language): string {
 	const offerLine = i18n.t(`smallEvents:recipeShop.offer.${data.source}`, {
 		lng,
-		recipe: i18n.t(`models:cooking.recipes.${data.recipeId}`, { lng }),
+		recipe: formatRecipe(data.recipe, lng),
 		price: data.recipeCost
 	});
 	return `${buildBaseDescription(data, lng)}\n\n${offerLine}`;
@@ -93,6 +96,6 @@ export async function recipeShopOutcomeHandler(context: PacketContext, source: R
 /**
  * Build the "recipe purchased" outcome message
  */
-export function buildRecipePurchasedMessage(recipeId: string, recipeCost: number, lng: Language): string {
-	return buildRecipeDiscoveryMessage([recipeId], lng, recipeCost);
+export function buildRecipePurchasedMessage(recipe: RecipeDisplayInfo, recipeCost: number, lng: Language): string {
+	return buildRecipeDiscoveryMessage([recipe], lng, recipeCost);
 }

--- a/Discord/src/smallEvents/recipeShop.ts
+++ b/Discord/src/smallEvents/recipeShop.ts
@@ -11,7 +11,7 @@ import i18n from "../translations/i18n";
 import { Language } from "../../../Lib/src/Language";
 import { ReactionCollectorReturnTypeOrNull } from "../packetHandlers/handlers/ReactionCollectorHandlers";
 import { DiscordCollectorUtils } from "../utils/DiscordCollectorUtils";
-import { buildRecipeDiscoveryMessage } from "../utils/SmallEventUtils";
+import { buildRecipeDiscoveryMessage } from "../utils/CookingDisplayUtils";
 import { buildFarmerDescription } from "../packetHandlers/handlers/smallEvents/farmer";
 import { buildUltimateFoodMerchantDescription } from "../packetHandlers/handlers/smallEvents/ultimateFoodMerchant";
 
@@ -94,5 +94,5 @@ export async function recipeShopOutcomeHandler(context: PacketContext, source: R
  * Build the "recipe purchased" outcome message
  */
 export function buildRecipePurchasedMessage(recipeId: string, recipeCost: number, lng: Language): string {
-	return buildRecipeDiscoveryMessage(recipeId, lng, recipeCost);
+	return buildRecipeDiscoveryMessage([recipeId], lng, recipeCost);
 }

--- a/Discord/src/smallEvents/witch.ts
+++ b/Discord/src/smallEvents/witch.ts
@@ -9,9 +9,8 @@ import {
 import { CrowniclesIcons } from "../../../Lib/src/CrowniclesIcons";
 import { sendInteractionNotForYou } from "../utils/ErrorUtils";
 import { ReactionCollectorWitchPacket } from "../../../Lib/src/packets/interaction/ReactionCollectorWitch";
-import {
-	buildRecipeDiscoveryMessage, getRandomSmallEventIntro
-} from "../utils/SmallEventUtils";
+import { getRandomSmallEventIntro } from "../utils/SmallEventUtils";
+import { buildRecipeDiscoveryMessage } from "../utils/CookingDisplayUtils";
 import { StringUtils } from "../utils/StringUtils";
 import { SmallEventWitchResultPacket } from "../../../Lib/src/packets/smallEvents/SmallEventWitchPacket";
 import { ReactionCollectorReturnTypeOrNull } from "../packetHandlers/handlers/ReactionCollectorHandlers";
@@ -103,7 +102,7 @@ export async function witchResult(packet: SmallEventWitchResultPacket, context: 
 	let description = buildWitchResultDescription(packet, lng);
 
 	if (packet.discoveredRecipeId) {
-		description += `\n\n${buildRecipeDiscoveryMessage(packet.discoveredRecipeId, lng)}`;
+		description += `\n\n${buildRecipeDiscoveryMessage([packet.discoveredRecipeId], lng)}`;
 	}
 
 	await (interaction.isRepliable() ? interaction.followUp : interaction.editReply).bind(interaction)({

--- a/Discord/src/smallEvents/witch.ts
+++ b/Discord/src/smallEvents/witch.ts
@@ -101,8 +101,8 @@ export async function witchResult(packet: SmallEventWitchResultPacket, context: 
 	const lng = context.discord!.language;
 	let description = buildWitchResultDescription(packet, lng);
 
-	if (packet.discoveredRecipeId) {
-		description += `\n\n${buildRecipeDiscoveryMessage([packet.discoveredRecipeId], lng)}`;
+	if (packet.discoveredRecipe) {
+		description += `\n\n${buildRecipeDiscoveryMessage([packet.discoveredRecipe], lng)}`;
 	}
 
 	await (interaction.isRepliable() ? interaction.followUp : interaction.editReply).bind(interaction)({

--- a/Discord/src/utils/CookingDisplayUtils.ts
+++ b/Discord/src/utils/CookingDisplayUtils.ts
@@ -1,0 +1,30 @@
+import { Language } from "../../../Lib/src/Language";
+import { CrowniclesIcons } from "../../../Lib/src/CrowniclesIcons";
+import i18n from "../translations/i18n";
+
+/**
+ * Build the "recipe discovered" message shown wherever a player learns cooking recipes
+ * (cooking level up, small events, level milestones, campaign milestones, island bosses).
+ * @param recipeIds the recipes just learned, empty yielding an empty message
+ * @param lng
+ * @param recipeCost price paid for the recipe, when it was bought
+ */
+export function buildRecipeDiscoveryMessage(recipeIds: string[], lng: Language, recipeCost?: number): string {
+	if (recipeIds.length === 0) {
+		return "";
+	}
+
+	if (recipeIds.length > 1) {
+		return i18n.t("commands:report.city.homes.cooking.recipesDiscovered", {
+			lng,
+			recipes: recipeIds.map(recipeId => `**${i18n.t(`models:cooking.recipes.${recipeId}`, { lng })}**`)
+				.join(", ")
+		});
+	}
+
+	const recipeMsg = i18n.t("commands:report.city.homes.cooking.recipeDiscovered", {
+		lng,
+		recipe: i18n.t(`models:cooking.recipes.${recipeIds[0]}`, { lng })
+	});
+	return recipeCost === undefined ? recipeMsg : `${recipeMsg} (${recipeCost} ${CrowniclesIcons.unitValues.money})`;
+}

--- a/Discord/src/utils/CookingDisplayUtils.ts
+++ b/Discord/src/utils/CookingDisplayUtils.ts
@@ -1,30 +1,46 @@
 import { Language } from "../../../Lib/src/Language";
 import { CrowniclesIcons } from "../../../Lib/src/CrowniclesIcons";
+import { RecipeDisplayInfo } from "../../../Lib/src/types/CookingTypes";
 import i18n from "../translations/i18n";
+
+/**
+ * Render a recipe the way the rest of the game renders obtained entities: its own icon,
+ * its name and the cooking level needed to prepare it.
+ * @param recipe
+ * @param lng
+ */
+export function formatRecipe(recipe: RecipeDisplayInfo, lng: Language): string {
+	return i18n.t("models:cooking.recipeDisplay", {
+		lng,
+		recipeId: recipe.recipeId,
+		recipeType: recipe.recipeType,
+		level: recipe.level
+	});
+}
 
 /**
  * Build the "recipe discovered" message shown wherever a player learns cooking recipes
  * (cooking level up, small events, level milestones, campaign milestones, island bosses).
- * @param recipeIds the recipes just learned, empty yielding an empty message
+ * @param recipes the recipes just learned, empty yielding an empty message
  * @param lng
  * @param recipeCost price paid for the recipe, when it was bought
  */
-export function buildRecipeDiscoveryMessage(recipeIds: string[], lng: Language, recipeCost?: number): string {
-	if (recipeIds.length === 0) {
+export function buildRecipeDiscoveryMessage(recipes: RecipeDisplayInfo[], lng: Language, recipeCost?: number): string {
+	if (recipes.length === 0) {
 		return "";
 	}
 
-	if (recipeIds.length > 1) {
+	if (recipes.length > 1) {
 		return i18n.t("commands:report.city.homes.cooking.recipesDiscovered", {
 			lng,
-			recipes: recipeIds.map(recipeId => `**${i18n.t(`models:cooking.recipes.${recipeId}`, { lng })}**`)
+			recipes: recipes.map(recipe => `**${formatRecipe(recipe, lng)}**`)
 				.join(", ")
 		});
 	}
 
 	const recipeMsg = i18n.t("commands:report.city.homes.cooking.recipeDiscovered", {
 		lng,
-		recipe: i18n.t(`models:cooking.recipes.${recipeIds[0]}`, { lng })
+		recipe: formatRecipe(recipes[0], lng)
 	});
 	return recipeCost === undefined ? recipeMsg : `${recipeMsg} (${recipeCost} ${CrowniclesIcons.unitValues.money})`;
 }

--- a/Discord/src/utils/SmallEventUtils.ts
+++ b/Discord/src/utils/SmallEventUtils.ts
@@ -1,6 +1,4 @@
 import { Language } from "../../../Lib/src/Language";
-import { CrowniclesIcons } from "../../../Lib/src/CrowniclesIcons";
-import i18n from "../translations/i18n";
 import { StringUtils } from "./StringUtils";
 
 /**
@@ -8,18 +6,4 @@ import { StringUtils } from "./StringUtils";
  */
 export function getRandomSmallEventIntro(language: Language): string {
 	return StringUtils.getRandomTranslation("smallEvents:intro", language);
-}
-
-/**
- * Build the "recipe discovered" message shown after certain small events
- */
-export function buildRecipeDiscoveryMessage(recipeId: string, lng: Language, recipeCost?: number): string {
-	let recipeMsg = i18n.t("commands:report.city.homes.cooking.recipeDiscovered", {
-		lng,
-		recipe: i18n.t(`models:cooking.recipes.${recipeId}`, { lng })
-	});
-	if (recipeCost !== undefined) {
-		recipeMsg += ` (${recipeCost} ${CrowniclesIcons.unitValues.money})`;
-	}
-	return recipeMsg;
 }

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -2493,7 +2493,6 @@
     "10": "Arbre ancestral"
   },
   "cooking": {
-    "recipeDiscoveryTitle": "Cuisine",
     "grades": {
       "kitchenHelper": "Aide-cuisine",
       "scullion": "Marmiton",

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -2493,6 +2493,7 @@
     "10": "Arbre ancestral"
   },
   "cooking": {
+    "recipeDiscoveryTitle": "Cuisine",
     "grades": {
       "kitchenHelper": "Aide-cuisine",
       "scullion": "Marmiton",

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -2493,6 +2493,7 @@
     "10": "Arbre ancestral"
   },
   "cooking": {
+    "recipeDisplay": "{emote:cookingRecipeTypes.{{recipeType}}} $t(models:cooking.recipes.{{recipeId}}) (Niv. {{level}})",
     "grades": {
       "kitchenHelper": "Aide-cuisine",
       "scullion": "Marmiton",

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -366,6 +366,40 @@ export const SLOT_SEED_OFFSETS = [
 export const MIN_GUARANTEED_PLAYER_LEVEL_RECIPES = 2;
 
 /**
+ * Player levels granting the n-th `PLAYER_LEVEL_MILESTONE` recipe (recipes ordered by level).
+ * Must hold exactly as many entries as there are recipes of that source.
+ */
+export const PLAYER_LEVEL_RECIPE_MILESTONES: readonly number[] = [
+	10,
+	20,
+	30,
+	40,
+	50,
+	60,
+	70,
+	80,
+	90,
+	100
+];
+
+/**
+ * Number of completed campaign missions granting the n-th `CAMPAIGN_MILESTONE` recipe
+ * (recipes ordered by level). Must hold exactly as many entries as there are recipes of that source.
+ */
+export const CAMPAIGN_RECIPE_MILESTONES: readonly number[] = [
+	15,
+	30,
+	45,
+	60,
+	75,
+	90,
+	105,
+	120,
+	135,
+	149
+];
+
+/**
  * Gaspard Jo recipe costs by grade index (0-9)
  */
 export const GASPARD_JO_RECIPE_COSTS = [

--- a/Lib/src/packets/AsyncPacketSender.ts
+++ b/Lib/src/packets/AsyncPacketSender.ts
@@ -12,6 +12,7 @@ import { PlayerLeavePveIslandPacket } from "./events/PlayerLeavePveIslandPacket"
 import { PlayerLevelUpPacket } from "./events/PlayerLevelUpPacket";
 import { PlayerReceivePetPacket } from "./events/PlayerReceivePetPacket";
 
+
 type AsyncPacketSenderCallback = (context: PacketContext, packetName: string, packet: CrowniclesPacket) => Promise<void> | void;
 
 type AsyncPacketSenderOptions = {

--- a/Lib/src/packets/commands/CommandReportPacket.ts
+++ b/Lib/src/packets/commands/CommandReportPacket.ts
@@ -116,6 +116,11 @@ export class CommandReportMonsterRewardRes extends CrowniclesPacket {
 	};
 
 	materialLoot?: MaterialQuantity[];
+
+	/**
+	 * Cooking recipe learned from the notes left by a defeated island boss.
+	 */
+	discoveredRecipeId?: string;
 }
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)

--- a/Lib/src/packets/commands/CommandReportPacket.ts
+++ b/Lib/src/packets/commands/CommandReportPacket.ts
@@ -25,7 +25,7 @@ export {
 	CookingSlotData, CookingCraftErrors, CookingCraftError, PinnedRecipeInfo, RecipeIngredients, CookingMenuSnapshot
 } from "../../types/CookingTypes";
 import {
-	CookingCraftError, CookingMenuSnapshot
+	CookingCraftError, CookingMenuSnapshot, RecipeDisplayInfo
 } from "../../types/CookingTypes";
 import type { ReactionCollectorCityData } from "../interaction/ReactionCollectorCity";
 
@@ -120,7 +120,7 @@ export class CommandReportMonsterRewardRes extends CrowniclesPacket {
 	/**
 	 * Cooking recipe learned from the notes left by a defeated island boss.
 	 */
-	discoveredRecipeId?: string;
+	discoveredRecipe?: RecipeDisplayInfo;
 }
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
@@ -706,7 +706,7 @@ export class CommandReportCookingCraftRes extends CrowniclesPacket {
 
 	bonusOutput?: boolean;
 
-	discoveredRecipeIds?: string[];
+	discoveredRecipes?: RecipeDisplayInfo[];
 
 	error?: CookingCraftError;
 

--- a/Lib/src/packets/events/MissionsCompletedPacket.ts
+++ b/Lib/src/packets/events/MissionsCompletedPacket.ts
@@ -16,4 +16,9 @@ export class MissionsCompletedPacket extends CrowniclesPacket {
 	 * and the campaign is not finished. Lets the player see what comes next without /mission.
 	 */
 	nextCampaignMission?: BaseMission;
+
+	/**
+	 * Cooking recipes unlocked by reaching a campaign progression milestone.
+	 */
+	discoveredRecipeIds?: string[];
 }

--- a/Lib/src/packets/events/MissionsCompletedPacket.ts
+++ b/Lib/src/packets/events/MissionsCompletedPacket.ts
@@ -4,6 +4,7 @@ import {
 import {
 	BaseMission, CompletedMission
 } from "../../types/CompletedMission";
+import { RecipeDisplayInfo } from "../../types/CookingTypes";
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class MissionsCompletedPacket extends CrowniclesPacket {
@@ -20,5 +21,5 @@ export class MissionsCompletedPacket extends CrowniclesPacket {
 	/**
 	 * Cooking recipes unlocked by reaching a campaign progression milestone.
 	 */
-	discoveredRecipeIds?: string[];
+	discoveredRecipes?: RecipeDisplayInfo[];
 }

--- a/Lib/src/packets/events/PlayerLevelUpPacket.ts
+++ b/Lib/src/packets/events/PlayerLevelUpPacket.ts
@@ -1,6 +1,7 @@
 import {
 	CrowniclesPacket, PacketDirection, sendablePacket
 } from "../CrowniclesPacket";
+import { RecipeDisplayInfo } from "../../types/CookingTypes";
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class PlayerLevelUpPacket extends CrowniclesPacket {
@@ -33,5 +34,5 @@ export class PlayerLevelUpPacket extends CrowniclesPacket {
 	/**
 	 * Cooking recipes unlocked by reaching this level milestone.
 	 */
-	discoveredRecipeIds?: string[];
+	discoveredRecipes?: RecipeDisplayInfo[];
 }

--- a/Lib/src/packets/events/PlayerLevelUpPacket.ts
+++ b/Lib/src/packets/events/PlayerLevelUpPacket.ts
@@ -29,4 +29,9 @@ export class PlayerLevelUpPacket extends CrowniclesPacket {
 	pveUnlocked!: boolean;
 
 	statsIncreased!: boolean;
+
+	/**
+	 * Cooking recipes unlocked by reaching this level milestone.
+	 */
+	discoveredRecipeIds?: string[];
 }

--- a/Lib/src/packets/interaction/ReactionCollectorRecipeShopSmallEvent.ts
+++ b/Lib/src/packets/interaction/ReactionCollectorRecipeShopSmallEvent.ts
@@ -5,6 +5,7 @@ import {
 	ReactionCollectorData,
 	ReactionCollectorRefuseReaction
 } from "./ReactionCollectorPacket";
+import { RecipeDisplayInfo } from "../../types/CookingTypes";
 
 export enum RecipeShopSource {
 	FARMER = "farmer",
@@ -26,7 +27,7 @@ export class RecipeShopUltimateFoodMerchantContext {
 export class ReactionCollectorRecipeShopSmallEventData extends ReactionCollectorData {
 	source!: RecipeShopSource;
 
-	recipeId!: string;
+	recipe!: RecipeDisplayInfo;
 
 	recipeCost!: number;
 

--- a/Lib/src/packets/smallEvents/SmallEventRecipeShopPacket.ts
+++ b/Lib/src/packets/smallEvents/SmallEventRecipeShopPacket.ts
@@ -3,12 +3,13 @@ import {
 	PacketDirection, sendablePacket
 } from "../CrowniclesPacket";
 import { RecipeShopSource } from "../interaction/ReactionCollectorRecipeShopSmallEvent";
+import { RecipeDisplayInfo } from "../../types/CookingTypes";
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class SmallEventRecipeShopAcceptedPacket extends SmallEventPacket {
 	source!: RecipeShopSource;
 
-	recipeId!: string;
+	recipe!: RecipeDisplayInfo;
 
 	recipeCost!: number;
 }

--- a/Lib/src/packets/smallEvents/SmallEventWitchPacket.ts
+++ b/Lib/src/packets/smallEvents/SmallEventWitchPacket.ts
@@ -2,6 +2,7 @@ import { SmallEventPacket } from "./SmallEventPacket";
 import {
 	PacketDirection, sendablePacket
 } from "../CrowniclesPacket";
+import { RecipeDisplayInfo } from "../../types/CookingTypes";
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class SmallEventWitchResultPacket extends SmallEventPacket {
@@ -19,5 +20,5 @@ export class SmallEventWitchResultPacket extends SmallEventPacket {
 
 	outcome!: number;
 
-	discoveredRecipeId?: string;
+	discoveredRecipe?: RecipeDisplayInfo;
 }

--- a/Lib/src/types/CookingTypes.ts
+++ b/Lib/src/types/CookingTypes.ts
@@ -49,6 +49,15 @@ export const CookingCraftErrors = {
 
 export type CookingCraftError = typeof CookingCraftErrors[keyof typeof CookingCraftErrors];
 
+/**
+ * Minimal recipe info needed to render a recipe as "{icon} Name (level)".
+ */
+export interface RecipeDisplayInfo {
+	recipeId: string;
+	level: number;
+	recipeType: RecipeType;
+}
+
 export interface PinnedRecipeInfo {
 	recipeId: string;
 	level: number;


### PR DESCRIPTION
Corrige #4610.

## Problèmes

1. **Découvertes silencieuses** : 3 des 7 sources de recettes ne disaient rien au joueur. Les valeurs de retour étaient simplement ignorées lors d'une montée de niveau, d'un palier de campagne et d'une victoire contre un boss d'île.

2. **`PLAYER_LEVEL_MILESTONE` n'était pas un palier** : une recette était accordée à *chaque* montée de niveau, donc un joueur ayant progressé lentement n'en accumulait presque aucune. En prod, la moyenne était de 0,15 recette pour les joueurs niveau 60+.

3. **Aucune rétroactivité** : les recettes de campagne n'étaient distribuées que dans `hasNextCampaign()`. Un joueur ayant déjà terminé la campagne ne pouvait donc **jamais** obtenir les 10 recettes associées — c'est exactement le cas décrit dans l'issue.

## Corrections

Les recettes de progression sont désormais liées à des **paliers** (`PLAYER_LEVEL_RECIPE_MILESTONES` : 10, 20, ... 100 ; `CAMPAIGN_RECIPE_MILESTONES` : 15, 30, ... 149). L'attribution devient idempotente et auto-réparatrice : un palier manqué est rattrapé à la progression suivante.

Une **migration rétroactive** (`068`) accorde à chaque joueur toutes les recettes auxquelles sa progression actuelle lui donne droit. Elle réutilise `RecipeDiscoveryService.getProgressionUnlocks()` pour garantir un ordre identique à celui du runtime.

Chaque découverte est maintenant **affichée**, en enrichissant les messages existants plutôt qu'en ajoutant un packet de notification dédié — les 7 sources passent par le même helper et le même texte.

Les recettes sont rendues comme les autres entités obtenues dans le jeu, avec leur emoji de type et le niveau de cuisine requis :

```
🍳 Vous avez appris une nouvelle recette : **🧪 Potion de vitesse (Niv. 5)** !
```

Le nouveau type partagé `RecipeDisplayInfo` transporte l'identité d'une recette jusqu'au front, qui n'a pas accès aux données de recettes. L'offre du fermier et de Gaspard-Jo en profite aussi : le joueur voit le niveau requis avant d'acheter.

## Validation

- `tsc` et `eslint` verts sur Lib, Core et Discord
- Tests : Lib 580, Core 1522, Discord 259
- Nouveau test garantissant qu'il existe exactement un palier par recette de progression et que migration et runtime partagent le même ordre
