### PR TITLE
Bloquer le joueur jusqu'à la persistance du transfert de familier

### DIFF
--- a/Core/src/commands/pet/PetFeedCommand.ts
+++ b/Core/src/commands/pet/PetFeedCommand.ts
@@ -15,6 +15,7 @@ import {
 	CommandPetFeedPacketReq,
 	CommandPetFeedPetOnExpeditionErrorPacket,
 	CommandPetFeedResult,
+	CommandPetFeedSituationChangedErrorPacket,
 	CommandPetFeedSuccessPacket
 } from "../../../../Lib/src/packets/commands/CommandPetFeedPacket";
 import {
@@ -46,6 +47,8 @@ import {
 
 type GuildFeedReason = "OK" | "petChanged" | "storageEmpty";
 
+type CandyFeedReason = "OK" | "petChanged" | "noMoney";
+
 /**
  * In-lock body for the no-guild candy-feed flow. Re-validates that
  * the player still owns this pet and can still afford the candy
@@ -58,7 +61,7 @@ async function applyLockedCandyFeed(
 		player: Player; pet: PetEntity;
 	},
 	expectedPetId: number
-): Promise<boolean> {
+): Promise<CandyFeedReason> {
 	const {
 		player, pet
 	} = locked;
@@ -66,10 +69,10 @@ async function applyLockedCandyFeed(
 	const candyPrice = GuildDomainConstants.SHOP_PRICES.FOOD[candyIndex];
 
 	if (player.petId !== expectedPetId) {
-		return false;
+		return "petChanged";
 	}
 	if (player.money < candyPrice) {
-		return false;
+		return "noMoney";
 	}
 
 	await player.spendMoney({
@@ -87,7 +90,7 @@ async function applyLockedCandyFeed(
 	});
 
 	await Promise.all([pet.save(), player.save()]);
-	return true;
+	return "OK";
 }
 
 /**
@@ -105,7 +108,8 @@ type FeedResolution =
 		errorPacket:
 			| typeof CommandPetFeedNoPetErrorPacket
 			| typeof CommandPetFeedNoMoneyFeedErrorPacket
-			| typeof CommandPetFeedGuildStorageEmptyErrorPacket;
+			| typeof CommandPetFeedGuildStorageEmptyErrorPacket
+			| typeof CommandPetFeedSituationChangedErrorPacket;
 	};
 
 /**
@@ -177,9 +181,10 @@ async function runCandyFeedUnderLock(
 				authorPet.id
 			)
 		);
-		if (!outcome) {
+		if (outcome !== "OK") {
 			return {
-				ok: false, errorPacket: CommandPetFeedNoMoneyFeedErrorPacket
+				ok: false,
+				errorPacket: outcome === "petChanged" ? CommandPetFeedSituationChangedErrorPacket : CommandPetFeedNoMoneyFeedErrorPacket
 			};
 		}
 		return {
@@ -368,7 +373,8 @@ async function runGuildFeedUnderLock(
 		);
 		if (outcome.reason !== "OK") {
 			return {
-				ok: false, errorPacket: CommandPetFeedGuildStorageEmptyErrorPacket
+				ok: false,
+				errorPacket: outcome.reason === "petChanged" ? CommandPetFeedSituationChangedErrorPacket : CommandPetFeedGuildStorageEmptyErrorPacket
 			};
 		}
 		return {

--- a/Core/src/commands/pet/PetTransferCommand.ts
+++ b/Core/src/commands/pet/PetTransferCommand.ts
@@ -329,6 +329,49 @@ async function switchPetWithGuild(
 	);
 }
 
+const PET_TRANSFER_CHOICES = {
+	DEPOSIT: "deposit",
+	WITHDRAW: "withdraw",
+	SWITCH: "switch"
+} as const;
+
+type PetTransferChoice =
+	| { kind: typeof PET_TRANSFER_CHOICES.DEPOSIT }
+	| {
+		kind: typeof PET_TRANSFER_CHOICES.WITHDRAW; petEntityId: number;
+	}
+	| {
+		kind: typeof PET_TRANSFER_CHOICES.SWITCH; petEntityId: number;
+	};
+
+/**
+ * Read the collected reaction as one of the three transfer choices. Returns null when the
+ * player refused or let the collector expire.
+ */
+function readTransferChoice(collector: ReactionCollectorInstance): PetTransferChoice | null {
+	const firstReaction = collector.getFirstReaction();
+	if (!firstReaction) {
+		return null;
+	}
+
+	switch (firstReaction.reaction.type) {
+		case ReactionCollectorPetTransferDepositReaction.name:
+			return { kind: PET_TRANSFER_CHOICES.DEPOSIT };
+		case ReactionCollectorPetTransferWithdrawReaction.name:
+			return {
+				kind: PET_TRANSFER_CHOICES.WITHDRAW,
+				petEntityId: (firstReaction.reaction.data as ReactionCollectorPetTransferWithdrawReaction).petEntityId
+			};
+		case ReactionCollectorPetTransferSwitchReaction.name:
+			return {
+				kind: PET_TRANSFER_CHOICES.SWITCH,
+				petEntityId: (firstReaction.reaction.data as ReactionCollectorPetTransferSwitchReaction).petEntityId
+			};
+		default:
+			return null;
+	}
+}
+
 /**
  * Apply the transfer chosen by the player. The reaction has already been
  * validated, so only the persistence work is left.
@@ -336,26 +379,24 @@ async function switchPetWithGuild(
 async function applyChosenTransfer(
 	response: CrowniclesPacket[],
 	player: Player,
-	choice: {
-		depositOwnPet: boolean; withdrawPetEntityId: number | null;
-	}
+	choice: PetTransferChoice
 ): Promise<void> {
-	const {
-		depositOwnPet, withdrawPetEntityId
-	} = choice;
-
 	await player.reload();
 
-	if (depositOwnPet) {
-		if (withdrawPetEntityId !== null) {
-			await switchPetWithGuild(response, player, withdrawPetEntityId);
-		}
-		else {
+	switch (choice.kind) {
+		case PET_TRANSFER_CHOICES.DEPOSIT:
 			await deposePetToGuild(response, player);
-		}
-	}
-	else if (withdrawPetEntityId !== null) {
-		await withdrawPetFromGuild(response, player, withdrawPetEntityId);
+			return;
+		case PET_TRANSFER_CHOICES.WITHDRAW:
+			await withdrawPetFromGuild(response, player, choice.petEntityId);
+			return;
+		case PET_TRANSFER_CHOICES.SWITCH:
+			await switchPetWithGuild(response, player, choice.petEntityId);
+			return;
+		default:
+
+			// `choice` narrows to never here: the compiler proves every choice is handled
+			throw new Error(`unhandled pet transfer choice: ${JSON.stringify(choice)}`);
 	}
 }
 
@@ -368,22 +409,13 @@ function getEndCallback(player: Player): EndCallback {
 		 */
 		BlockingUtils.blockPlayer(player.keycloakId, BlockingConstants.REASONS.PET_TRANSFER);
 		try {
-			const firstReaction = collector.getFirstReaction();
-			if (!firstReaction || firstReaction.reaction.type === ReactionCollectorRefuseReaction.name) {
+			const choice = readTransferChoice(collector);
+			if (!choice) {
 				response.push(makePacket(CommandPetTransferCancelErrorPacket, {}));
 				return;
 			}
 
-			const depositOwnPet = firstReaction.reaction.type === ReactionCollectorPetTransferDepositReaction.name || firstReaction.reaction.type === ReactionCollectorPetTransferSwitchReaction.name;
-			const withdrawPetEntityId = firstReaction.reaction.type === ReactionCollectorPetTransferWithdrawReaction.name
-				? (firstReaction.reaction.data as ReactionCollectorPetTransferWithdrawReaction).petEntityId
-				: firstReaction.reaction.type === ReactionCollectorPetTransferSwitchReaction.name
-					? (firstReaction.reaction.data as ReactionCollectorPetTransferSwitchReaction).petEntityId
-					: null;
-
-			await applyChosenTransfer(response, player, {
-				depositOwnPet, withdrawPetEntityId
-			});
+			await applyChosenTransfer(response, player, choice);
 		}
 		finally {
 			BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.PET_TRANSFER);

--- a/Core/src/commands/pet/PetTransferCommand.ts
+++ b/Core/src/commands/pet/PetTransferCommand.ts
@@ -19,7 +19,9 @@ import {
 import {
 	PetEntities, PetEntity
 } from "../../core/database/game/models/PetEntity";
-import { ReactionCollectorInstance } from "../../core/utils/ReactionsCollector";
+import {
+	EndCallback, ReactionCollectorInstance
+} from "../../core/utils/ReactionsCollector";
 import { BlockingConstants } from "../../../../Lib/src/constants/BlockingConstants";
 import {
 	ReactionCollectorReaction,
@@ -327,35 +329,64 @@ async function switchPetWithGuild(
 	);
 }
 
-function getEndCallback(player: Player) {
+/**
+ * Apply the transfer chosen by the player. The reaction has already been
+ * validated, so only the persistence work is left.
+ */
+async function applyChosenTransfer(
+	response: CrowniclesPacket[],
+	player: Player,
+	choice: {
+		depositOwnPet: boolean; withdrawPetEntityId: number | null;
+	}
+): Promise<void> {
+	const {
+		depositOwnPet, withdrawPetEntityId
+	} = choice;
+
+	await player.reload();
+
+	if (depositOwnPet) {
+		if (withdrawPetEntityId !== null) {
+			await switchPetWithGuild(response, player, withdrawPetEntityId);
+		}
+		else {
+			await deposePetToGuild(response, player);
+		}
+	}
+	else if (withdrawPetEntityId !== null) {
+		await withdrawPetFromGuild(response, player, withdrawPetEntityId);
+	}
+}
+
+function getEndCallback(player: Player): EndCallback {
 	return async (collector: ReactionCollectorInstance, response: CrowniclesPacket[]): Promise<void> => {
-		BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.PET_TRANSFER);
-
-		const firstReaction = collector.getFirstReaction();
-		if (!firstReaction || firstReaction.reaction.type === ReactionCollectorRefuseReaction.name) {
-			response.push(makePacket(CommandPetTransferCancelErrorPacket, {}));
-			return;
-		}
-
-		const depositOwnPet = firstReaction.reaction.type === ReactionCollectorPetTransferDepositReaction.name || firstReaction.reaction.type === ReactionCollectorPetTransferSwitchReaction.name;
-		const withdrawPetEntityId = firstReaction.reaction.type === ReactionCollectorPetTransferWithdrawReaction.name
-			? (firstReaction.reaction.data as ReactionCollectorPetTransferWithdrawReaction).petEntityId
-			: firstReaction.reaction.type === ReactionCollectorPetTransferSwitchReaction.name
-				? (firstReaction.reaction.data as ReactionCollectorPetTransferSwitchReaction).petEntityId
-				: null;
-
-		await player.reload();
-
-		if (depositOwnPet) {
-			if (withdrawPetEntityId) {
-				await switchPetWithGuild(response, player, withdrawPetEntityId);
+		/*
+		 * The collector block expires on its own deadline, so it is renewed here: the player must stay
+		 * blocked until `petId` is persisted, otherwise a pet command fired right after the choice would
+		 * read the pet being transferred away.
+		 */
+		BlockingUtils.blockPlayer(player.keycloakId, BlockingConstants.REASONS.PET_TRANSFER);
+		try {
+			const firstReaction = collector.getFirstReaction();
+			if (!firstReaction || firstReaction.reaction.type === ReactionCollectorRefuseReaction.name) {
+				response.push(makePacket(CommandPetTransferCancelErrorPacket, {}));
+				return;
 			}
-			else {
-				await deposePetToGuild(response, player);
-			}
+
+			const depositOwnPet = firstReaction.reaction.type === ReactionCollectorPetTransferDepositReaction.name || firstReaction.reaction.type === ReactionCollectorPetTransferSwitchReaction.name;
+			const withdrawPetEntityId = firstReaction.reaction.type === ReactionCollectorPetTransferWithdrawReaction.name
+				? (firstReaction.reaction.data as ReactionCollectorPetTransferWithdrawReaction).petEntityId
+				: firstReaction.reaction.type === ReactionCollectorPetTransferSwitchReaction.name
+					? (firstReaction.reaction.data as ReactionCollectorPetTransferSwitchReaction).petEntityId
+					: null;
+
+			await applyChosenTransfer(response, player, {
+				depositOwnPet, withdrawPetEntityId
+			});
 		}
-		else if (withdrawPetEntityId !== null) {
-			await withdrawPetFromGuild(response, player, withdrawPetEntityId);
+		finally {
+			BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.PET_TRANSFER);
 		}
 	};
 }

--- a/Discord/src/packetHandlers/handlers/commands/pet/PetFeedPacketHandlers.ts
+++ b/Discord/src/packetHandlers/handlers/commands/pet/PetFeedPacketHandlers.ts
@@ -8,6 +8,7 @@ import {
 	CommandPetFeedNoPetErrorPacket,
 	CommandPetFeedNotHungryErrorPacket,
 	CommandPetFeedPetOnExpeditionErrorPacket,
+	CommandPetFeedSituationChangedErrorPacket,
 	CommandPetFeedSuccessPacket
 } from "../../../../../../Lib/src/packets/commands/CommandPetFeedPacket";
 import { DisplayUtils } from "../../../../utils/DisplayUtils";
@@ -39,6 +40,11 @@ export default class PetFeedCommandPacketHandlers {
 	@packetHandler(CommandPetFeedGuildStorageEmptyErrorPacket)
 	async guildStorageEmpty(context: PacketContext, _packet: CommandPetFeedGuildStorageEmptyErrorPacket): Promise<void> {
 		await handleClassicError(context, "commands:petFeed.guildStorageEmpty");
+	}
+
+	@packetHandler(CommandPetFeedSituationChangedErrorPacket)
+	async situationChanged(context: PacketContext, _packet: CommandPetFeedSituationChangedErrorPacket): Promise<void> {
+		await handleClassicError(context, "commands:petFeed.situationChanged");
 	}
 
 	@packetHandler(CommandPetFeedCancelErrorPacket)

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -2700,6 +2700,7 @@
     "noMoney": "Vous n'avez pas assez d'argent pour effectuer cet achat...",
     "notHungry": "Il semblerait que **{{pet}}** n'ait pas faim...",
     "guildStorageEmpty": "L'entrepôt de nourriture de votre guilde est vide. Ravitaillez votre guilde en ville avec {command:report}.",
+    "situationChanged": "Votre familier a changé pendant le nourrissage. Veuillez réessayer.",
     "cancelled": "Nourrissage annulé !",
     "resultTitle": "{{pseudo}}, nourrissage effectué !",
     "result": {

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -2700,7 +2700,7 @@
     "noMoney": "Vous n'avez pas assez d'argent pour effectuer cet achat...",
     "notHungry": "Il semblerait que **{{pet}}** n'ait pas faim...",
     "guildStorageEmpty": "L'entrepôt de nourriture de votre guilde est vide. Ravitaillez votre guilde en ville avec {command:report}.",
-    "situationChanged": "Votre familier a changé pendant le nourrissage. Veuillez réessayer.",
+    "situationChanged": "Votre familier a changé pendant que vous le nourrissiez. Veuillez réessayer.",
     "cancelled": "Nourrissage annulé !",
     "resultTitle": "{{pseudo}}, nourrissage effectué !",
     "result": {

--- a/Lib/src/packets/commands/CommandPetFeedPacket.ts
+++ b/Lib/src/packets/commands/CommandPetFeedPacket.ts
@@ -30,6 +30,10 @@ export class CommandPetFeedNoMoneyFeedErrorPacket extends CrowniclesPacket {}
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class CommandPetFeedGuildStorageEmptyErrorPacket extends CrowniclesPacket {}
 
+/** The pet owned by the player changed while the feed menu was open */
+@sendablePacket(PacketDirection.BACK_TO_FRONT)
+export class CommandPetFeedSituationChangedErrorPacket extends CrowniclesPacket {}
+
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class CommandPetFeedCancelErrorPacket extends CrowniclesPacket {}
 


### PR DESCRIPTION
Fixes #4605

## Le problème

Quand un joueur valide un `/pettransfert`, `getEndCallback` **débloquait le joueur en tout premier**, *avant* le `player.reload()` et avant l'écriture en base sous verrou.

Pendant cette fenêtre (allongée par un lag de la machine, comme dans le rapport) :

1. le joueur n'est plus bloqué, donc `/nourrirfamilier` (`notBlocked: true`) passe la garde ;
2. mais `player.petId` n'est pas encore à jour, donc le menu de nourrissage propose **l'ancien familier** ;
3. une fois sous son propre verrou, `applyLockedCandyFeed` détecte que `player.petId !== expectedPetId`, renvoie `false`, et `runCandyFeedUnderLock` traduisait ça en `CommandPetFeedNoMoneyFeedErrorPacket`.

D'où le « message d'erreur pas du tout adapté » (« pas assez d'argent ») et l'absence de consommation de nourriture décrits dans l'issue.

## Le correctif

**1. Cause racine — `PetTransferCommand`**

Le blocage est désormais renouvelé au début du callback de fin (`blockPlayer` sans expiration, le blocage du collecteur expirant sur sa propre deadline) et levé dans un `finally`, une fois le transfert persisté. Le joueur ne peut donc plus déclencher une commande familier sur un état intermédiaire.

La logique de persistance a été extraite dans `applyChosenTransfer` pour garder le callback plat malgré le `try`/`finally`.

**2. Symptôme — `PetFeedCommand`**

`applyLockedCandyFeed` renvoyait un booléen qui confondait « le familier a changé » et « pas assez d'argent ». Il renvoie maintenant un motif (`"OK" | "petChanged" | "noMoney"`), sur le modèle du `GuildFeedReason` déjà présent. Les deux flux (bonbon et entrepôt de guilde) routent le cas `petChanged` vers un nouveau paquet `CommandPetFeedSituationChangedErrorPacket`, avec un message dédié, au lieu de « pas assez d'argent » / « entrepôt vide ».

## Portée

Volontairement limitée au flux signalé. Les autres commandes familier (`petfree`, `petsell`, `petexpedition`) revalident déjà sous verrou et affichent un message « situation changée » correct.

À noter au passage, hors périmètre : `PetNickCommand` est `notBlocked: true` et lit `player.petId` **sans aucun verrou**.

## Tests

`eslint`, `tsc` et `pnpm test` verts sur Core, Discord et Lib (1547 / 260 / 580). Pas de test automatisé ajouté : le correctif porte sur une fenêtre de blocage en mémoire, qui demanderait le harnais d'intégration Docker/MariaDB pour être reproduite.
