### PR TITLE
Garde la date de voyage intacte pour les joueurs immobiles

### DIFF
--- a/Core/__tests__/core/maps/TravelTime.test.ts
+++ b/Core/__tests__/core/maps/TravelTime.test.ts
@@ -146,6 +146,36 @@ describe('TravelTime', () => {
 		expect(save).toHaveBeenCalledOnce();
 	});
 
+	it('removeEffect keeps a non travelling player stationary', async () => {
+		vi.spyOn(TravelTime, 'timeTravelMilliseconds').mockResolvedValue();
+		const player: any = {
+			effectRemainingTime: () => 0,
+			effectDuration: 1440,
+			startTravelDate: new Date(0),
+			effectEndDate: new Date(now),
+			effectId: 'occupied',
+			save: vi.fn().mockResolvedValue(undefined)
+		};
+
+		await TravelTime.removeEffect(player, 0);
+
+		expect(player.startTravelDate.valueOf()).toBe(0);
+		expect(Maps.isTravelling(player)).toBe(false);
+	});
+
+	it('timeTravel keeps a non travelling player stationary', async () => {
+		const player: any = {
+			effectEndDate: new Date(now + 5_000),
+			startTravelDate: new Date(0),
+			id: 1,
+			keycloakId: 'user123'
+		};
+
+		await TravelTime.timeTravelMilliseconds(player, asMilliseconds(-500_000), 0);
+
+		expect(player.startTravelDate.valueOf()).toBe(0);
+	});
+
 	it('applyEffect sets new effect and logs', async () => {
 		const save = vi.fn().mockResolvedValue(undefined);
 		const player: any = {

--- a/Core/__tests__/core/maps/TravelTime.test.ts
+++ b/Core/__tests__/core/maps/TravelTime.test.ts
@@ -180,8 +180,48 @@ describe('TravelTime', () => {
 		expect(player.startTravelDate.valueOf()).toBe(now);
 	});
 
-	it('timeTravel keeps a non travelling player stationary', async () => {
+	it('removeEffect never delays a travel started after the alteration when it is healed early', async () => {
+		const thirtyMinutes = 30 * 60_000;
 		const player: any = {
+			/*
+			 * A 60 minutes alteration taken while staying in the city, half of it left, and the travel
+			 * just started: paying to be healed must not push the departure into the future.
+			 */
+			effectRemainingTime: () => asMilliseconds(thirtyMinutes),
+			effectDuration: 60,
+			startTravelDate: new Date(now),
+			effectEndDate: new Date(now + thirtyMinutes),
+			mapLinkId: 1,
+			id: 1,
+			keycloakId: 'user123',
+			save: vi.fn().mockResolvedValue(undefined)
+		};
+
+		await TravelTime.removeEffect(player, 0);
+
+		expect(player.startTravelDate.valueOf()).toBe(now);
+	});
+
+	it('removeEffect consumes the whole alteration of a travel it delayed', async () => {
+		const thirtyMinutes = 30 * 60_000;
+		const player: any = {
+			// Travelling for 30 minutes under a 60 minutes alteration: none of it counted as travel time
+			effectRemainingTime: () => asMilliseconds(thirtyMinutes),
+			effectDuration: 60,
+			startTravelDate: new Date(now - thirtyMinutes),
+			effectEndDate: new Date(now + thirtyMinutes),
+			mapLinkId: 1,
+			id: 1,
+			keycloakId: 'user123',
+			save: vi.fn().mockResolvedValue(undefined)
+		};
+
+		await TravelTime.removeEffect(player, 0);
+
+		expect(player.startTravelDate.valueOf()).toBe(now);
+	});
+
+	it('timeTravel keeps a non travelling player stationary', async () => {		const player: any = {
 			effectEndDate: new Date(now + 5_000),
 			startTravelDate: new Date(0),
 			id: 1,

--- a/Core/__tests__/core/maps/TravelTime.test.ts
+++ b/Core/__tests__/core/maps/TravelTime.test.ts
@@ -163,6 +163,23 @@ describe('TravelTime', () => {
 		expect(Maps.isTravelling(player)).toBe(false);
 	});
 
+	it('removeEffect never pushes the travel start into the future', async () => {
+		vi.spyOn(TravelTime, 'timeTravelMilliseconds').mockResolvedValue();
+		const player: any = {
+			effectRemainingTime: () => 0,
+			// 24h alteration entirely consumed before the travel started
+			effectDuration: 1440,
+			startTravelDate: new Date(now - 60_000),
+			effectEndDate: new Date(now - 60_000),
+			effectId: 'occupied',
+			save: vi.fn().mockResolvedValue(undefined)
+		};
+
+		await TravelTime.removeEffect(player, 0);
+
+		expect(player.startTravelDate.valueOf()).toBe(now);
+	});
+
 	it('timeTravel keeps a non travelling player stationary', async () => {
 		const player: any = {
 			effectEndDate: new Date(now + 5_000),

--- a/Core/src/core/maps/TravelTime.ts
+++ b/Core/src/core/maps/TravelTime.ts
@@ -160,8 +160,10 @@ export abstract class TravelTime {
 		// Move the end date of the effect
 		player.effectEndDate = new Date(Math.max(player.effectEndDate.valueOf() - adjustedTimeMs, 0));
 
-		// Move the start date
-		player.startTravelDate = new Date(Math.max(player.startTravelDate.valueOf() - adjustedTimeMs, 0));
+		// Move the start date, unless the player is not travelling: 0 is the sentinel value meaning "no travel in progress"
+		if (Maps.isTravelling(player)) {
+			player.startTravelDate = new Date(Math.max(player.startTravelDate.valueOf() - adjustedTimeMs, 0));
+		}
 
 		// If the effect is not active anymore and was active before
 		if ((player.effectEndDate.valueOf() < currentTime) && (initialEffectEndDate > currentTime)) {
@@ -219,7 +221,9 @@ export abstract class TravelTime {
 		await TravelTime.timeTravelMilliseconds(player, player.effectRemainingTime(), reason);
 
 		// Move the start of the travel because the effect will have a duration of 0
-		player.startTravelDate = new Date(player.startTravelDate.valueOf() + minutesToMilliseconds(asMinutes(player.effectDuration)));
+		if (Maps.isTravelling(player)) {
+			player.startTravelDate = new Date(player.startTravelDate.valueOf() + minutesToMilliseconds(asMinutes(player.effectDuration)));
+		}
 
 		// Now we can safely remove the effect, as the player is after the effect
 		player.effectId = Effect.NO_EFFECT.id;

--- a/Core/src/core/maps/TravelTime.ts
+++ b/Core/src/core/maps/TravelTime.ts
@@ -222,7 +222,11 @@ export abstract class TravelTime {
 
 		// Move the start of the travel because the effect will have a duration of 0
 		if (Maps.isTravelling(player)) {
-			player.startTravelDate = new Date(player.startTravelDate.valueOf() + minutesToMilliseconds(asMinutes(player.effectDuration)));
+			// Clamped to now: an effect started before the current travel (e.g. while staying in a city) never delayed it
+			player.startTravelDate = new Date(Math.min(
+				player.startTravelDate.valueOf() + minutesToMilliseconds(asMinutes(player.effectDuration)),
+				nowMs()
+			));
 		}
 
 		// Now we can safely remove the effect, as the player is after the effect


### PR DESCRIPTION
Fixes #4633

## Analyse

Le symptôme (voyage de 496170 h + altération de 1 h 50 affichée à 23 h 31) vient de `startTravelDate` poussé dans le futur.

### Cause principale : une altération subie *hors voyage* décale le voyage suivant

Depuis la fonctionnalité des villes, un joueur peut rester immobile en ville (`startTravelDate = 0`, la sentinelle de `Maps.isTravelling`) tout en portant une altération — le menu de destination gère explicitement ce cas (`time: Math.min(COLLECTOR_TIME, player.effectRemainingTime() || ...)`), et un timeout bascule sur `applyStayInCity`.

Rien ne nettoie l'altération tant qu'elle n'est pas explicitement retirée. Quand le joueur repart puis déclenche un `removeEffect` (nouveau small event via `applyEffect`, bouton jetons, bonus de guilde, `/revivre`, `/debloquer`…), `TravelTime.removeEffect` faisait :

```ts
startTravelDate += effectDuration
```

sans borne. Avec une altération de 24 h consommée *avant* le départ, la date de départ saute 24 h dans le futur. Ensuite `getTravelDataSimplified` remonte `effectEndTime` jusqu'à `travelStartTime`, ce qui transforme l'altération de 1 h 50 en 23 h 31 — exactement le second symptôme de l'issue.

### Cause secondaire : la sentinelle « pas en voyage » écrasée

Pour un joueur immobile (`startTravelDate = 0`), le même `+=` produit `epoch + effectDuration`, donc « en voyage depuis 1970 ». `applyTimeTravel` déplaçait lui aussi la sentinelle. Vérification en base de production : 7 comptes ont aujourd'hui `insideCity = 1`, `effectId = none` et un `startTravelDate` valant l'epoch plus une durée d'altération ronde (15 min, 20 min, 35 min, 3 h…).

### Déjà corrigé sur `develop`, pas encore en prod

Le commit `034189c2a` (« fix token travel rollback », #4567) borne `timeToNextSmallEvent` à `Math.max(..., 0)`. Il est sur `develop` mais absent de `master` : le joueur était en 6.0.2.b. Il ne couvrait toutefois que le flux jetons, pas les deux causes ci-dessus.

## Correctif

Dans `TravelTime` :
- `startTravelDate` n'est plus modifié quand le joueur ne voyage pas (`applyTimeTravel` et `removeEffect`) ;
- `removeEffect` borne la date de départ à `now` : une altération commencée avant le voyage courant n'a pas pu le retarder. Cela rétablit l'invariant `startTravelDate <= now` (I1 de #4571).

## Tests

3 tests de non-régression ajoutés dans `TravelTime.test.ts` :
- `removeEffect` sur joueur immobile → sentinelle préservée ;
- time travel négatif sur joueur immobile → sentinelle préservée ;
- `removeEffect` avec une altération consommée avant le départ → date de départ bornée à `now`.

`pnpm eslint` (Core) : OK — `pnpm test` (Core) : 1568 tests passés.

## Note

Les comptes déjà cassés en base auront besoin d'un clamp one-shot (`startTravelDate = min(startTravelDate, now)`), comme prévu par #4571.
