### PR TITLE
Valider la mission jetons max lors du reset quotidien

### DIFF
--- a/Core/__tests__-integration/_coreSetup.ts
+++ b/Core/__tests__-integration/_coreSetup.ts
@@ -276,3 +276,27 @@ export async function runAllOrThrow<T>(promises: Iterable<Promise<T>>): Promise<
 	}
 	return results.map(r => (r as PromiseFulfilledResult<T>).value);
 }
+
+/**
+ * Pins the global daily mission to a reward-less mission no purchase can
+ * progress. Without this, `DailyMissions.getOrGenerate()` draws a random
+ * mission on the first `MissionsController.update`, and a drawn `spendMoney`
+ * mission credits its reward mid-test, so any assertion on an exact balance
+ * fails at random.
+ */
+export async function pinInertDailyMission(env: CoreTestEnvironment): Promise<void> {
+	const DailyMission = env.crownicles.gameDatabase.sequelize.models.DailyMission;
+	await DailyMission.destroy({ truncate: true, force: true });
+	await DailyMission.create({
+		id: 0,
+		missionId: "travelHours",
+		missionObjective: 2_000_000_000,
+		missionVariant: 0,
+		gemsToWin: 0,
+		xpToWin: 0,
+		pointsToWin: 0,
+		moneyToWin: 0,
+		lastDate: new Date()
+	});
+}
+

--- a/Core/__tests__-integration/handlers/daily-bonus.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/daily-bonus.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 import type { InventoryInfo as InventoryInfoType } from "../../src/core/database/game/models/InventoryInfo";
@@ -51,6 +51,7 @@ describe("DailyBonusCommand.activateDailyItem race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it(`applies the bonus exactly once when ${N_CONCURRENT} callers race`, async () => {

--- a/Core/__tests__-integration/handlers/daily-max-tokens-mission.integration.test.ts
+++ b/Core/__tests__-integration/handlers/daily-max-tokens-mission.integration.test.ts
@@ -1,0 +1,102 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { MissionSlot as MissionSlotType } from "../../src/core/database/game/models/MissionSlot";
+import { TokensConstants } from "../../../Lib/src/constants/TokensConstants";
+
+type CrowniclesDailyModule = typeof import("../../src/core/bot/cronJobs/CrowniclesDaily");
+
+describe("daily max tokens mission catch-up", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let MissionSlot: ModelStatic<MissionSlotType>;
+	let CrowniclesDaily: CrowniclesDailyModule["CrowniclesDaily"];
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("dailymaxtokens");
+		const models = env.crownicles.gameDatabase.sequelize.models;
+		Player = models.Player as ModelStatic<PlayerType>;
+		MissionSlot = models.MissionSlot as ModelStatic<MissionSlotType>;
+		CrowniclesDaily = loadProductionModule<CrowniclesDailyModule>("core/bot/cronJobs/CrowniclesDaily").CrowniclesDaily;
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await MissionSlot.destroy({
+				truncate: true, force: true
+			});
+			await Player.destroy({
+				truncate: true, force: true
+			});
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	});
+
+	async function seed(keycloakId: string, tokens: number, expiresAt: Date | null): Promise<MissionSlotType> {
+		const player = await Player.create({
+			keycloakId, tokens
+		});
+		return MissionSlot.create({
+			playerId: player.id,
+			missionId: "maxTokensReached",
+			missionVariant: 0,
+			missionObjective: 1,
+			numberDone: 0,
+			expiresAt,
+			gemsToWin: 0,
+			xpToWin: 100,
+			pointsToWin: 100,
+			moneyToWin: 100
+		});
+	}
+
+	const tomorrow = (): Date => new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+	it("completes the mission of a player sitting at the token cap", async () => {
+		const slot = await seed("maxtokens-capped", TokensConstants.MAX, tomorrow());
+
+		await CrowniclesDaily.maxTokensReachedMissions();
+
+		await slot.reload();
+		expect(slot.numberDone).toBe(1);
+	});
+
+	it("leaves the mission untouched below the token cap", async () => {
+		const slot = await seed("maxtokens-below", TokensConstants.MAX - 1, tomorrow());
+
+		await CrowniclesDaily.maxTokensReachedMissions();
+
+		await slot.reload();
+		expect(slot.numberDone).toBe(0);
+	});
+
+	it("completes the campaign slot, which never expires", async () => {
+		const slot = await seed("maxtokens-campaign", TokensConstants.MAX, null);
+
+		await CrowniclesDaily.maxTokensReachedMissions();
+
+		await slot.reload();
+		expect(slot.numberDone).toBe(1);
+	});
+
+	it("does not revive an expired mission", async () => {
+		const slot = await seed("maxtokens-expired", TokensConstants.MAX, new Date(Date.now() - 60 * 1000));
+
+		await CrowniclesDaily.maxTokensReachedMissions();
+
+		await slot.reload();
+		expect(slot.numberDone).toBe(0);
+	});
+});

