### PR TITLE
Fiabilise le calcul des alliés PVE lors de l'attaque de guilde

### DIFF
--- a/Core/src/core/database/logs/LogsReadRequests.ts
+++ b/Core/src/core/database/logs/LogsReadRequests.ts
@@ -192,14 +192,14 @@ export class LogsReadRequests {
 
 		const leaveTravels = await getPveIslandLeaveDates(logsPlayers.map(logsPlayer => logsPlayer.id));
 		const oldestAcceptedLeaveDate = dateToLogs(new Date(Date.now() - PVEConstants.TIME_CHECKED_FOR_PLAYERS_THAT_WERE_ON_THE_ISLAND));
-		const recentlyLeftLogsPlayerIds = leaveTravels
+		const recentlyLeftLogsPlayerIds = new Set(leaveTravels
 			.filter(travel => travel.leaveDate > oldestAcceptedLeaveDate)
-			.map(travel => travel.playerId);
-		const recentlyLeftKeycloakIds = logsPlayers
-			.filter(logsPlayer => recentlyLeftLogsPlayerIds.includes(logsPlayer.id))
-			.map(logsPlayer => logsPlayer.keycloakId);
+			.map(travel => travel.playerId));
+		const recentlyLeftKeycloakIds = new Set(logsPlayers
+			.filter(logsPlayer => recentlyLeftLogsPlayerIds.has(logsPlayer.id))
+			.map(logsPlayer => logsPlayer.keycloakId));
 
-		return playersInGuild.filter(guildMember => recentlyLeftKeycloakIds.includes(guildMember.keycloakId));
+		return playersInGuild.filter(guildMember => recentlyLeftKeycloakIds.has(guildMember.keycloakId));
 	}
 
 	/**

--- a/Core/src/core/fights/actions/interfaces/players/guildAttack.ts
+++ b/Core/src/core/fights/actions/interfaces/players/guildAttack.ts
@@ -34,9 +34,11 @@ function getAttackInfo(): attackInfo {
 function getStatsInfo(sender: Fighter, receiver: Fighter): statsInfo {
 	let cumulatedAttack = sender.getAttack();
 	let cumulatedSpeed = sender.getSpeed();
-	for (const member of (sender as PlayerFighter).getPveMembersOnIsland()) {
-		cumulatedAttack += member.attack;
-		cumulatedSpeed += member.speed;
+	if (sender instanceof PlayerFighter) {
+		for (const member of sender.getPveMembersOnIsland()) {
+			cumulatedAttack += member.attack;
+			cumulatedSpeed += member.speed;
+		}
 	}
 
 	return {

--- a/Core/src/core/fights/fighter/PlayerFighter.ts
+++ b/Core/src/core/fights/fighter/PlayerFighter.ts
@@ -24,14 +24,18 @@ import { PetConstants } from "../../../../../Lib/src/constants/PetConstants";
 import { PetUtils } from "../../utils/PetUtils";
 import { ItemConstants } from "../../../../../Lib/src/constants/ItemConstants";
 
+export type PveMemberStats = {
+	attack: number; speed: number;
+};
+
 /**
  * Fighter
  * Class representing a human-controlled player in a fight
  */
 export class PlayerFighter extends PlayerBaseFighter {
-	protected pveMembers!: {
-		attack: number; speed: number;
-	}[];
+	protected pveMembers: PveMemberStats[] = [];
+
+	protected pveMembersLoaded = false;
 
 	protected petAssisted: boolean;
 
@@ -158,9 +162,9 @@ export class PlayerFighter extends PlayerBaseFighter {
 
 		// Add guild attack if on PVE island and members are here
 		if (Maps.isOnPveIsland(this.player)) {
-			if (!this.pveMembers) {
+			if (!this.pveMembersLoaded) {
+				this.pveMembersLoaded = true;
 				const members = await Maps.getGuildMembersOnPveIsland(this.player);
-				this.pveMembers = [];
 				for (const member of members) {
 					const memberActiveObjects = await InventorySlots.getMainSlotsItems(member.id);
 					this.pveMembers.push({
@@ -180,9 +184,7 @@ export class PlayerFighter extends PlayerBaseFighter {
 	/**
 	 * Get the members of the player's guild on the island of the fighter
 	 */
-	public getPveMembersOnIsland(): {
-		attack: number; speed: number;
-	}[] {
+	public getPveMembersOnIsland(): PveMemberStats[] {
 		return this.pveMembers;
 	}
 


### PR DESCRIPTION
Suite de review de la PR #4628, mergée avant que ces correctifs n'aient pu y être intégrés (la branche avait été supprimée après un merge en rebase).

## Correctifs

**`PlayerFighter.pveMembers` pouvait être `undefined`**

Le champ était déclaré avec une assertion `!` et n'était renseigné que dans `chooseAction()`, uniquement quand le joueur se trouve sur l'île PVE. `getPveMembersOnIsland()` le retournait tel quel et `guildAttack` itère dessus, ce qui pouvait lever une `TypeError`. Le champ est désormais initialisé à `[]`, et le chargement unique par combat est porté par un booléen dédié `pveMembersLoaded` (positionné avant le `await`, comme le faisait implicitement l'ancien `this.pveMembers = []`).

**Type inline répété**

Le type `{ attack: number; speed: number }[]` apparaissait deux fois ; il est extrait en `PveMemberStats`.

**Recherche linéaire dans un filtre**

`getGuildMembersThatWereOnPveIsland` faisait des `Array.includes` à l'intérieur d'un `filter` (O(n^2)) ; les tableaux intermédiaires deviennent des `Set`. Même sémantique et même ordre de résultat.

**Cast non vérifié**

`(sender as PlayerFighter)` dans `guildAttack` est remplacé par une garde `instanceof`. Sans `PlayerFighter`, pas de bonus d'alliés : seules l'attaque et la vitesse de base sont utilisées.

## Tests

- `pnpm eslint` (Core) : OK
- `pnpm tsc --noEmit` (Core) : OK
- `pnpm test` (Core) : 1565 tests passés
