### PR TITLE
Valide la mission de dépôt lors d'un échange dans le coffre

### DIFF
--- a/Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts
+++ b/Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts
@@ -43,7 +43,7 @@ describe("Chest deposit mission (issue #4589)", () => {
 	let PlayerMissionsInfo: ModelStatic<PlayerMissionsInfoType>;
 	let chestService: ReportCityChestServiceModule;
 
-	async function setupPlayerWithFullChest(): Promise<PlayerType> {
+	async function setupPlayerWithSwappableItems(): Promise<PlayerType> {
 		const player = await Player.create({ keycloakId: KEYCLOAK_ID });
 		const home = await Home.create({
 			ownerId: player.id,
@@ -123,7 +123,7 @@ describe("Chest deposit mission (issue #4589)", () => {
 	});
 
 	it("progresses the deposit mission when swapping an inventory item with a chest item", async () => {
-		const player = await setupPlayerWithFullChest();
+		const player = await setupPlayerWithSwappableItems();
 		const swapPacket: CommandReportHomeChestActionReq = {
 			action: HomeConstants.CHEST_ACTIONS.SWAP,
 			slot: 0,
@@ -138,7 +138,7 @@ describe("Chest deposit mission (issue #4589)", () => {
 	});
 
 	it("leaves the deposit mission untouched when withdrawing an item", async () => {
-		const player = await setupPlayerWithFullChest();
+		const player = await setupPlayerWithSwappableItems();
 		await InventorySlot.update({ itemId: 0 }, {
 			where: {
 				playerId: player.id,

--- a/Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts
+++ b/Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts
@@ -14,6 +14,9 @@ import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/cor
 import { ItemCategory } from "../../../Lib/src/constants/ItemConstants";
 import { HomeConstants } from "../../../Lib/src/constants/HomeConstants";
 import { CommandReportHomeChestActionReq } from "../../../Lib/src/packets/commands/CommandReportPacket";
+import { HomeLevel } from "../../../Lib/src/types/HomeLevel";
+import { hoursToMilliseconds } from "../../../Lib/src/utils/TimeUtils";
+import { asHours } from "../../../Lib/src/types/TimeTypes";
 
 type ReportCityChestServiceModule = typeof import("../../src/core/report/ReportCityChestService");
 
@@ -22,8 +25,13 @@ const INVENTORY_WEAPON_ID = 1;
 const CHEST_WEAPON_ID = 2;
 const CHEST_SLOT = 1;
 const MISSION_OBJECTIVE = 100;
-const ONE_HOUR = 3_600_000;
-const HOME_LEVEL_WITH_CHEST = 8;
+const ONE_HOUR_MS = hoursToMilliseconds(asHours(1));
+
+// Max home level: every chest category has enough slots for the swap scenario.
+const HOME_LEVEL_WITH_CHEST = HomeLevel.LEVEL_8.level;
+
+// Withdrawing takes an item out of the chest, so no destination chest slot applies.
+const NO_CHEST_SLOT = -1;
 
 /**
  * Functional regression test for issue #4589.
@@ -57,7 +65,7 @@ describe("Chest deposit mission (issue #4589)", () => {
 			missionVariant: 0,
 			missionObjective: MISSION_OBJECTIVE,
 			numberDone: 0,
-			expiresAt: new Date(Date.now() + ONE_HOUR),
+			expiresAt: new Date(Date.now() + ONE_HOUR_MS),
 			gemsToWin: 0,
 			pointsToWin: 0,
 			xpToWin: 0,
@@ -149,7 +157,7 @@ describe("Chest deposit mission (issue #4589)", () => {
 			action: HomeConstants.CHEST_ACTIONS.WITHDRAW,
 			slot: CHEST_SLOT,
 			itemCategory: ItemCategory.WEAPON,
-			chestSlot: -1
+			chestSlot: NO_CHEST_SLOT
 		};
 
 		const result = await chestService.handleChestAction(KEYCLOAK_ID, withdrawPacket, []);

--- a/Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts
+++ b/Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts
@@ -1,0 +1,160 @@
+import {
+	afterAll, beforeAll, beforeEach, describe, expect, it
+} from "vitest";
+import type { ModelStatic } from "sequelize";
+import {
+	CoreTestEnvironment, loadProductionModule, setupCoreForTests
+} from "../_coreSetup";
+import type { Player as PlayerType } from "../../src/core/database/game/models/Player";
+import type { Home as HomeType } from "../../src/core/database/game/models/Home";
+import type { HomeChestSlot as HomeChestSlotType } from "../../src/core/database/game/models/HomeChestSlot";
+import type { InventorySlot as InventorySlotType } from "../../src/core/database/game/models/InventorySlot";
+import type { MissionSlot as MissionSlotType } from "../../src/core/database/game/models/MissionSlot";
+import type { PlayerMissionsInfo as PlayerMissionsInfoType } from "../../src/core/database/game/models/PlayerMissionsInfo";
+import { ItemCategory } from "../../../Lib/src/constants/ItemConstants";
+import { HomeConstants } from "../../../Lib/src/constants/HomeConstants";
+import { CommandReportHomeChestActionReq } from "../../../Lib/src/packets/commands/CommandReportPacket";
+
+type ReportCityChestServiceModule = typeof import("../../src/core/report/ReportCityChestService");
+
+const KEYCLOAK_ID = "chest-swap-mission";
+const INVENTORY_WEAPON_ID = 1;
+const CHEST_WEAPON_ID = 2;
+const CHEST_SLOT = 1;
+const MISSION_OBJECTIVE = 100;
+const ONE_HOUR = 3_600_000;
+const HOME_LEVEL_WITH_CHEST = 8;
+
+/**
+ * Functional regression test for issue #4589.
+ *
+ * Swapping an inventory item with a chest item does place an item in the chest,
+ * so it must progress the "deposit an item in the chest" campaign mission. It
+ * used to be ignored, forcing players with a full inventory and a full chest to
+ * sell an item before they could complete the mission.
+ */
+describe("Chest deposit mission (issue #4589)", () => {
+	let env: CoreTestEnvironment;
+	let Player: ModelStatic<PlayerType>;
+	let Home: ModelStatic<HomeType>;
+	let HomeChestSlot: ModelStatic<HomeChestSlotType>;
+	let InventorySlot: ModelStatic<InventorySlotType>;
+	let MissionSlot: ModelStatic<MissionSlotType>;
+	let PlayerMissionsInfo: ModelStatic<PlayerMissionsInfoType>;
+	let chestService: ReportCityChestServiceModule;
+
+	async function setupPlayerWithFullChest(): Promise<PlayerType> {
+		const player = await Player.create({ keycloakId: KEYCLOAK_ID });
+		const home = await Home.create({
+			ownerId: player.id,
+			cityId: "chest-swap-city",
+			level: HOME_LEVEL_WITH_CHEST
+		});
+		await PlayerMissionsInfo.create({ playerId: player.id });
+		await MissionSlot.create({
+			playerId: player.id,
+			missionId: "depositChestItem",
+			missionVariant: 0,
+			missionObjective: MISSION_OBJECTIVE,
+			numberDone: 0,
+			expiresAt: new Date(Date.now() + ONE_HOUR),
+			gemsToWin: 0,
+			pointsToWin: 0,
+			xpToWin: 0,
+			moneyToWin: 0
+		});
+		await InventorySlot.create({
+			playerId: player.id,
+			slot: 0,
+			itemCategory: ItemCategory.WEAPON,
+			itemId: INVENTORY_WEAPON_ID,
+			itemLevel: 0,
+			itemEnchantmentId: null
+		});
+		await HomeChestSlot.create({
+			homeId: home.id,
+			slot: CHEST_SLOT,
+			itemCategory: ItemCategory.WEAPON,
+			itemId: CHEST_WEAPON_ID,
+			itemLevel: 0,
+			itemEnchantmentId: null
+		});
+		return player;
+	}
+
+	async function getMissionProgress(playerId: number): Promise<number | undefined> {
+		const slot = await MissionSlot.findOne({
+			where: {
+				playerId,
+				missionId: "depositChestItem"
+			}
+		});
+		return slot?.numberDone;
+	}
+
+	beforeAll(async () => {
+		env = await setupCoreForTests("chestswapmission");
+		Player = env.crownicles.gameDatabase.sequelize.models.Player as ModelStatic<PlayerType>;
+		Home = env.crownicles.gameDatabase.sequelize.models.Home as ModelStatic<HomeType>;
+		HomeChestSlot = env.crownicles.gameDatabase.sequelize.models.HomeChestSlot as ModelStatic<HomeChestSlotType>;
+		InventorySlot = env.crownicles.gameDatabase.sequelize.models.InventorySlot as ModelStatic<InventorySlotType>;
+		MissionSlot = env.crownicles.gameDatabase.sequelize.models.MissionSlot as ModelStatic<MissionSlotType>;
+		PlayerMissionsInfo = env.crownicles.gameDatabase.sequelize.models.PlayerMissionsInfo as ModelStatic<PlayerMissionsInfoType>;
+		chestService = loadProductionModule<ReportCityChestServiceModule>("core/report/ReportCityChestService");
+	});
+
+	afterAll(async () => {
+		await env?.teardown();
+	});
+
+	beforeEach(async () => {
+		await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			await HomeChestSlot.destroy({ truncate: true, force: true });
+			await InventorySlot.destroy({ truncate: true, force: true });
+			await MissionSlot.destroy({ truncate: true, force: true });
+			await PlayerMissionsInfo.destroy({ truncate: true, force: true });
+			await Home.destroy({ truncate: true, force: true });
+			await Player.destroy({ truncate: true, force: true });
+		}
+		finally {
+			await env.crownicles.gameDatabase.sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	});
+
+	it("progresses the deposit mission when swapping an inventory item with a chest item", async () => {
+		const player = await setupPlayerWithFullChest();
+		const swapPacket: CommandReportHomeChestActionReq = {
+			action: HomeConstants.CHEST_ACTIONS.SWAP,
+			slot: 0,
+			itemCategory: ItemCategory.WEAPON,
+			chestSlot: CHEST_SLOT
+		};
+
+		const result = await chestService.handleChestAction(KEYCLOAK_ID, swapPacket, []);
+
+		expect(result.success).toBe(true);
+		await expect(getMissionProgress(player.id)).resolves.toBe(1);
+	});
+
+	it("leaves the deposit mission untouched when withdrawing an item", async () => {
+		const player = await setupPlayerWithFullChest();
+		await InventorySlot.update({ itemId: 0 }, {
+			where: {
+				playerId: player.id,
+				slot: 0
+			}
+		});
+		const withdrawPacket: CommandReportHomeChestActionReq = {
+			action: HomeConstants.CHEST_ACTIONS.WITHDRAW,
+			slot: CHEST_SLOT,
+			itemCategory: ItemCategory.WEAPON,
+			chestSlot: -1
+		};
+
+		const result = await chestService.handleChestAction(KEYCLOAK_ID, withdrawPacket, []);
+
+		expect(result.success).toBe(true);
+		await expect(getMissionProgress(player.id)).resolves.toBe(0);
+	});
+});

--- a/Core/src/core/report/ReportCityChestService.ts
+++ b/Core/src/core/report/ReportCityChestService.ts
@@ -157,23 +157,25 @@ export async function handleChestAction(
 	 */
 	response.push(makePacket(CommandReportHomeChestActionRes, result));
 
-	/*
-	 * Trigger the mission update only after the Player + Home locks are
-	 * released: `MissionsController.update` additionally locks
-	 * `player_missions_info` then `players`, which would invert the
-	 * already-held `players` lock and risk a deadlock.
-	 */
-	if (result.success && actionPlacesItemInChest(packet.action)) {
-		await MissionsController.update(chestActionContext.player, response, { missionId: "depositChestItem" });
-	}
+	if (result.success) {
+		/*
+		 * Trigger the mission update only after the Player + Home locks are
+		 * released: `MissionsController.update` additionally locks
+		 * `player_missions_info` then `players`, which would invert the
+		 * already-held `players` lock and risk a deadlock.
+		 */
+		if (actionPlacesItemInChest(packet.action)) {
+			await MissionsController.update(chestActionContext.player, response, { missionId: "depositChestItem" });
+		}
 
-	/*
-	 * Withdrawing or swapping brings an item (potentially of higher rarity) back
-	 * into the inventory, so re-evaluate the "have an item of a given rarity"
-	 * mission against the player's best owned item. See issue #4393.
-	 */
-	if (result.success && actionBringsItemToInventory(packet.action)) {
-		await updateHaveItemRarityMission(chestActionContext.player, response);
+		/*
+		 * Withdrawing or swapping brings an item (potentially of higher rarity) back
+		 * into the inventory, so re-evaluate the "have an item of a given rarity"
+		 * mission against the player's best owned item. See issue #4393.
+		 */
+		if (actionBringsItemToInventory(packet.action)) {
+			await updateHaveItemRarityMission(chestActionContext.player, response);
+		}
 	}
 	return result;
 }

--- a/Core/src/core/report/ReportCityChestService.ts
+++ b/Core/src/core/report/ReportCityChestService.ts
@@ -73,6 +73,14 @@ function actionBringsItemToInventory(action: ChestAction): boolean {
 	return action === HomeConstants.CHEST_ACTIONS.WITHDRAW || action === HomeConstants.CHEST_ACTIONS.SWAP;
 }
 
+/**
+ * Whether a chest action places an item from the inventory into the chest, which
+ * is what the "deposit an item in the chest" mission tracks. See issue #4589.
+ */
+function actionPlacesItemInChest(action: ChestAction): boolean {
+	return action === HomeConstants.CHEST_ACTIONS.DEPOSIT || action === HomeConstants.CHEST_ACTIONS.SWAP;
+}
+
 function findEmptyActiveSlot(playerInventory: PlayerInventory, itemCategory: ItemCategory): InventorySlot | undefined {
 	return playerInventory.find(slot => slot.itemCategory === itemCategory && slot.slot === 0 && slot.itemId === 0);
 }
@@ -155,7 +163,7 @@ export async function handleChestAction(
 	 * `player_missions_info` then `players`, which would invert the
 	 * already-held `players` lock and risk a deadlock.
 	 */
-	if (result.success && packet.action === HomeConstants.CHEST_ACTIONS.DEPOSIT) {
+	if (result.success && actionPlacesItemInChest(packet.action)) {
 		await MissionsController.update(chestActionContext.player, response, { missionId: "depositChestItem" });
 	}
 


### PR DESCRIPTION
Fixes #4589

## Cause racine

`ReportCityChestService.handleChestAction` ne déclenchait la mission `depositChestItem` que pour l'action `DEPOSIT` :

```ts
if (result.success && packet.action === HomeConstants.CHEST_ACTIONS.DEPOSIT) {
```

Or `processChestSwap` place bien un objet de l'inventaire dans le coffre — c'est même la *seule* façon d'y parvenir quand l'inventaire et le coffre sont tous deux pleins sur une catégorie, puisque `DEPOSIT` échoue alors avec `CHEST_FULL`. Le joueur était donc contraint de vendre un objet pour libérer une place avant de pouvoir valider la mission de campagne.

Le fichier gérait déjà ce cas dans l'autre sens : `actionBringsItemToInventory` inclut `WITHDRAW` **et** `SWAP` pour réévaluer la mission de rareté (#4393). Seule la symétrie côté dépôt manquait.

## Correctif

Ajout d'un prédicat `actionPlacesItemInChest` symétrique à `actionBringsItemToInventory` :

```ts
function actionPlacesItemInChest(action: ChestAction): boolean {
	return action === HomeConstants.CHEST_ACTIONS.DEPOSIT || action === HomeConstants.CHEST_ACTIONS.SWAP;
}
```

L'appel à `MissionsController.update` reste après la libération des verrous `Player` + `Home`, comme avant (l'ordre des verrous ne change pas).

## Tests

`Core/__tests__-integration/handlers/chest-swap-mission.integration.test.ts` :

- un échange inventaire/coffre fait progresser `depositChestItem`
- un retrait ne la fait pas progresser (garde-fou contre une correction trop large)

Le premier test a été vérifié en échec sur le code d'origine avant application du correctif, puis en succès après.

Suites : `pnpm eslint` (0 erreur), `pnpm test` (1553 tests) et `pnpm test:integration` (55 tests) vertes.