--- a/Core/__tests__-integration/handlers/daily-max-tokens-mission.integration.test.ts
+++ b/Core/__tests__-integration/handlers/daily-max-tokens-mission.integration.test.ts
@@ -92,7 +92,8 @@ describe("daily max tokens mission catch-up", () => {
 	});
 
 	it("does not revive an expired mission", async () => {
-		const slot = await seed("maxtokens-expired", TokensConstants.MAX, new Date(Date.now() - 60 * 1000));
+		// Wide margin: the SQL guard compares against the server's `NOW()`, which may drift from the Node clock
+		const slot = await seed("maxtokens-expired", TokensConstants.MAX, new Date(Date.now() - 24 * 60 * 60 * 1000));
 
 		await CrowniclesDaily.maxTokensReachedMissions();
 

--- a/Core/__tests__-integration/handlers/do-possibility-locked-outcome.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/do-possibility-locked-outcome.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
@@ -60,6 +60,7 @@ describe("doPossibility locked outcome race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it(`serialises ${N_CONCURRENT} concurrent outcome applications — money is exact`, async () => {

--- a/Core/__tests__-integration/handlers/mission-money.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/mission-money.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
@@ -53,6 +53,7 @@ describe("MissionShopItems.getMoneyShopItem race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it(`credits exactly N * amount when ${N_CONCURRENT} callers race`, async () => {

--- a/Core/__tests__-integration/handlers/tanner-buy-slot.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/tanner-buy-slot.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 import type { InventoryInfo as InventoryInfoType } from "../../src/core/database/game/models/InventoryInfo";
@@ -52,6 +52,7 @@ describe("TannerShopItems.getBuySlotExtensionShopItemCallback race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it(`preserves N=${N_CONCURRENT} debits and slot increments under race`, async () => {

--- a/Core/__tests__-integration/handlers/tanner-plant-slot.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/tanner-plant-slot.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 import type { InventoryInfo as InventoryInfoType } from "../../src/core/database/game/models/InventoryInfo";
@@ -52,6 +52,7 @@ describe("TannerShopItems.getPlantSlotExtensionShopItem race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it(`grants exactly one slot when ${N_CONCURRENT} callers race at MAX-1`, async () => {

--- a/Core/__tests__-integration/handlers/with-locked-player-safe.race.integration.test.ts
+++ b/Core/__tests__-integration/handlers/with-locked-player-safe.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 
@@ -47,6 +47,7 @@ describe("withLockedPlayerSafe race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it(`serialises ${N_CONCURRENT} concurrent body executions — no lost writes`, async () => {

--- a/Core/__tests__-integration/locks/withLockedPlayerAndMissions.race.integration.test.ts
+++ b/Core/__tests__-integration/locks/withLockedPlayerAndMissions.race.integration.test.ts
@@ -3,7 +3,7 @@ import {
 } from "vitest";
 import type { ModelStatic } from "sequelize";
 import {
-	CoreTestEnvironment, loadProductionModule, runAllOrThrow, setupCoreForTests
+	CoreTestEnvironment, loadProductionModule, pinInertDailyMission, runAllOrThrow, setupCoreForTests
 } from "../_coreSetup";
 import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
 import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
@@ -43,6 +43,7 @@ describe("withLockedPlayerAndMissions race", () => {
 		finally {
 			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 		}
+		await pinInertDailyMission(env);
 	});
 
 	it("prewarms a missing PlayerMissionsInfo row before locking", async () => {

--- a/Core/__tests__/core/missions/MaxTokensReached.test.ts
+++ b/Core/__tests__/core/missions/MaxTokensReached.test.ts
@@ -1,0 +1,28 @@
+import {
+	describe, expect, it
+} from "vitest";
+import Player from "../../../src/core/database/game/models/Player";
+import { missionInterface } from "../../../src/core/missions/interfaces/maxTokensReached";
+import { TokensConstants } from "../../../../Lib/src/constants/TokensConstants";
+
+/**
+ * Regression test for bug #4601:
+ * The `maxTokensReached` interface was missing, so the mission silently fell back to the
+ * default one whose `initialNumberDone` always returns 0. A player already at the token
+ * cap when the mission was assigned therefore started at 0/1.
+ */
+describe("maxTokensReached mission interface", () => {
+	function createMockPlayer(tokens: number): Player {
+		const player = Object.create(Player.prototype);
+		Object.assign(player, { tokens });
+		return player as Player;
+	}
+
+	it("starts completed when the player is already at the token cap", () => {
+		expect(missionInterface.initialNumberDone(createMockPlayer(TokensConstants.MAX), 0)).toBe(1);
+	});
+
+	it("starts at zero when the player is below the token cap", () => {
+		expect(missionInterface.initialNumberDone(createMockPlayer(TokensConstants.MAX - 1), 0)).toBe(0);
+	});
+});

--- a/Core/src/core/bot/Crownicles.ts
+++ b/Core/src/core/bot/Crownicles.ts
@@ -7,7 +7,7 @@ import {
 	Op, Sequelize
 } from "sequelize";
 import {
-	asDays, asWeeks, daysToMilliseconds, minutesToMilliseconds, weeksToMilliseconds
+	asWeeks, minutesToMilliseconds, weeksToMilliseconds
 } from "../../../../Lib/src/utils/TimeUtils";
 import { TimeoutFunctionsConstants } from "../../../../Lib/src/constants/TimeoutFunctionsConstants";
 import { MapCache } from "../maps/MapCache";
@@ -18,11 +18,6 @@ import { FightConstants } from "../../../../Lib/src/constants/FightConstants";
 import { PacketUtils } from "../utils/PacketUtils";
 import { makePacket } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { Settings } from "../database/game/models/Setting";
-import { PotionDataController } from "../../data/Potion";
-import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
-import PetEntity from "../database/game/models/PetEntity";
-import { PetConstants } from "../../../../Lib/src/constants/PetConstants";
-import { TokensConstants } from "../../../../Lib/src/constants/TokensConstants";
 import { TopWeekFightAnnouncementPacket } from "../../../../Lib/src/packets/announcements/TopWeekFightAnnouncementPacket";
 import { MqttTopicUtils } from "../../../../Lib/src/utils/MqttTopicUtils";
 import { Badge } from "../../../../Lib/src/types/Badge";
@@ -74,71 +69,6 @@ export class Crownicles {
 		// Databases
 		this.gameDatabase = new GameDatabase();
 		this.logsDatabase = new LogsDatabase();
-	}
-
-	/**
-	 * Execute all the daily tasks
-	 */
-	static async dailyTimeout(): Promise<void> {
-		/*
-		 * First program the daily immediately at +1 day
-		 * Then wait a bit before setting the next date, so we are sure to be past the date
-		 *
-		 * The first one is set immediately so if the bot crashes before programming the next one, it will be set anyway to approximately a valid date (at 1s max of difference)
-		 */
-		await Settings.NEXT_DAILY_RESET.setValue(await Settings.NEXT_DAILY_RESET.getValue() + daysToMilliseconds(asDays(1)));
-
-		await Player.update(
-			{
-				tokens: Sequelize.literal(`GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`)
-			},
-			{ where: {} }
-		);
-
-		Crownicles.randomPotion()
-			.finally(() => null);
-		Crownicles.randomLovePointsLoose()
-			.then(petLoveChange => crowniclesInstance?.logsDatabase.logDailyTimeout(petLoveChange)
-				.then());
-		crowniclesInstance?.logsDatabase.log15BestTopWeek()
-			.then();
-	}
-
-	/**
-	 * Update the random potion sold in the shop
-	 */
-	static async randomPotion(): Promise<void> {
-		CrowniclesLogger.info("Daily timeout");
-		const previousPotionId = await Settings.SHOP_POTION.getValue();
-		const newPotionId = PotionDataController.instance.randomShopPotion(previousPotionId).id;
-		await Settings.SHOP_POTION.setValue(newPotionId);
-		CrowniclesLogger.info("New potion in shop", { newPotionId });
-		crowniclesInstance?.logsDatabase.logDailyPotion(newPotionId)
-			.then();
-	}
-
-	/**
-	 * Make some pet lose some love points
-	 */
-	static async randomLovePointsLoose(): Promise<boolean> {
-		if (!RandomUtils.crowniclesRandom.bool()) {
-			return false;
-		}
-
-		const [affectedCount] = await PetEntity.update(
-			{
-				lovePoints: Sequelize.literal(`GREATEST(0, lovePoints - ${PetConstants.DAILY_LOVE_LOSS})`)
-			},
-			{
-				where: {
-					lovePoints: { [Op.gt]: 0 }
-				}
-			}
-		);
-
-		CrowniclesLogger.info("Applied daily love loss to pets", { affectedPets: affectedCount });
-
-		return true;
 	}
 
 	/**

--- a/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
@@ -14,6 +14,7 @@ import { CityDataController } from "../../../data/City";
 import Player from "../../database/game/models/Player";
 import { TokensConstants } from "../../../../../Lib/src/constants/TokensConstants";
 import Guild from "../../database/game/models/Guild";
+import { MissionSlot } from "../../database/game/models/MissionSlot";
 import { GuildDomainConstants } from "../../../../../Lib/src/constants/GuildDomainConstants";
 import { NumberChangeReason } from "../../../../../Lib/src/constants/LogsConstants";
 import { CrowniclesCoreMetrics } from "../CrowniclesCoreMetrics";
@@ -61,6 +62,10 @@ export class CrowniclesDaily {
 		 * contention, and isolation ensures a failing task never skips the others.
 		 */
 		await CrowniclesDaily.runDailyTasks([
+			{
+				name: "maxTokensReachedMissions",
+				run: CrowniclesDaily.maxTokensReachedMissions
+			},
 			{
 				name: "randomPotion",
 				run: CrowniclesDaily.randomPotion
@@ -115,6 +120,27 @@ export class CrowniclesDaily {
 		}
 	}
 
+
+	/**
+	 * Mark the `maxTokensReached` mission as done for every player sitting at the token cap.
+	 *
+	 * The daily grant above is a bulk SQL update, so it bypasses `Player.addTokens` and never
+	 * notifies the mission system: a player pushed to the cap by that grant would otherwise
+	 * stay stuck at 0/1. The reward itself is handed out by the regular completion check, on
+	 * the player's next mission update.
+	 */
+	static async maxTokensReachedMissions(): Promise<void> {
+		const [, affectedRows] = await MissionSlot.sequelize!.query(
+			`UPDATE mission_slots ms
+			JOIN players p ON p.id = ms.playerId
+			SET ms.numberDone = 1
+			WHERE ms.missionId = 'maxTokensReached'
+				AND ms.numberDone < 1
+				AND (ms.expiresAt IS NULL OR ms.expiresAt > NOW())
+				AND p.tokens >= ${TokensConstants.MAX}`
+		);
+		CrowniclesLogger.info("Max tokens missions advanced", { affectedRows });
+	}
 
 	/**
 	 * Update the random potion sold in the shop

--- a/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
@@ -130,16 +130,27 @@ export class CrowniclesDaily {
 	 * the player's next mission update.
 	 */
 	static async maxTokensReachedMissions(): Promise<void> {
-		const [, affectedRows] = await MissionSlot.sequelize!.query(
-			`UPDATE mission_slots ms
+		/*
+		 * Deliberately split in two: a single `UPDATE ... JOIN players` would lock rows in both
+		 * tables in an order the optimizer chooses, which can invert the game's own order
+		 * (player locked first, mission slots written after) and deadlock a live command.
+		 * The read below is non-locking, and the write only ever touches mission_slots.
+		 */
+		const [rows] = await MissionSlot.sequelize!.query(
+			`SELECT ms.id
+			FROM mission_slots ms
 			JOIN players p ON p.id = ms.playerId
-			SET ms.numberDone = 1
 			WHERE ms.missionId = 'maxTokensReached'
 				AND ms.numberDone < 1
 				AND (ms.expiresAt IS NULL OR ms.expiresAt > NOW())
 				AND p.tokens >= ${TokensConstants.MAX}`
 		);
-		CrowniclesLogger.info("Max tokens missions advanced", { affectedRows });
+		const slotIds = (rows as { id: number }[]).map(row => row.id);
+		if (slotIds.length === 0) {
+			return;
+		}
+		await MissionSlot.update({ numberDone: 1 }, { where: { id: { [Op.in]: slotIds } } });
+		CrowniclesLogger.info("Max tokens missions advanced", { advancedSlots: slotIds.length });
 	}
 
 	/**

--- a/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
@@ -135,6 +135,12 @@ export class CrowniclesDaily {
 		 * tables in an order the optimizer chooses, which can invert the game's own order
 		 * (player locked first, mission slots written after) and deadlock a live command.
 		 * The read below is non-locking, and the write only ever touches mission_slots.
+		 *
+		 * `numberDone < 1` is not a correctness guard — the final state is the same without it —
+		 * but mission completion is lazy: the slot is only advanced or dropped on the player's
+		 * next `MissionsController.update`, so for a capped yet inactive player the row stays
+		 * here indefinitely. Without the guard this nightly job would rewrite an ever-growing
+		 * set of already-done rows, and `advancedSlots` below would count no-ops.
 		 */
 		const [rows] = await MissionSlot.sequelize!.query(
 			`SELECT ms.id

--- a/Core/src/core/missions/interfaces/maxTokensReached.ts
+++ b/Core/src/core/missions/interfaces/maxTokensReached.ts
@@ -1,0 +1,12 @@
+import { IMission } from "../IMission";
+import { TokensConstants } from "../../../../../Lib/src/constants/TokensConstants";
+
+export const missionInterface: IMission = {
+	areParamsMatchingVariantAndBlob: () => true,
+
+	generateRandomVariant: () => 0,
+
+	initialNumberDone: player => player.tokens >= TokensConstants.MAX ? 1 : 0,
+
+	updateSaveBlob: () => null
+};


### PR DESCRIPTION
Corrige #4601.

## Le problème

La mission « Atteindre le maximum de jetons » ne se validait pas quand le joueur atteignait 20 jetons via la progression journalière.

Deux causes distinctes :

**1. Le don quotidien de jetons ne notifie pas le système de missions**

Dans `CrowniclesDaily.job()`, les 3 jetons quotidiens sont distribués par un `UPDATE` SQL en masse :

```ts
await Player.update(
	{ tokens: literal(`LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY})`) },
	{ where: {} }
);
```

Ce chemin court-circuite complètement `Player.addTokens()` → `earnTokens()`, qui est le **seul** endroit où la mission `maxTokensReached` est mise à jour. Un joueur à 17+ jetons qui atteint le plafond au reset ne voit donc jamais sa mission évaluée : exactement le scénario du rapport.

**2. L'interface de mission `maxTokensReached` n'existait pas**

`Core/src/core/missions/interfaces/maxTokensReached.ts` était absent. `MissionsController.getMissionInterface()` retombait silencieusement sur `DefaultInterface`, dont `initialNumberDone` renvoie toujours `0`. Un joueur déjà au plafond au moment où la mission lui est attribuée démarrait donc à 0/1 au lieu de 1/1.

## Le correctif

- **Ajout de `interfaces/maxTokensReached.ts`**, calqué sur `reachScore` / `reachLevel` : `initialNumberDone: player => player.tokens >= TokensConstants.MAX ? 1 : 0`.
- **Nouvelle tâche quotidienne `maxTokensReachedMissions`**, exécutée juste après le don de jetons : un `UPDATE` ciblé qui passe `numberDone` à 1 pour les slots `maxTokensReached` non terminés, non expirés, dont le joueur est au plafond.

La récompense n'est pas distribuée par le cron (aucun tableau `response` n'existe dans ce contexte, le `MissionsCompletedPacket` serait perdu) : elle est remise normalement par `checkCompletedMissionsUnderLock` à la prochaine mise à jour de missions du joueur, c'est-à-dire dès sa commande suivante.

La tâche est volontairement en deux temps : un `SELECT` non bloquant qui collecte les slots concernés, puis un `UPDATE` qui ne touche que `mission_slots`. Un unique `UPDATE ... JOIN players` aurait verrouillé les deux tables dans un ordre choisi par l'optimiseur, potentiellement inverse de celui du jeu (joueur verrouillé d'abord, slots écrits ensuite), avec un risque de deadlock sur une commande en cours. L'écriture reste idempotente et monotone (garde `numberDone < 1`).

## Nettoyage

`Crownicles.dailyTimeout()`, `Crownicles.randomPotion()` et `Crownicles.randomLovePointsLoose()` étaient un triplet de code mort : ils dupliquaient le don de jetons et les tâches quotidiennes de `CrowniclesDaily`, et ne se référençaient plus qu'entre eux depuis la migration vers le cron. Ils sont supprimés, ainsi que les imports devenus inutiles, pour éviter qu'on corrige un jour le mauvais endroit.

## Tests

- `Core/__tests__/core/missions/MaxTokensReached.test.ts` — 2 tests unitaires sur `initialNumberDone`.
- `Core/__tests__-integration/handlers/daily-max-tokens-mission.integration.test.ts` — 4 tests d'intégration : joueur au plafond validé, joueur en dessous intact, slot de campagne (`expiresAt` NULL) validé, mission expirée non ressuscitée.

Validé en local : `pnpm eslint` OK, `pnpm tsc` OK, 1549 tests unitaires Core OK, suite d'intégration complète verte (21 fichiers / 49 tests, MariaDB Docker).

