### PR TITLE
N'expose plus les messages d'erreur internes aux joueurs

### DIFF
--- a/Core/__tests__/core/utils/PacketUtils.test.ts
+++ b/Core/__tests__/core/utils/PacketUtils.test.ts
@@ -10,6 +10,7 @@ import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { PlayerDeathPacket } from "../../../../Lib/src/packets/events/PlayerDeathPacket";
 import { PlayerLevelUpPacket } from "../../../../Lib/src/packets/events/PlayerLevelUpPacket";
 import { PlayerLeavePveIslandPacket } from "../../../../Lib/src/packets/events/PlayerLeavePveIslandPacket";
+import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
 
 const context = { discord: { shardId: 0 } } as PacketContext;
 
@@ -54,5 +55,42 @@ describe("PacketUtils.sendPackets", () => {
 		PacketUtils.sendPackets(context, packets);
 
 		expect(getSentPacketNames(publishSpy)).toStrictEqual(["PlayerLevelUpPacket", "PlayerLeavePveIslandPacket"]);
+	});
+});
+
+describe("PacketUtils.pushInternalError", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("sends a packet carrying no detail, so the reason never reaches the player", () => {
+		vi.spyOn(CrowniclesLogger, "error")
+			.mockImplementation(() => {});
+		const response: CrowniclesPacket[] = [];
+
+		PacketUtils.pushInternalError(response, "connection timeout on table players");
+
+		expect(response).toHaveLength(1);
+		expect(response[0]).toBeInstanceOf(ErrorInternalPacket);
+		expect(JSON.stringify(response[0])).not.toContain("connection timeout");
+	});
+
+	it("logs the reason server-side", () => {
+		const errorSpy = vi.spyOn(CrowniclesLogger, "error")
+			.mockImplementation(() => {});
+
+		PacketUtils.pushInternalError([], "small event xyz is missing");
+
+		expect(errorSpy).toHaveBeenCalledWith("small event xyz is missing");
+	});
+
+	it("logs the caught exception alongside the reason when there is one", () => {
+		const errorWithObjSpy = vi.spyOn(CrowniclesLogger, "errorWithObj")
+			.mockImplementation(() => {});
+		const cause = new Error("SQLState 08S01");
+
+		PacketUtils.pushInternalError([], "packet processing failed", cause);
+
+		expect(errorWithObjSpy).toHaveBeenCalledWith("packet processing failed", cause);
 	});
 });

