### PR TITLE
fix: remove the unreachable Plaines du Contre Bois map location (#4613)

### DIFF
--- a/Core/__tests__/core/data/MapDataIntegrity.test.ts
+++ b/Core/__tests__/core/data/MapDataIntegrity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	readdirSync, readFileSync
+} from "fs";
+import { resolve } from "path";
+import { MapConstants } from "../../../../Lib/src/constants/MapConstants";
+
+type MapLinkData = {
+	startMap: number;
+	endMap: number;
+};
+
+const mapLocationsPath = resolve(__dirname, "../../../resources/mapLocations");
+const mapLinksPath = resolve(__dirname, "../../../resources/mapLinks");
+
+function readIds(path: string): number[] {
+	return readdirSync(path)
+		.filter(file => file.endsWith(".json"))
+		.map(file => Number(file.replace(".json", "")));
+}
+
+function readMapLinks(): Map<number, MapLinkData> {
+	const links = new Map<number, MapLinkData>();
+	for (const id of readIds(mapLinksPath)) {
+		links.set(id, JSON.parse(readFileSync(resolve(mapLinksPath, `${id}.json`), "utf-8")) as MapLinkData);
+	}
+	return links;
+}
+
+describe("Map data integrity", () => {
+	const mapLocationIds = new Set(readIds(mapLocationsPath));
+	const mapLinks = readMapLinks();
+
+	/*
+	 * Map location ids are sparse: a location can be removed without renumbering the others, so
+	 * nothing may iterate over a contiguous id range or derive an id by arithmetic. These checks
+	 * catch the references that such a removal would leave dangling.
+	 */
+	it("every map link points to existing map locations", () => {
+		const danglingLinks = [...mapLinks.entries()]
+			.filter(([, link]) => !mapLocationIds.has(link.startMap) || !mapLocationIds.has(link.endMap))
+			.map(([id, link]) => `${id} (${link.startMap} -> ${link.endMap})`);
+
+		expect(danglingLinks).toEqual([]);
+	});
+
+	it("every map location id referenced by MapConstants.LOCATIONS_IDS exists", () => {
+		const missing = Object.entries(MapConstants.LOCATIONS_IDS)
+			.filter(([, id]) => !mapLocationIds.has(id))
+			.map(([name, id]) => `${name} = ${id}`);
+
+		expect(missing).toEqual([]);
+	});
+
+	it("every map link id referenced by MapConstants.WATER_MAP_LINKS exists", () => {
+		const missing = MapConstants.WATER_MAP_LINKS.filter(id => !mapLinks.has(id));
+
+		expect(missing).toEqual([]);
+	});
+
+	it("every map location is reachable through at least one map link", () => {
+		const reachable = new Set<number>();
+		for (const link of mapLinks.values()) {
+			reachable.add(link.startMap);
+			reachable.add(link.endMap);
+		}
+		const unreachable = [...mapLocationIds].filter(id => !reachable.has(id));
+
+		expect(unreachable).toEqual([]);
+	});
+});

--- a/Core/resources/mapLocations/20.json
+++ b/Core/resources/mapLocations/20.json
@@ -1,8 +1,0 @@
-{
-  "type": "pl",
-  "tags": [
-    "detALa"
-  ],
-  "canBeGoToPlaceMissionDestination": false,
-  "attribute": "continent1"
-}

--- a/Core/src/core/database/game/migrations/068-remove-contre-bois-map-location.ts
+++ b/Core/src/core/database/game/migrations/068-remove-contre-bois-map-location.ts
@@ -1,0 +1,19 @@
+import { QueryInterface } from "sequelize";
+
+export async function up({ context }: { context: QueryInterface }): Promise<void> {
+	/*
+	 * Map location 20 (Plaines du Contre Bois) was unreachable by road but could
+	 * still be drawn as a distant expedition destination. It is removed from the
+	 * game data, so pending expeditions are moved to another plain of the same
+	 * continent to keep their name translatable.
+	 */
+	await context.sequelize.query(`
+		UPDATE pet_expeditions
+		SET mapLocationId = 12
+		WHERE mapLocationId = 20
+	`);
+}
+
+export async function down(): Promise<void> {
+	// No rollback: map location 20 no longer exists.
+}

