### PR TITLE
L'aveuglement frappe désormais réellement au hasard

### DIFF
--- a/Core/__tests__/core/fights/actions/alterations/blind.test.ts
+++ b/Core/__tests__/core/fights/actions/alterations/blind.test.ts
@@ -1,0 +1,62 @@
+import {
+	afterEach, describe, expect, it, vi
+} from "vitest";
+import { RandomUtils } from "../../../../../../Lib/src/utils/RandomUtils";
+import blindUse from "../../../../../src/core/fights/actions/interfaces/alterations/blind";
+import { FightActionDataController } from "../../../../../src/data/FightAction";
+import { FightAlterationState } from "../../../../../../Lib/src/types/FightAlterationResult";
+import type { Fighter } from "../../../../../src/core/fights/fighter/Fighter";
+import type { FightAlteration } from "../../../../../src/data/FightAlteration";
+import type { FightAction } from "../../../../../src/data/FightAction";
+import type { FightController } from "../../../../../src/core/fights/FightController";
+
+const CHOSEN_ACTION = { id: "chosenAttack" } as FightAction;
+const RANDOM_ACTION = { id: "randomAttack" } as FightAction;
+
+function buildAffected(): Fighter {
+	// alterationTurn 1 keeps the alteration out of its heal branch, which requires alterationTurn > 1
+	return {
+		alterationTurn: 1,
+		nextFightAction: CHOSEN_ACTION,
+		hasDefenseModifier: (): boolean => true,
+		hasSpeedModifier: (): boolean => true,
+		getRandomAvailableFightAction: (): FightAction => RANDOM_ACTION
+	} as unknown as Fighter;
+}
+
+function useBlind(affected: Fighter): ReturnType<typeof blindUse> {
+	return blindUse(affected, null as unknown as FightAlteration, affected, 1, null as unknown as FightController);
+}
+
+/**
+ * Regression test for #4639: the "blind" narration announces that the fighter strikes at random, so the
+ * alteration must actually replace the action they chose when it does not make them miss their turn.
+ */
+describe("blind alteration", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("replaces the chosen action by a random one while active", () => {
+		// No heal, and no missed turn: only the "strikes at random" branch is left
+		vi.spyOn(RandomUtils.crowniclesRandom, "bool").mockReturnValue(false);
+		const affected = buildAffected();
+
+		const result = useBlind(affected);
+
+		expect(result.state).toBe(FightAlterationState.ACTIVE);
+		expect(affected.nextFightAction).toBe(RANDOM_ACTION);
+	});
+
+	it("makes the fighter do nothing when the alteration steals their turn", () => {
+		const none = FightActionDataController.instance.getNone();
+		vi.spyOn(RandomUtils.crowniclesRandom, "bool").mockReturnValue(true);
+		const affected = buildAffected();
+		affected.alterationTurn = 1;
+
+		const result = useBlind(affected);
+
+		expect(result.state).toBe(FightAlterationState.NO_ACTION);
+		expect(affected.nextFightAction).toBe(none);
+	});
+});

--- a/Core/src/core/fights/actions/interfaces/alterations/blind.ts
+++ b/Core/src/core/fights/actions/interfaces/alterations/blind.ts
@@ -46,6 +46,9 @@ const use: FightAlterationFunc = (affected, fightAlteration, _opponent) => {
 		affected.nextFightAction = FightActionDataController.instance.getNone();
 		result.state = FightAlterationState.NO_ACTION;
 	}
+	else if (result.state === FightAlterationState.ACTIVE) {
+		affected.nextFightAction = affected.getRandomAvailableFightAction();
+	}
 
 	return result;
 };


### PR DESCRIPTION
Fixes #4639

## Problème

L'altération `blind` applique les malus de défense/vitesse puis, 80 % du temps, bloque l'action (`NO_ACTION`). Dans les 20 % restants elle renvoie l'état `ACTIVE` **sans jamais modifier `nextFightAction`** : l'IA choisit donc normalement sa meilleure attaque, alors que le message affiché annonce « est aveuglé et frappe au hasard tout autour de lui ».

## Correctif

Quand l'aveuglement est actif sans blocage d'action, on assigne réellement une action aléatoire via `getRandomAvailableFightAction()`, comme le fait déjà l'altération `confused`. L'état `NEW` (premier tour, « est aveuglé. ») reste inchangé.

## Vérifications

- `pnpm eslint` (Core) : OK
- `pnpm test` (Core) : 1565 tests passés