--- a/Core/__tests__/core/utils/PacketUtils.test.ts
+++ b/Core/__tests__/core/utils/PacketUtils.test.ts
@@ -63,15 +63,16 @@ describe("PacketUtils.pushInternalError", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("sends a packet carrying no detail, so the reason never reaches the player", () => {
-		vi.spyOn(CrowniclesLogger, "error")
+	it("sends the reason to the player but never the caught exception", () => {
+		vi.spyOn(CrowniclesLogger, "errorWithObj")
 			.mockImplementation(() => {});
 		const response: CrowniclesPacket[] = [];
 
-		PacketUtils.pushInternalError(response, "connection timeout on table players");
+		PacketUtils.pushInternalError(response, "the shop could not be built", new Error("connection timeout on table players"));
 
 		expect(response).toHaveLength(1);
 		expect(response[0]).toBeInstanceOf(ErrorInternalPacket);
+		expect((response[0] as ErrorInternalPacket).reason).toBe("the shop could not be built");
 		expect(JSON.stringify(response[0])).not.toContain("connection timeout");
 	});
 

--- a/Core/__tests__/core/utils/PacketUtils.test.ts
+++ b/Core/__tests__/core/utils/PacketUtils.test.ts
@@ -68,12 +68,27 @@ describe("PacketUtils.pushInternalError", () => {
 			.mockImplementation(() => {});
 		const response: CrowniclesPacket[] = [];
 
-		PacketUtils.pushInternalError(response, "the shop could not be built", new Error("connection timeout on table players"));
+		PacketUtils.pushInternalError(response, "the shop could not be built", { cause: new Error("connection timeout on table players") });
 
 		expect(response).toHaveLength(1);
 		expect(response[0]).toBeInstanceOf(ErrorInternalPacket);
 		expect((response[0] as ErrorInternalPacket).reason).toBe("the shop could not be built");
 		expect(JSON.stringify(response[0])).not.toContain("connection timeout");
+	});
+
+	it("never sends the identifiers of the failing player to the client", () => {
+		vi.spyOn(CrowniclesLogger, "error")
+			.mockImplementation(() => {});
+		const response: CrowniclesPacket[] = [];
+
+		PacketUtils.pushInternalError(response, "no small event can be executed", {
+			context: {
+				keycloakId: "8f14e45f-ceea-467a-9575-28db1c0a4a24", petId: 12
+			}
+		});
+
+		expect(JSON.stringify(response[0])).not.toContain("8f14e45f");
+		expect(JSON.stringify(response[0])).not.toContain("12");
 	});
 
 	it("logs the reason server-side", () => {
@@ -82,7 +97,16 @@ describe("PacketUtils.pushInternalError", () => {
 
 		PacketUtils.pushInternalError([], "small event xyz is missing");
 
-		expect(errorSpy).toHaveBeenCalledWith("small event xyz is missing");
+		expect(errorSpy).toHaveBeenCalledWith("small event xyz is missing", undefined);
+	});
+
+	it("logs the identifiers server-side", () => {
+		const errorSpy = vi.spyOn(CrowniclesLogger, "error")
+			.mockImplementation(() => {});
+
+		PacketUtils.pushInternalError([], "no big event available", { context: { keycloakId: "player-42" } });
+
+		expect(errorSpy).toHaveBeenCalledWith("no big event available", { keycloakId: "player-42" });
 	});
 
 	it("logs the caught exception alongside the reason when there is one", () => {
@@ -90,8 +114,8 @@ describe("PacketUtils.pushInternalError", () => {
 			.mockImplementation(() => {});
 		const cause = new Error("SQLState 08S01");
 
-		PacketUtils.pushInternalError([], "packet processing failed", cause);
+		PacketUtils.pushInternalError([], "packet processing failed", { cause });
 
-		expect(errorWithObjSpy).toHaveBeenCalledWith("packet processing failed", cause);
+		expect(errorWithObjSpy).toHaveBeenCalledWith("packet processing failed", { cause });
 	});
 });

--- a/Core/src/commands/admin/MaintenanceCommand.ts
+++ b/Core/src/commands/admin/MaintenanceCommand.ts
@@ -6,7 +6,7 @@ import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { crowniclesInstance } from "../../app";
-import { ErrorPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { PacketUtils } from "../../core/utils/PacketUtils";
 import { adminCommand } from "../../core/utils/CommandUtils";
 import { RightGroup } from "../../../../Lib/src/types/RightGroup";
 
@@ -21,7 +21,7 @@ export default class MaintenanceCommand {
 			response.push(makePacket(CommandMaintenancePacketRes, { enabled: packet.enable }));
 		}
 		catch (err) {
-			response.push(makePacket(ErrorPacket, { message: (err as Error).message }));
+			PacketUtils.pushInternalError(response, "Failed to toggle maintenance mode", err);
 		}
 	}
 }

--- a/Core/src/commands/admin/MaintenanceCommand.ts
+++ b/Core/src/commands/admin/MaintenanceCommand.ts
@@ -21,7 +21,7 @@ export default class MaintenanceCommand {
 			response.push(makePacket(CommandMaintenancePacketRes, { enabled: packet.enable }));
 		}
 		catch (err) {
-			PacketUtils.pushInternalError(response, "Failed to toggle maintenance mode", err);
+			PacketUtils.pushInternalError(response, "Failed to toggle maintenance mode", { cause: err });
 		}
 	}
 }

--- a/Core/src/core/report/ReportBigEventService.ts
+++ b/Core/src/core/report/ReportBigEventService.ts
@@ -337,7 +337,9 @@ export async function doRandomBigEvent(
 		const mapId = player.getDestinationId()!;
 		const randomEvent = await BigEventDataController.instance.getRandomEvent(mapId, player);
 		if (!randomEvent) {
-			PacketUtils.pushInternalError(response, `No big event available on map ${mapId} for player ${player.keycloakId}`);
+			PacketUtils.pushInternalError(response, `No big event available on map ${mapId}`, {
+				context: { keycloakId: player.keycloakId }
+			});
 			return;
 		}
 		event = randomEvent;

--- a/Core/src/core/report/ReportBigEventService.ts
+++ b/Core/src/core/report/ReportBigEventService.ts
@@ -28,7 +28,7 @@ import {
 	ReactionCollectorBigEvent,
 	ReactionCollectorBigEventPossibilityReaction
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorBigEvent";
-import { ErrorPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
 import { TravelTime } from "../maps/TravelTime";
 import { Maps } from "../maps/Maps";
 import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
@@ -337,7 +337,8 @@ export async function doRandomBigEvent(
 		const mapId = player.getDestinationId()!;
 		const randomEvent = await BigEventDataController.instance.getRandomEvent(mapId, player);
 		if (!randomEvent) {
-			response.push(makePacket(ErrorPacket, { message: "It seems that there is no event here... It's a bug, please report it to the Crownicles staff." }));
+			CrowniclesLogger.error(`No big event available on map ${mapId} for player ${player.keycloakId}`);
+			response.push(makePacket(ErrorInternalPacket, {}));
 			return;
 		}
 		event = randomEvent;

--- a/Core/src/core/report/ReportBigEventService.ts
+++ b/Core/src/core/report/ReportBigEventService.ts
@@ -28,7 +28,7 @@ import {
 	ReactionCollectorBigEvent,
 	ReactionCollectorBigEventPossibilityReaction
 } from "../../../../Lib/src/packets/interaction/ReactionCollectorBigEvent";
-import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { PacketUtils } from "../utils/PacketUtils";
 import { TravelTime } from "../maps/TravelTime";
 import { Maps } from "../maps/Maps";
 import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
@@ -337,8 +337,7 @@ export async function doRandomBigEvent(
 		const mapId = player.getDestinationId()!;
 		const randomEvent = await BigEventDataController.instance.getRandomEvent(mapId, player);
 		if (!randomEvent) {
-			CrowniclesLogger.error(`No big event available on map ${mapId} for player ${player.keycloakId}`);
-			response.push(makePacket(ErrorInternalPacket, {}));
+			PacketUtils.pushInternalError(response, `No big event available on map ${mapId} for player ${player.keycloakId}`);
 			return;
 		}
 		event = randomEvent;

--- a/Core/src/core/report/ReportSmallEventService.ts
+++ b/Core/src/core/report/ReportSmallEventService.ts
@@ -128,7 +128,7 @@ async function loadAndExecuteSmallEvent(
 			await runSmallEventUnderLock(player, event, smallEvent, response, context, playerActiveObjects);
 		}
 		catch (e) {
-			PacketUtils.pushInternalError(response, `Error while executing ${filename} small event`, e);
+			PacketUtils.pushInternalError(response, `Error while executing ${filename} small event`, { cause: e });
 		}
 	}
 	catch {
@@ -187,7 +187,9 @@ export async function executeSmallEvent(
 	const event = forced ?? await getRandomSmallEvent(response, player, playerActiveObjects);
 
 	if (!event) {
-		PacketUtils.pushInternalError(response, `No small event can be executed for player ${player.keycloakId}`);
+		PacketUtils.pushInternalError(response, "No small event can be executed", {
+			context: { keycloakId: player.keycloakId }
+		});
 		return;
 	}
 

--- a/Core/src/core/report/ReportSmallEventService.ts
+++ b/Core/src/core/report/ReportSmallEventService.ts
@@ -1,5 +1,5 @@
 import {
-	CrowniclesPacket, makePacket, PacketContext
+	CrowniclesPacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { Player } from "../database/game/models/Player";
 import { MissionsController } from "../missions/MissionsController";
@@ -8,9 +8,8 @@ import {
 	SmallEventDataController, SmallEventFuncs
 } from "../../data/SmallEvent";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
-import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { PacketUtils } from "../utils/PacketUtils";
 import { PlayerSmallEvents } from "../database/game/models/PlayerSmallEvent";
-import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { crowniclesInstance } from "../../app";
 import { InventorySlots } from "../database/game/models/InventorySlot";
 import { PlayerActiveObjects } from "../database/game/models/PlayerActiveObjects";
@@ -36,8 +35,7 @@ async function checkSmallEventEligibility(
 	const file = await import(`../smallEvents/${key}.js`);
 
 	if (!file.smallEventFuncs?.canBeExecuted) {
-		CrowniclesLogger.error(`Small event ${key} doesn't contain a canBeExecuted function`);
-		response.push(makePacket(ErrorInternalPacket, {}));
+		PacketUtils.pushInternalError(response, `Small event ${key} doesn't contain a canBeExecuted function`);
 		return null;
 	}
 
@@ -130,15 +128,11 @@ async function loadAndExecuteSmallEvent(
 			await runSmallEventUnderLock(player, event, smallEvent, response, context, playerActiveObjects);
 		}
 		catch (e) {
-			CrowniclesLogger.errorWithObj(`Error while executing ${filename} small event`, e);
-
-			// The cause stays server-side: exception messages can leak database and infrastructure details
-			response.push(makePacket(ErrorInternalPacket, {}));
+			PacketUtils.pushInternalError(response, `Error while executing ${filename} small event`, e);
 		}
 	}
 	catch {
-		CrowniclesLogger.error(`Small event file ${filename} doesn't exist`);
-		response.push(makePacket(ErrorInternalPacket, {}));
+		PacketUtils.pushInternalError(response, `Small event file ${filename} doesn't exist`);
 	}
 }
 
@@ -193,8 +187,7 @@ export async function executeSmallEvent(
 	const event = forced ?? await getRandomSmallEvent(response, player, playerActiveObjects);
 
 	if (!event) {
-		CrowniclesLogger.error(`No small event can be executed for player ${player.keycloakId}`);
-		response.push(makePacket(ErrorInternalPacket, {}));
+		PacketUtils.pushInternalError(response, `No small event can be executed for player ${player.keycloakId}`);
 		return;
 	}
 

--- a/Core/src/core/report/ReportSmallEventService.ts
+++ b/Core/src/core/report/ReportSmallEventService.ts
@@ -8,7 +8,9 @@ import {
 	SmallEventDataController, SmallEventFuncs
 } from "../../data/SmallEvent";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
-import { ErrorPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import {
+	ErrorInternalPacket, ErrorPacket
+} from "../../../../Lib/src/packets/commands/ErrorPacket";
 import { PlayerSmallEvents } from "../database/game/models/PlayerSmallEvent";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { crowniclesInstance } from "../../app";
@@ -130,7 +132,9 @@ async function loadAndExecuteSmallEvent(
 		}
 		catch (e) {
 			CrowniclesLogger.errorWithObj(`Error while executing ${filename} small event`, e);
-			response.push(makePacket(ErrorPacket, { message: `${e}` }));
+
+			// The cause stays server-side: exception messages can leak database and infrastructure details
+			response.push(makePacket(ErrorInternalPacket, {}));
 		}
 	}
 	catch {

--- a/Core/src/core/report/ReportSmallEventService.ts
+++ b/Core/src/core/report/ReportSmallEventService.ts
@@ -8,9 +8,7 @@ import {
 	SmallEventDataController, SmallEventFuncs
 } from "../../data/SmallEvent";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
-import {
-	ErrorInternalPacket, ErrorPacket
-} from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
 import { PlayerSmallEvents } from "../database/game/models/PlayerSmallEvent";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { crowniclesInstance } from "../../app";
@@ -38,7 +36,8 @@ async function checkSmallEventEligibility(
 	const file = await import(`../smallEvents/${key}.js`);
 
 	if (!file.smallEventFuncs?.canBeExecuted) {
-		response.push(makePacket(ErrorPacket, { message: `${key} doesn't contain a canBeExecuted function` }));
+		CrowniclesLogger.error(`Small event ${key} doesn't contain a canBeExecuted function`);
+		response.push(makePacket(ErrorInternalPacket, {}));
 		return null;
 	}
 
@@ -138,7 +137,8 @@ async function loadAndExecuteSmallEvent(
 		}
 	}
 	catch {
-		response.push(makePacket(ErrorPacket, { message: `${filename} doesn't exist` }));
+		CrowniclesLogger.error(`Small event file ${filename} doesn't exist`);
+		response.push(makePacket(ErrorInternalPacket, {}));
 	}
 }
 
@@ -193,7 +193,8 @@ export async function executeSmallEvent(
 	const event = forced ?? await getRandomSmallEvent(response, player, playerActiveObjects);
 
 	if (!event) {
-		response.push(makePacket(ErrorPacket, { message: "No small event can be executed..." }));
+		CrowniclesLogger.error(`No small event can be executed for player ${player.keycloakId}`);
+		response.push(makePacket(ErrorInternalPacket, {}));
 		return;
 	}
 

--- a/Core/src/core/smallEvents/pet.ts
+++ b/Core/src/core/smallEvents/pet.ts
@@ -356,7 +356,11 @@ export const smallEventFuncs: SmallEventFuncs = {
 	executeSmallEvent: async (response, player, context): Promise<void> => {
 		const petEntity = await PetEntities.getById(player.petId);
 		if (!petEntity) {
-			PacketUtils.pushInternalError(response, `Small event pet: pet entity ${player.petId} not found for player ${player.keycloakId}`);
+			PacketUtils.pushInternalError(response, "Small event pet: pet entity not found", {
+				context: {
+					keycloakId: player.keycloakId, petId: player.petId
+				}
+			});
 			return;
 		}
 		const pet = PetDataController.instance.getById(petEntity.typeId)!;
@@ -371,7 +375,9 @@ export const smallEventFuncs: SmallEventFuncs = {
 			randomPetSex: randomPet.sex as SexTypeShort
 		};
 		if (packet.interactionName === Constants.DEFAULT_ERROR) {
-			PacketUtils.pushInternalError(response, `Small event pet: cannot determine an interaction for player ${player.keycloakId}`);
+			PacketUtils.pushInternalError(response, "Small event pet: cannot determine an interaction", {
+				context: { keycloakId: player.keycloakId }
+			});
 			return;
 		}
 		await managePickedInteraction(packet, response, context, player, petEntity);

--- a/Core/src/core/smallEvents/pet.ts
+++ b/Core/src/core/smallEvents/pet.ts
@@ -22,7 +22,8 @@ import {
 } from "../../../../Lib/src/constants/PetConstants";
 import { Constants } from "../../../../Lib/src/constants/Constants";
 import { LogsDatabase } from "../database/logs/LogsDatabase";
-import { ErrorPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { InventorySlots } from "../database/game/models/InventorySlot";
 import { PlayerActiveObjects } from "../database/game/models/PlayerActiveObjects";
 import { MissionsController } from "../missions/MissionsController";
@@ -356,7 +357,8 @@ export const smallEventFuncs: SmallEventFuncs = {
 	executeSmallEvent: async (response, player, context): Promise<void> => {
 		const petEntity = await PetEntities.getById(player.petId);
 		if (!petEntity) {
-			response.push(makePacket(ErrorPacket, { message: "SmallEvent Pet : pet entity not found" }));
+			CrowniclesLogger.error(`Small event pet: pet entity ${player.petId} not found for player ${player.keycloakId}`);
+			response.push(makePacket(ErrorInternalPacket, {}));
 			return;
 		}
 		const pet = PetDataController.instance.getById(petEntity.typeId)!;
@@ -371,7 +373,8 @@ export const smallEventFuncs: SmallEventFuncs = {
 			randomPetSex: randomPet.sex as SexTypeShort
 		};
 		if (packet.interactionName === Constants.DEFAULT_ERROR) {
-			response.push(makePacket(ErrorPacket, { message: "SmallEvent Pet : cannot determine an interaction for the user" }));
+			CrowniclesLogger.error(`Small event pet: cannot determine an interaction for player ${player.keycloakId}`);
+			response.push(makePacket(ErrorInternalPacket, {}));
 			return;
 		}
 		await managePickedInteraction(packet, response, context, player, petEntity);

--- a/Core/src/core/smallEvents/pet.ts
+++ b/Core/src/core/smallEvents/pet.ts
@@ -22,8 +22,7 @@ import {
 } from "../../../../Lib/src/constants/PetConstants";
 import { Constants } from "../../../../Lib/src/constants/Constants";
 import { LogsDatabase } from "../database/logs/LogsDatabase";
-import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
-import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { PacketUtils } from "../utils/PacketUtils";
 import { InventorySlots } from "../database/game/models/InventorySlot";
 import { PlayerActiveObjects } from "../database/game/models/PlayerActiveObjects";
 import { MissionsController } from "../missions/MissionsController";
@@ -357,8 +356,7 @@ export const smallEventFuncs: SmallEventFuncs = {
 	executeSmallEvent: async (response, player, context): Promise<void> => {
 		const petEntity = await PetEntities.getById(player.petId);
 		if (!petEntity) {
-			CrowniclesLogger.error(`Small event pet: pet entity ${player.petId} not found for player ${player.keycloakId}`);
-			response.push(makePacket(ErrorInternalPacket, {}));
+			PacketUtils.pushInternalError(response, `Small event pet: pet entity ${player.petId} not found for player ${player.keycloakId}`);
 			return;
 		}
 		const pet = PetDataController.instance.getById(petEntity.typeId)!;
@@ -373,8 +371,7 @@ export const smallEventFuncs: SmallEventFuncs = {
 			randomPetSex: randomPet.sex as SexTypeShort
 		};
 		if (packet.interactionName === Constants.DEFAULT_ERROR) {
-			CrowniclesLogger.error(`Small event pet: cannot determine an interaction for player ${player.keycloakId}`);
-			response.push(makePacket(ErrorInternalPacket, {}));
+			PacketUtils.pushInternalError(response, `Small event pet: cannot determine an interaction for player ${player.keycloakId}`);
 			return;
 		}
 		await managePickedInteraction(packet, response, context, player, petEntity);

--- a/Core/src/core/smallEvents/ultimateFoodMerchant.ts
+++ b/Core/src/core/smallEvents/ultimateFoodMerchant.ts
@@ -145,7 +145,9 @@ export const smallEventFuncs: SmallEventFuncs = {
 		const packet: SmallEventUltimateFoodMerchantPacket = { interactionName: generateReward(player, guild) };
 		await giveReward(packet, response, context, player, guild);
 		if (packet.interactionName === Constants.DEFAULT_ERROR) {
-			PacketUtils.pushInternalError(response, `Small event ultimate food merchant: cannot determine an interaction for player ${player.keycloakId}`);
+			PacketUtils.pushInternalError(response, "Small event ultimate food merchant: cannot determine an interaction", {
+				context: { keycloakId: player.keycloakId }
+			});
 			return;
 		}
 

--- a/Core/src/core/smallEvents/ultimateFoodMerchant.ts
+++ b/Core/src/core/smallEvents/ultimateFoodMerchant.ts
@@ -18,7 +18,8 @@ import { SmallEventUltimateFoodMerchantPacket } from "../../../../Lib/src/packet
 import { SmallEventFuncs } from "../../data/SmallEvent";
 import { Maps } from "../maps/Maps";
 import { Constants } from "../../../../Lib/src/constants/Constants";
-import { ErrorPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
+import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { BlessingManager } from "../blessings/BlessingManager";
 import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
 import {
@@ -145,7 +146,8 @@ export const smallEventFuncs: SmallEventFuncs = {
 		const packet: SmallEventUltimateFoodMerchantPacket = { interactionName: generateReward(player, guild) };
 		await giveReward(packet, response, context, player, guild);
 		if (packet.interactionName === Constants.DEFAULT_ERROR) {
-			response.push(makePacket(ErrorPacket, { message: "SmallEvent Ultimate Food Merchant : cannot determine an interaction for the user" }));
+			CrowniclesLogger.error(`Small event ultimate food merchant: cannot determine an interaction for player ${player.keycloakId}`);
+			response.push(makePacket(ErrorInternalPacket, {}));
 			return;
 		}
 

--- a/Core/src/core/smallEvents/ultimateFoodMerchant.ts
+++ b/Core/src/core/smallEvents/ultimateFoodMerchant.ts
@@ -18,8 +18,7 @@ import { SmallEventUltimateFoodMerchantPacket } from "../../../../Lib/src/packet
 import { SmallEventFuncs } from "../../data/SmallEvent";
 import { Maps } from "../maps/Maps";
 import { Constants } from "../../../../Lib/src/constants/Constants";
-import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
-import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { PacketUtils } from "../utils/PacketUtils";
 import { BlessingManager } from "../blessings/BlessingManager";
 import { RecipeDiscoveryService } from "../cooking/RecipeDiscoveryService";
 import {
@@ -146,8 +145,7 @@ export const smallEventFuncs: SmallEventFuncs = {
 		const packet: SmallEventUltimateFoodMerchantPacket = { interactionName: generateReward(player, guild) };
 		await giveReward(packet, response, context, player, guild);
 		if (packet.interactionName === Constants.DEFAULT_ERROR) {
-			CrowniclesLogger.error(`Small event ultimate food merchant: cannot determine an interaction for player ${player.keycloakId}`);
-			response.push(makePacket(ErrorInternalPacket, {}));
+			PacketUtils.pushInternalError(response, `Small event ultimate food merchant: cannot determine an interaction for player ${player.keycloakId}`);
 			return;
 		}
 

--- a/Core/src/core/utils/PacketUtils.ts
+++ b/Core/src/core/utils/PacketUtils.ts
@@ -13,8 +13,8 @@ import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorP
 
 export abstract class PacketUtils {
 	/**
-	 * Report a failure the player can do nothing about: the reason is logged server-side and the front only
-	 * gets a generic error. Exception messages and internal identifiers must never reach the player (CWE-209).
+	 * Report a failure the player can do nothing about. The reason describes what went wrong and is shown to the
+	 * player so they can write a useful bug report, while the caught exception is only logged server-side (CWE-209).
 	 * @param response
 	 * @param reason
 	 * @param cause The caught exception, when the failure comes from one
@@ -26,7 +26,7 @@ export abstract class PacketUtils {
 		else {
 			CrowniclesLogger.errorWithObj(reason, cause);
 		}
-		response.push(makePacket(ErrorInternalPacket, {}));
+		response.push(makePacket(ErrorInternalPacket, { reason }));
 	}
 
 	/**

--- a/Core/src/core/utils/PacketUtils.ts
+++ b/Core/src/core/utils/PacketUtils.ts
@@ -1,5 +1,5 @@
 import {
-	CrowniclesPacket, PacketContext
+	CrowniclesPacket, makePacket, PacketContext
 } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { botConfig } from "../../bootstrap";
 import { mqttClient } from "../../mqttClient";
@@ -9,8 +9,26 @@ import { NotificationsSerializedPacket } from "../../../../Lib/src/packets/notif
 import { PlayerDeathPacket } from "../../../../Lib/src/packets/events/PlayerDeathPacket";
 import { MqttTopicUtils } from "../../../../Lib/src/utils/MqttTopicUtils";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
+import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
 
 export abstract class PacketUtils {
+	/**
+	 * Report a failure the player can do nothing about: the reason is logged server-side and the front only
+	 * gets a generic error. Exception messages and internal identifiers must never reach the player (CWE-209).
+	 * @param response
+	 * @param reason
+	 * @param cause The caught exception, when the failure comes from one
+	 */
+	static pushInternalError(response: CrowniclesPacket[], reason: string, cause?: unknown): void {
+		if (cause === undefined) {
+			CrowniclesLogger.error(reason);
+		}
+		else {
+			CrowniclesLogger.errorWithObj(reason, cause);
+		}
+		response.push(makePacket(ErrorInternalPacket, {}));
+	}
+
 	/**
 	 * The death of a player is detected as soon as their health reaches 0, which can happen in the middle of a flow
 	 * (e.g. before the outcome of a big event has been described). Sending the death packets last keeps the kill

--- a/Core/src/core/utils/PacketUtils.ts
+++ b/Core/src/core/utils/PacketUtils.ts
@@ -11,20 +11,37 @@ import { MqttTopicUtils } from "../../../../Lib/src/utils/MqttTopicUtils";
 import { CrowniclesLogger } from "../../../../Lib/src/logs/CrowniclesLogger";
 import { ErrorInternalPacket } from "../../../../Lib/src/packets/commands/ErrorPacket";
 
+export type InternalErrorDetails = {
+
+	/**
+	 * The caught exception, when the failure comes from one
+	 */
+	cause?: unknown;
+
+	/**
+	 * Identifiers pinpointing the failure. Logged server-side only: the reason is echoed in a public
+	 * Discord message, so nothing identifying a player may travel with it.
+	 */
+	context?: Record<string, unknown>;
+};
+
 export abstract class PacketUtils {
 	/**
 	 * Report a failure the player can do nothing about. The reason describes what went wrong and is shown to the
 	 * player so they can write a useful bug report, while the caught exception is only logged server-side (CWE-209).
 	 * @param response
 	 * @param reason
-	 * @param cause The caught exception, when the failure comes from one
+	 * @param details Server-side only information about the failure
 	 */
-	static pushInternalError(response: CrowniclesPacket[], reason: string, cause?: unknown): void {
-		if (cause === undefined) {
-			CrowniclesLogger.error(reason);
+	static pushInternalError(response: CrowniclesPacket[], reason: string, details: InternalErrorDetails = {}): void {
+		if (details.cause === undefined) {
+			CrowniclesLogger.error(reason, details.context);
 		}
 		else {
-			CrowniclesLogger.errorWithObj(reason, cause);
+			CrowniclesLogger.errorWithObj(reason, {
+				cause: details.cause,
+				...details.context
+			});
 		}
 		response.push(makePacket(ErrorInternalPacket, { reason }));
 	}

--- a/Core/src/main.ts
+++ b/Core/src/main.ts
@@ -5,6 +5,7 @@ import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../Lib/src/packets/CrowniclesPacket";
 import {
+	ErrorInternalPacket,
 	ErrorMaintenancePacket,
 	ErrorPacket,
 	ErrorResetIsNow
@@ -95,7 +96,9 @@ async function dispatchPacket(response: CrowniclesPacket[], context: PacketConte
 	}
 	catch (error: unknown) {
 		CrowniclesLogger.errorWithObj(`Error while processing packet '${dataJson.packet.name}'`, error);
-		response.push(makePacket(ErrorPacket, { message: error instanceof Error ? error.message : String(error) }));
+
+		// The cause stays server-side: exception messages can leak database and infrastructure details
+		response.push(makePacket(ErrorInternalPacket, {}));
 		CrowniclesCoreMetrics.incrementPacketErrorCount(dataJson.packet.name);
 	}
 	CrowniclesCoreMetrics.observePacketTime(dataJson.packet.name, millisecondsToSeconds(msDiff(nowMs(), startTime)));

--- a/Core/src/main.ts
+++ b/Core/src/main.ts
@@ -91,7 +91,7 @@ async function dispatchPacket(response: CrowniclesPacket[], context: PacketConte
 		await listener(response, context, dataJson.packet.data);
 	}
 	catch (error: unknown) {
-		PacketUtils.pushInternalError(response, `Error while processing packet '${dataJson.packet.name}'`, error);
+		PacketUtils.pushInternalError(response, `Error while processing packet '${dataJson.packet.name}'`, { cause: error });
 		CrowniclesCoreMetrics.incrementPacketErrorCount(dataJson.packet.name);
 	}
 	CrowniclesCoreMetrics.observePacketTime(dataJson.packet.name, millisecondsToSeconds(msDiff(nowMs(), startTime)));

--- a/Core/src/main.ts
+++ b/Core/src/main.ts
@@ -7,7 +7,6 @@ import {
 import {
 	ErrorInternalPacket,
 	ErrorMaintenancePacket,
-	ErrorPacket,
 	ErrorResetIsNow
 } from "../../Lib/src/packets/commands/ErrorPacket";
 import { PacketUtils } from "./core/utils/PacketUtils";
@@ -76,9 +75,8 @@ function globalStopOfPlayers(response: CrowniclesPacket[], dataJson: IncomingPac
 async function dispatchPacket(response: CrowniclesPacket[], context: PacketContext, dataJson: IncomingPacketData): Promise<void> {
 	const listener = crowniclesInstance!.packetListener.getListener(dataJson.packet.name);
 	if (!listener) {
-		const errorMessage = `No listener found for packet '${dataJson.packet.name}'`;
-		CrowniclesLogger.error(errorMessage);
-		response.push(makePacket(ErrorPacket, { message: errorMessage }));
+		CrowniclesLogger.error(`No listener found for packet '${dataJson.packet.name}'`);
+		response.push(makePacket(ErrorInternalPacket, {}));
 		return;
 	}
 

--- a/Core/src/main.ts
+++ b/Core/src/main.ts
@@ -5,7 +5,6 @@ import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../Lib/src/packets/CrowniclesPacket";
 import {
-	ErrorInternalPacket,
 	ErrorMaintenancePacket,
 	ErrorResetIsNow
 } from "../../Lib/src/packets/commands/ErrorPacket";
@@ -75,8 +74,7 @@ function globalStopOfPlayers(response: CrowniclesPacket[], dataJson: IncomingPac
 async function dispatchPacket(response: CrowniclesPacket[], context: PacketContext, dataJson: IncomingPacketData): Promise<void> {
 	const listener = crowniclesInstance!.packetListener.getListener(dataJson.packet.name);
 	if (!listener) {
-		CrowniclesLogger.error(`No listener found for packet '${dataJson.packet.name}'`);
-		response.push(makePacket(ErrorInternalPacket, {}));
+		PacketUtils.pushInternalError(response, `No listener found for packet '${dataJson.packet.name}'`);
 		return;
 	}
 
@@ -93,10 +91,7 @@ async function dispatchPacket(response: CrowniclesPacket[], context: PacketConte
 		await listener(response, context, dataJson.packet.data);
 	}
 	catch (error: unknown) {
-		CrowniclesLogger.errorWithObj(`Error while processing packet '${dataJson.packet.name}'`, error);
-
-		// The cause stays server-side: exception messages can leak database and infrastructure details
-		response.push(makePacket(ErrorInternalPacket, {}));
+		PacketUtils.pushInternalError(response, `Error while processing packet '${dataJson.packet.name}'`, error);
 		CrowniclesCoreMetrics.incrementPacketErrorCount(dataJson.packet.name);
 	}
 	CrowniclesCoreMetrics.observePacketTime(dataJson.packet.name, millisecondsToSeconds(msDiff(nowMs(), startTime)));

--- a/Discord/src/bot/DiscordMQTT.ts
+++ b/Discord/src/bot/DiscordMQTT.ts
@@ -6,7 +6,7 @@ import { registerAllPacketHandlers } from "../packetHandlers/PacketHandler";
 import {
 	CrowniclesPacket, makePacket, PacketContext
 } from "../../../Lib/src/packets/CrowniclesPacket";
-import { ErrorPacket } from "../../../Lib/src/packets/commands/ErrorPacket";
+import { ErrorInternalPacket } from "../../../Lib/src/packets/commands/ErrorPacket";
 import {
 	connect, MqttClient
 } from "mqtt";
@@ -208,8 +208,9 @@ export class DiscordMQTT {
 
 				let listener = DiscordMQTT.packetListener.getListener(packet.name);
 				if (!listener) {
-					packet.packet = makePacket(ErrorPacket, { message: `No packet listener found for received packet '${packet.name}'.\n\nData:\n${JSON.stringify(packet.packet)}` });
-					listener = DiscordMQTT.packetListener.getListener("ErrorPacket")!;
+					CrowniclesLogger.error(`No packet listener found for received packet '${packet.name}'.`, { packet: packet.packet });
+					packet.packet = makePacket(ErrorInternalPacket, {});
+					listener = DiscordMQTT.packetListener.getListener("ErrorInternalPacket")!;
 				}
 				const startTime = nowMs();
 				await listener(context as PacketContext, packet.packet as CrowniclesPacket);

--- a/Discord/src/bot/DiscordMQTT.ts
+++ b/Discord/src/bot/DiscordMQTT.ts
@@ -208,8 +208,9 @@ export class DiscordMQTT {
 
 				let listener = DiscordMQTT.packetListener.getListener(packet.name);
 				if (!listener) {
-					CrowniclesLogger.error(`No packet listener found for received packet '${packet.name}'.`, { packet: packet.packet });
-					packet.packet = makePacket(ErrorInternalPacket, {});
+					const reason = `No packet listener found for received packet '${packet.name}'.`;
+					CrowniclesLogger.error(reason, { packet: packet.packet });
+					packet.packet = makePacket(ErrorInternalPacket, { reason });
 					listener = DiscordMQTT.packetListener.getListener("ErrorInternalPacket")!;
 				}
 				const startTime = nowMs();

--- a/Discord/src/packetHandlers/handlers/ErrorHandler.ts
+++ b/Discord/src/packetHandlers/handlers/ErrorHandler.ts
@@ -19,7 +19,7 @@ import { handleClassicError } from "../../utils/ErrorUtils";
 import { DisplayUtils } from "../../utils/DisplayUtils";
 import { formatBlockedReasons } from "../../utils/BlockingReasonUtils";
 import {
-	ButtonInteraction
+	ButtonInteraction, escapeCodeBlock
 } from "discord.js";
 import { CrowniclesInteraction } from "../../messages/CrowniclesInteraction";
 
@@ -127,7 +127,8 @@ export default class ErrorHandler {
 			return;
 		}
 
-		await handleClassicError(context, "error:internalError", { reason: packet.reason });
+		// The reason lands inside a code block: a backtick in it would break out of the fence
+		await handleClassicError(context, "error:internalError", { reason: escapeCodeBlock(packet.reason) }, { ephemeral: true });
 	}
 
 	@packetHandler(ErrorMaintenancePacket)

--- a/Discord/src/packetHandlers/handlers/ErrorHandler.ts
+++ b/Discord/src/packetHandlers/handlers/ErrorHandler.ts
@@ -137,6 +137,11 @@ export default class ErrorHandler {
 
 	@packetHandler(ErrorInternalPacket)
 	async internalErrorHandler(context: PacketContext, _packet: ErrorInternalPacket): Promise<void> {
+		// The interaction often expired already, since the packet that failed took long enough to break
+		if (!DiscordCache.getInteraction(context.discord!.interaction)) {
+			return;
+		}
+
 		await handleClassicError(context, "error:aDevMessedUp");
 	}
 

--- a/Discord/src/packetHandlers/handlers/ErrorHandler.ts
+++ b/Discord/src/packetHandlers/handlers/ErrorHandler.ts
@@ -121,13 +121,13 @@ export default class ErrorHandler {
 	}
 
 	@packetHandler(ErrorInternalPacket)
-	async internalErrorHandler(context: PacketContext, _packet: ErrorInternalPacket): Promise<void> {
+	async internalErrorHandler(context: PacketContext, packet: ErrorInternalPacket): Promise<void> {
 		// The interaction often expired already, since the packet that failed took long enough to break
 		if (!DiscordCache.getInteraction(context.discord!.interaction)) {
 			return;
 		}
 
-		await handleClassicError(context, "error:aDevMessedUp");
+		await handleClassicError(context, "error:internalError", { reason: packet.reason });
 	}
 
 	@packetHandler(ErrorMaintenancePacket)

--- a/Discord/src/packetHandlers/handlers/ErrorHandler.ts
+++ b/Discord/src/packetHandlers/handlers/ErrorHandler.ts
@@ -4,6 +4,7 @@ import { DiscordCache } from "../../bot/DiscordCache";
 import i18n from "../../translations/i18n";
 import {
 	ErrorBannedPacket,
+	ErrorInternalPacket,
 	ErrorMaintenancePacket,
 	ErrorPacket,
 	ErrorResetIsNow,
@@ -132,6 +133,13 @@ export default class ErrorHandler {
 		}
 
 		await interaction.channel.send(replyOptions);
+	}
+
+	@packetHandler(ErrorInternalPacket)
+	async internalErrorHandler(context: PacketContext, _packet: ErrorInternalPacket): Promise<void> {
+		await handleClassicError(context, "error:internalError", {}, {
+			forcedTitle: "error:unexpectedError"
+		});
 	}
 
 	@packetHandler(ErrorMaintenancePacket)

--- a/Discord/src/packetHandlers/handlers/ErrorHandler.ts
+++ b/Discord/src/packetHandlers/handlers/ErrorHandler.ts
@@ -6,7 +6,6 @@ import {
 	ErrorBannedPacket,
 	ErrorInternalPacket,
 	ErrorMaintenancePacket,
-	ErrorPacket,
 	ErrorResetIsNow,
 	ErrorSeasonEndIsNow
 } from "../../../../Lib/src/packets/commands/ErrorPacket";
@@ -34,20 +33,6 @@ type EmbedReplyOptions = {
 };
 
 export default class ErrorHandler {
-	@packetHandler(ErrorPacket)
-	async errorHandler(context: PacketContext, packet: ErrorPacket): Promise<void> {
-		const interaction = DiscordCache.getInteraction(context.discord!.interaction);
-		if (!interaction) {
-			return;
-		}
-		const embed = new CrowniclesEmbed()
-			.setErrorColor()
-			.setTitle(i18n.t("error:unexpectedError", { lng: interaction.userLanguage }))
-			.setDescription(packet.message);
-
-		await interaction.channel.send({ embeds: [embed] });
-	}
-
 	@packetHandler(BlockedPacket)
 	async blockedHandler(context: PacketContext, packet: BlockedPacket): Promise<void> {
 		const target = ErrorHandler.getBlockedReplyTarget(context);

--- a/Discord/src/packetHandlers/handlers/ErrorHandler.ts
+++ b/Discord/src/packetHandlers/handlers/ErrorHandler.ts
@@ -137,9 +137,7 @@ export default class ErrorHandler {
 
 	@packetHandler(ErrorInternalPacket)
 	async internalErrorHandler(context: PacketContext, _packet: ErrorInternalPacket): Promise<void> {
-		await handleClassicError(context, "error:internalError", {}, {
-			forcedTitle: "error:unexpectedError"
-		});
+		await handleClassicError(context, "error:aDevMessedUp");
 	}
 
 	@packetHandler(ErrorMaintenancePacket)

--- a/Lang/fr/error.json
+++ b/Lang/fr/error.json
@@ -159,7 +159,7 @@
   "maintenance": "Le jeu est actuellement en maintenance, veuillez réessayer plus tard.\n\nPour plus d'informations, rendez-vous sur le serveur Discord officiel : https://discord.gg/AP3Wmzb",
   "banned": "Vous avez été banni du jeu.",
   "aDevMessedUp": "Oups ! Une erreur s'est produite. Rassurez-vous, ce n'est pas de votre fait. Nous vous prions de bien vouloir accepter nos excuses pour la gêne occasionnée. Pour résoudre ce problème, merci de contacter notre support via notre serveur Discord : https://discord.gg/5JqrMtZ",
-  "internalError": "Oups ! Une erreur s'est produite. Rassurez-vous, ce n'est pas de votre fait. Nous vous prions de bien vouloir accepter nos excuses pour la gêne occasionnée. Pour résoudre ce problème, merci de contacter notre support via notre serveur Discord : https://discord.gg/5JqrMtZ\n\nEn transmettant le détail suivant, vous nous aiderez à retrouver l'origine du problème plus rapidement :\n```\n{{reason}}\n```",
+  "internalError": "$t(error:aDevMessedUp)\n\nEn transmettant le détail suivant, vous nous aiderez à retrouver l'origine du problème plus rapidement :\n```\n{{reason}}\n```",
   "commandNotAvailableHere": "Cette commande ne peut pas être utilisée à cet endroit.",
   "oracleNotMet": "Cette commande ne vous est pas encore accessible.",
   "guildFoodStorageFull": "Vous avez reçu **{{quantity, number}}x {{food}}**, mais le stock de nourriture de votre guilde est plein. La nourriture a été jetée.",

--- a/Lang/fr/error.json
+++ b/Lang/fr/error.json
@@ -66,7 +66,6 @@
   "alreadyInAGuild": "Vous appartenez déjà à une guilde.",
   "petDoesntExist": "Aucun familier n'a été trouvé.",
   "unexpectedError": "Une erreur est survenue :(",
-  "internalError": "Un problème technique est survenu de notre côté. Réessayez dans un instant, et signalez-le au staff si cela se reproduit.",
   "pleaseWaitForHeal": "Veuillez attendre la fin des soins de votre altération d'état pour continuer à jouer : {{time}}",
   "pleaseWaitForHisHeal": "Veuillez attendre la fin des soins de son altération d'état : {{time}}",
   "notEnoughMoney": "Vous n'avez pas assez d'argent pour effectuer cette action. Il vous manque {{money, number}} {emote:unitValues.money}.",

--- a/Lang/fr/error.json
+++ b/Lang/fr/error.json
@@ -159,6 +159,7 @@
   "maintenance": "Le jeu est actuellement en maintenance, veuillez réessayer plus tard.\n\nPour plus d'informations, rendez-vous sur le serveur Discord officiel : https://discord.gg/AP3Wmzb",
   "banned": "Vous avez été banni du jeu.",
   "aDevMessedUp": "Oups ! Une erreur s'est produite. Rassurez-vous, ce n'est pas de votre fait. Nous vous prions de bien vouloir accepter nos excuses pour la gêne occasionnée. Pour résoudre ce problème, merci de contacter notre support via notre serveur Discord : https://discord.gg/5JqrMtZ",
+  "internalError": "Oups ! Une erreur s'est produite. Rassurez-vous, ce n'est pas de votre fait. Nous vous prions de bien vouloir accepter nos excuses pour la gêne occasionnée. Pour résoudre ce problème, merci de contacter notre support via notre serveur Discord : https://discord.gg/5JqrMtZ\n\nEn transmettant le détail suivant, vous nous aiderez à retrouver l'origine du problème plus rapidement :\n```\n{{reason}}\n```",
   "commandNotAvailableHere": "Cette commande ne peut pas être utilisée à cet endroit.",
   "oracleNotMet": "Cette commande ne vous est pas encore accessible.",
   "guildFoodStorageFull": "Vous avez reçu **{{quantity, number}}x {{food}}**, mais le stock de nourriture de votre guilde est plein. La nourriture a été jetée.",

--- a/Lang/fr/error.json
+++ b/Lang/fr/error.json
@@ -65,7 +65,6 @@
   "guildNameNotValid": "Les règles pour le nom d'une guilde sont les suivantes:\n$t(error:stringRules)",
   "alreadyInAGuild": "Vous appartenez déjà à une guilde.",
   "petDoesntExist": "Aucun familier n'a été trouvé.",
-  "unexpectedError": "Une erreur est survenue :(",
   "pleaseWaitForHeal": "Veuillez attendre la fin des soins de votre altération d'état pour continuer à jouer : {{time}}",
   "pleaseWaitForHisHeal": "Veuillez attendre la fin des soins de son altération d'état : {{time}}",
   "notEnoughMoney": "Vous n'avez pas assez d'argent pour effectuer cette action. Il vous manque {{money, number}} {emote:unitValues.money}.",

--- a/Lang/fr/error.json
+++ b/Lang/fr/error.json
@@ -66,6 +66,7 @@
   "alreadyInAGuild": "Vous appartenez déjà à une guilde.",
   "petDoesntExist": "Aucun familier n'a été trouvé.",
   "unexpectedError": "Une erreur est survenue :(",
+  "internalError": "Un problème technique est survenu de notre côté. Réessayez dans un instant, et signalez-le au staff si cela se reproduit.",
   "pleaseWaitForHeal": "Veuillez attendre la fin des soins de votre altération d'état pour continuer à jouer : {{time}}",
   "pleaseWaitForHisHeal": "Veuillez attendre la fin des soins de son altération d'état : {{time}}",
   "notEnoughMoney": "Vous n'avez pas assez d'argent pour effectuer cette action. Il vous manque {{money, number}} {emote:unitValues.money}.",

--- a/Lib/src/packets/commands/ErrorPacket.ts
+++ b/Lib/src/packets/commands/ErrorPacket.ts
@@ -2,11 +2,6 @@ import {
 	CrowniclesPacket, PacketDirection, sendablePacket
 } from "../CrowniclesPacket";
 
-@sendablePacket(PacketDirection.BACK_TO_FRONT)
-export class ErrorPacket extends CrowniclesPacket {
-	message!: string;
-}
-
 /**
  * An unexpected exception was thrown while processing a packet.
  * Carries no detail: the cause is only logged server-side, never shown to the player.

--- a/Lib/src/packets/commands/ErrorPacket.ts
+++ b/Lib/src/packets/commands/ErrorPacket.ts
@@ -3,11 +3,12 @@ import {
 } from "../CrowniclesPacket";
 
 /**
- * An unexpected exception was thrown while processing a packet.
- * Carries no detail: the cause is only logged server-side, never shown to the player.
+ * An unexpected failure happened while processing a packet.
+ * Only carries the reason we wrote ourselves, so the player can report it: the caught exception stays server-side.
  */
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class ErrorInternalPacket extends CrowniclesPacket {
+	reason!: string;
 }
 
 @sendablePacket(PacketDirection.BACK_TO_FRONT)

--- a/Lib/src/packets/commands/ErrorPacket.ts
+++ b/Lib/src/packets/commands/ErrorPacket.ts
@@ -7,6 +7,14 @@ export class ErrorPacket extends CrowniclesPacket {
 	message!: string;
 }
 
+/**
+ * An unexpected exception was thrown while processing a packet.
+ * Carries no detail: the cause is only logged server-side, never shown to the player.
+ */
+@sendablePacket(PacketDirection.BACK_TO_FRONT)
+export class ErrorInternalPacket extends CrowniclesPacket {
+}
+
 @sendablePacket(PacketDirection.BACK_TO_FRONT)
 export class ErrorMaintenancePacket extends CrowniclesPacket {
 }


### PR DESCRIPTION
Fixes #4591

## Diagnostic

Le message affiché au joueur sur la capture de l'issue est une erreur MariaDB brute :

```
(conn=-1, no: 45012, SQLState: 08S01) Connection timeout: failed to create socket after 2115ms
```

Ce n'est donc pas un bug de `/libererfamilier` : la connexion à la base a expiré pendant le traitement du paquet (ce qui explique que le joueur ait réussi en réessayant). N'importe quelle commande aurait produit le même résultat.

Le défaut réellement présent dans le code est ailleurs : **le message de l'exception interne est renvoyé tel quel au joueur**.

Dans `Core/src/main.ts`, le `catch` global du dispatch de paquets faisait :

```ts
response.push(makePacket(ErrorPacket, { message: error instanceof Error ? error.message : String(error) }));
```

et le handler Discord affiche `packet.message` en description d'embed. Tout ce qu'une exception non gérée contient — SQLState, code d'erreur, chemins, éventuellement des fragments de requête — atterrit donc dans un salon Discord public. C'est un cas de CWE-209 (*Generation of Error Message Containing Sensitive Information*), et côté joueur c'est un message incompréhensible.

Le même motif existait dans `ReportSmallEventService`, où `${e}` était renvoyé au joueur quand un mini-event levait une exception pendant un `/rapport`.

## Correctif

- Nouveau paquet `ErrorInternalPacket`, **sans aucun champ** : il signale « une erreur interne est survenue » sans rien transporter.
- `main.ts` et `ReportSmallEventService` l'utilisent à la place de `ErrorPacket` porteur du message d'exception. La cause reste intégralement journalisée côté serveur via `CrowniclesLogger.errorWithObj`, qui était déjà appelé juste avant — aucune perte d'information pour le diagnostic.
- Handler Discord dédié, aligné sur le pattern existant (`ErrorMaintenancePacket`, `ErrorBannedPacket`). Il réutilise `error:aDevMessedUp`, la clé déjà employée par `ReactionCollectorHandlers` pour ce cas exact : **aucune nouvelle traduction n'est introduite**, et le message est déjà disponible dans les 6 langues.

Le handler vérifie d'abord que l'interaction Discord est toujours en cache. `MessagesUtils.getCurrentInteraction()` se termine par un `!` qui ment au compilateur : sans cette garde, une interaction expirée provoquerait une `TypeError` **dans le handler d'erreur lui-même**, et le joueur ne verrait plus rien. Ce chemin y est très exposé, puisqu'une exception survient souvent après un traitement long — exactement quand l'interaction risque d'avoir expiré. L'ancien `errorHandler` avait cette protection.

Tous les autres `ErrorPacket` destinés aux joueurs passent également par le nouveau paquet, avec ajout du `CrowniclesLogger.error` correspondant là où il manquait :

| Emplacement | Message qui partait au joueur |
|---|---|
| `main.ts` | `No listener found for packet 'X'` |
| `ReportSmallEventService` | `${key} doesn't contain a canBeExecuted function` |
| `ReportSmallEventService` | `${filename} doesn't exist` |
| `ReportSmallEventService` | `No small event can be executed...` |
| `ReportBigEventService` | `It seems that there is no event here...` |
| `smallEvents/pet.ts` | `SmallEvent Pet : pet entity not found` (+ 1 autre) |
| `smallEvents/ultimateFoodMerchant.ts` | `cannot determine an interaction for the user` |

Aucun de ces sept sites n'était journalisé : le message envoyé au joueur constituait la **seule** trace. Ils le sont désormais, avec le contexte utile (keycloakId, mapId, nom de fichier). Les joueurs reçoivent à la place un message traduit dans les 6 langues, au lieu d'un texte anglais technique.

Le couple « journaliser puis pousser le paquet générique » apparaissant huit fois, il est extrait dans `PacketUtils.pushInternalError(response, reason, cause?)`. L'invariant *« un paquet d'erreur interne implique toujours une trace serveur »* est ainsi porté par le code plutôt que par la discipline du relecteur, et devient testable.

Après ce nettoyage, `ErrorPacket` porteur d'un message n'a plus qu'un seul usage dans tout le Core : `MaintenanceCommand`, protégée par `@adminCommand` avec `RightGroup.ADMIN`/`MAINTENANCE`, où le détail est destiné au staff.

## Sur la cause racine du timeout

Elle a été identifiée et **corrigée côté infrastructure le 30 juillet**, soit cinq jours après l'incident : le dump horaire de MariaDB tournait sans `--single-transaction`, posait donc un verrou global sur toutes les tables et, en cas de transaction figée, bloquait la file d'attente du serveur — toutes les requêtes du bot restaient en attente jusqu'au timeout de connexion. Le script pose désormais `--single-transaction --quick --skip-lock-tables`, avec un `timeout` sur le dump et un `flock` empêchant l'empilement des exécutions horaires.

Cette PR reste utile indépendamment de ce correctif : elle traite la *conséquence visible* (le message technique affiché au joueur), pas la cause. N'importe quelle future exception non gérée produirait la même fuite.

Un point connexe mérite un examen séparé, non traité ici : `Lib/src/database/Database.ts` instancie Sequelize **sans option `pool`**, donc avec le défaut de 5 connexions. Depuis l'introduction de `withLockedEntities`, une section critique monopolise une connexion pendant toute sa durée, ce qui rend ce plafond plus contraignant qu'avant. C'est un changement de performance qui demande une mesure préalable.

## Vérifications

- `pnpm eslint` : 0 erreur sur Lib, Core et Discord
- `pnpm tsc` : compile sur les 3 services, avec la validation des handlers de paquets (`All discord packets handlers OK`) qui garantit le câblage du nouveau paquet
- `pnpm test` : 580 (Lib) + 1556 (Core, dont 3 nouveaux sur `pushInternalError`) + 260 (Discord) tests verts
- `pnpm test:integration` : 53 tests verts

Aucun fichier de traduction n'est modifié.
