### PR TITLE
Gère l'échec d'envoi du message d'erreur dans un channel inaccessible

### DIFF
--- a/Discord/src/bot/DiscordMQTT.ts
+++ b/Discord/src/bot/DiscordMQTT.ts
@@ -15,7 +15,6 @@ import { DiscordAnnouncement } from "../announcements/DiscordAnnouncement";
 import { NotificationsHandler } from "../notifications/NotificationsHandler";
 import { NotificationsSerializedPacket } from "../../../Lib/src/packets/notifications/NotificationsSerializedPacket";
 import { LANGUAGE } from "../../../Lib/src/Language";
-import { TextChannel } from "discord.js";
 import { CrowniclesEmbed } from "../messages/CrowniclesEmbed";
 import i18n from "../translations/i18n";
 import { MqttTopicUtils } from "../../../Lib/src/utils/MqttTopicUtils";
@@ -235,7 +234,7 @@ export class DiscordMQTT {
 		const lng = context.discord.language ?? LANGUAGE.ENGLISH;
 		try {
 			const channel = await crowniclesClient.channels.fetch(context.discord.channel);
-			if (channel instanceof TextChannel) {
+			if (channel?.isTextBased() && channel.isSendable()) {
 				await channel.send({ embeds: [
 					new CrowniclesEmbed()
 						.setErrorColor()

--- a/Discord/src/bot/DiscordMQTT.ts
+++ b/Discord/src/bot/DiscordMQTT.ts
@@ -219,20 +219,33 @@ export class DiscordMQTT {
 				CrowniclesLogger.errorWithObj("Error while handling packet", error);
 				CrowniclesDiscordMetrics.incrementPacketErrorCount(packet.name);
 
-				const context = dataJson.context as PacketContext;
-				const lng = context.discord?.language ?? LANGUAGE.ENGLISH;
-				if (context.discord?.channel) {
-					const channel = await crowniclesClient.channels.fetch(context.discord.channel);
-					if (channel instanceof TextChannel) {
-						await channel.send({ embeds: [
-							new CrowniclesEmbed()
-								.setErrorColor()
-								.setTitle(i18n.t("error:errorOccurredTitle", { lng }))
-								.setDescription(i18n.t("error:errorOccurred", { lng }))
-						] });
-					}
-				}
+				await DiscordMQTT.notifyErrorInChannel(context);
 			}
+		}
+	}
+
+	/**
+	 * Warn the player in the channel where the command was launched that an error occurred
+	 * @param context
+	 */
+	private static async notifyErrorInChannel(context: PacketContext): Promise<void> {
+		if (!context.discord?.channel) {
+			return;
+		}
+		const lng = context.discord.language ?? LANGUAGE.ENGLISH;
+		try {
+			const channel = await crowniclesClient.channels.fetch(context.discord.channel);
+			if (channel instanceof TextChannel) {
+				await channel.send({ embeds: [
+					new CrowniclesEmbed()
+						.setErrorColor()
+						.setTitle(i18n.t("error:errorOccurredTitle", { lng }))
+						.setDescription(i18n.t("error:errorOccurred", { lng }))
+				] });
+			}
+		}
+		catch (error) {
+			CrowniclesLogger.errorWithObj(`Unable to send the error message in channel ${context.discord.channel}`, error);
 		}
 	}
 


### PR DESCRIPTION
## Contexte

Discord va bientôt appliquer l'obfuscation des channels aux bots : les channels sur lesquels le bot n'a pas `VIEW_CHANNEL` continueront d'être dispatchés par la Gateway (donc mis en cache par discord.js), mais avec des données caviardées.

Après audit, le code ne parcourt jamais la liste des channels d'un serveur et n'appelle jamais `GET /guilds/{id}/channels` : **aucun changement n'est requis pour se conformer**. Le seul point fragile identifié est ci-dessous.

## Problème

Dans le gestionnaire d'erreur de `handleMqttMessage`, on récupère le channel de la commande puis on y envoie l'embed d'erreur sans aucune protection :

- `channels.fetch()` peut lever (403 / 404) si le bot a perdu l'accès au channel ;
- `channel.send()` peut lever pour les mêmes raisons.

Comme on est déjà dans un `catch`, l'exception remonte en rejet non géré. Le bug est préexistant, mais il devient plus probable avec l'obfuscation : le channel restera présent en cache côté discord.js, donc le `fetch` réussira depuis le cache et c'est le `send` qui échouera.

## Changement

- Extraction de la notification d'erreur dans `DiscordMQTT.notifyErrorInChannel(context)` ;
- `fetch` + `send` encapsulés dans un `try/catch` qui log l'échec au lieu de le propager ;
- suppression au passage de la redéclaration locale de `context` qui masquait celle de la boucle.

Aucun changement de comportement quand le bot a bien accès au channel.

## Tests

- `pnpm eslint` : OK
- `pnpm test` (Discord) : 260 tests passés