--- a/Core/src/core/database/game/migrations/069-remove-contre-bois-map-location.ts
+++ b/Core/src/core/database/game/migrations/069-remove-contre-bois-map-location.ts
@@ -4,13 +4,15 @@ export async function up({ context }: { context: QueryInterface }): Promise<void
 	/*
 	 * Map location 20 (Plaines du Contre Bois) was unreachable by road but could
 	 * still be drawn as a distant expedition destination. It is removed from the
-	 * game data, so pending expeditions are moved to another plain of the same
-	 * continent to keep their name translatable.
+	 * game data, so the expeditions still shown to players are moved to another
+	 * plain of the same continent to keep their name translatable. Finished
+	 * expeditions are left untouched to keep the history faithful.
 	 */
 	await context.sequelize.query(`
 		UPDATE pet_expeditions
 		SET mapLocationId = 12
 		WHERE mapLocationId = 20
+		  AND status IN ('pending', 'in_progress')
 	`);
 }
 

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -314,7 +314,6 @@
       "17": "les Oasis Cachées du Village Coco",
       "18": "les Rapides Tumultueux de la Rivière Vacarme",
       "19": "les Sables Mouvants de La Dune",
-      "20": "les Champs Paisibles des Plaines du Contre Bois",
       "21": "les Échoppes Abandonnées de la Route des Merveilles",
       "22": "les Galeries Obscures du Bois Hurlant",
       "23": "les Ruelles Secrètes de Claire de Ville",

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -1208,7 +1208,7 @@
       "atParticle": "à la"
     },
     "19": {
-      "description": "Plage créée par les forts vents de la Vallée des Rois. La Dune protège les Plaines du Contre Bois de la chaleur et amène l'eau de la rivière Vacarme.",
+      "description": "Plage créée par les forts vents de la Vallée des Rois. La Dune protège les terres voisines de la chaleur et amène l'eau de la rivière Vacarme.",
       "name": "La Dune",
       "particle": "vers",
       "atParticle": "à"
@@ -1224,12 +1224,6 @@
       "name": "Voie champêtre",
       "particle": "vers la",
       "atParticle": "à la"
-    },
-    "20": {
-      "description": "Une vaste plaine paisible et agricole.",
-      "name": "Plaines du Contre Bois",
-      "particle": "vers les",
-      "atParticle": "aux"
     },
     "21": {
       "description": "Une route très empruntée par les villageois. Beaucoup de petits vendeurs ambulants s'y installent le temps d'une journée pour au final créer un immense marché.",

--- a/Lib/src/constants/MapConstants.ts
+++ b/Lib/src/constants/MapConstants.ts
@@ -54,7 +54,6 @@ export abstract class MapConstants {
 		COCO_VILLAGE: 17,
 		VACARME_RIVER: 18,
 		THE_DUNE: 19,
-		BACKWOODS_PLAINS: 20,
 		ROAD_OF_WONDERS: 21,
 		HOWLING_WOODS: 22,
 		CLAIRE_DE_VILLE: 23,


### PR DESCRIPTION
Fixes #4613

Les Plaines du Contre Bois (lieu 20) n'étaient reliées à aucun trajet : le lieu était inaccessible en jeu, mais l'expédition longue tire sa destination au hasard parmi tous les lieux du continent 1, donc elle pouvait l'y envoyer.

Le lieu est supprimé du jeu :

- suppression de `Core/resources/mapLocations/20.json` (le lieu disparaît donc automatiquement du tirage des expéditions longues)
- suppression de `MapConstants.LOCATIONS_IDS.BACKWOODS_PLAINS`, qui n'était référencé nulle part
- suppression des traductions françaises associées (nom/description du lieu, et nom stylisé d'expédition)
- la description de La Dune mentionnait les Plaines du Contre Bois, elle a été reformulée
- migration `069` : les expéditions encore affichées aux joueurs (`pending` / `in_progress`) qui pointaient sur le lieu 20 sont déplacées sur les Plaines de l'Étendue (12), une plaine du même continent, sinon leur nom ne serait plus traduisible jusqu'à la fin de l'expédition. Les expéditions terminées sont laissées telles quelles pour ne pas réécrire l'historique (il est exposé dans l'export RGPD).

À noter : `MapConstants.WATER_MAP_LINKS` contient aussi un `20`, mais c'est un identifiant de *mapLink*, pas de lieu — il est conservé.

## Vérifications

- `pnpm eslint` + `pnpm tsc` verts sur Core, Lib et Discord
- `pnpm test` Core : 1547 tests verts
