### PR TITLE
Mentionne le gain de trésorerie sur les récompenses de boss

### DIFF
--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -805,7 +805,7 @@
     "rewardEmbedTitle": "{{pseudo}}, récompenses de combat",
     "monsterRewardGuildXp": "{emote:unitValues.xp} Expérience de guilde gagnée : **{{guildXp, number}}**",
     "monsterRewardsDescription": "{emote:unitValues.money} Argent gagné : **{{money, number}}**\n{emote:unitValues.xp} XP gagnée : **{{experience, number}}**",
-    "monsterRewardsGuildPoints": "{emote:unitValues.guildPoint} Points de guilde gagnés : **{{guildPoints, number}}**",
+    "monsterRewardsGuildPoints": "{emote:unitValues.guildPoint} Points de guilde gagnés : **{{guildPoints, number}}**. La trésorerie augmente du même montant.",
     "monsterRewardsTitle": "{{pseudo}}, récompenses de combat",
     "newBigEvent": "{emote:languages.fr} Vous êtes arrivé à **{{destination}}** !",
     "noFight": "{emote:commands.report} **Journal de {{pseudo}} :** {emote:pveFights.waitABit} | Vous vous enfuyez rapidement et trouvez une petite cachette ! Le monstre vous attend patiemment dehors...",


### PR DESCRIPTION
Fixes #4635

## Problème

`Guild.addScore()` incrémente la trésorerie du même montant que les points de guilde gagnés, mais l'écran de récompense de combat de boss ne le mentionnait pas, contrairement au bonus de guilde quotidien.

## Correctif

Ajout de la phrase « La trésorerie augmente du même montant. » à la clé `commands:report.monsterRewardsGuildPoints` (FR uniquement, les autres langues suivent via Crowdin).

Le message n'est affiché que lorsque `guildPoints > 0`, donc il n'apparaît jamais après une perte de points.
