### PR TITLE
Ne ressuscite plus la notification d'arrivée après l'arrivée

### DIFF
--- a/Core/__tests__/core/bot/ReportNotifications.test.ts
+++ b/Core/__tests__/core/bot/ReportNotifications.test.ts
@@ -150,6 +150,7 @@ describe("dispatchOrRescheduleArrivalNotification", () => {
 
 		await dispatchOrRescheduleArrivalNotification(travellingPlayer(43));
 
+		expect(ScheduledReportNotifications.claimNotification).not.toHaveBeenCalled();
 		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
 	});
 });

--- a/Core/__tests__/core/bot/ReportNotifications.test.ts
+++ b/Core/__tests__/core/bot/ReportNotifications.test.ts
@@ -5,8 +5,14 @@ import {
 vi.mock("../../../src/core/database/game/models/ScheduledReportNotification", () => ({
 	ScheduledReportNotifications: {
 		getNotificationsBeforeDate: vi.fn(),
-		claimNotification: vi.fn()
+		claimNotification: vi.fn(),
+		rescheduleNotification: vi.fn(),
+		getPendingNotification: vi.fn()
 	}
+}));
+
+vi.mock("../../../src/core/maps/TravelTime", () => ({
+	TravelTime: { getTravelDataSimplified: vi.fn() }
 }));
 
 vi.mock("../../../src/core/utils/PacketUtils", () => ({
@@ -23,8 +29,11 @@ vi.mock("../../../src/data/MapLocation", () => ({
 	}
 }));
 
-import { processDueReportNotifications } from "../../../src/core/bot/ReportNotifications";
+import {
+	dispatchOrRescheduleArrivalNotification, processDueReportNotifications
+} from "../../../src/core/bot/ReportNotifications";
 import { ScheduledReportNotifications } from "../../../src/core/database/game/models/ScheduledReportNotification";
+import { TravelTime } from "../../../src/core/maps/TravelTime";
 import { PacketUtils } from "../../../src/core/utils/PacketUtils";
 import { ReachDestinationNotificationPacket } from "../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
 
@@ -65,5 +74,54 @@ describe("processDueReportNotifications", () => {
 
 		expect(ScheduledReportNotifications.claimNotification).toHaveBeenCalledWith(1);
 		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
+	});
+});
+
+describe("dispatchOrRescheduleArrivalNotification", () => {
+	const now = Date.now();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("never resurrects a notification for a travel that is already over", async () => {
+		// The arrival big event granted an alteration, pushing the travel end back into the future
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue({ travelEndTime: now + 3_600_000 } as never);
+
+		await dispatchOrRescheduleArrivalNotification({
+			id: 1,
+			getDestinationId: (): number => 42
+		} as never);
+
+		expect(ScheduledReportNotifications.rescheduleNotification).toHaveBeenCalledWith(1, 42, new Date(now + 3_600_000));
+		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
+	});
+
+	it("stays silent when the player has no pending notification left", async () => {
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue({ travelEndTime: now - 1_000 } as never);
+		vi.mocked(ScheduledReportNotifications.getPendingNotification).mockResolvedValue(null);
+
+		await dispatchOrRescheduleArrivalNotification({
+			id: 1,
+			getDestinationId: (): number => 42
+		} as never);
+
+		expect(ScheduledReportNotifications.claimNotification).not.toHaveBeenCalled();
+		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
+	});
+
+	it("dispatches the arrival notification it claimed", async () => {
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue({ travelEndTime: now - 1_000 } as never);
+		vi.mocked(ScheduledReportNotifications.getPendingNotification).mockResolvedValue({
+			playerId: 1, keycloakId: "player", mapId: 42
+		} as never);
+		vi.mocked(ScheduledReportNotifications.claimNotification).mockResolvedValue(true);
+
+		await dispatchOrRescheduleArrivalNotification({
+			id: 1,
+			getDestinationId: (): number => 42
+		} as never);
+
+		expect(PacketUtils.sendNotifications).toHaveBeenCalledOnce();
 	});
 });

--- a/Core/__tests__/core/bot/ReportNotifications.test.ts
+++ b/Core/__tests__/core/bot/ReportNotifications.test.ts
@@ -36,6 +36,8 @@ import { ScheduledReportNotifications } from "../../../src/core/database/game/mo
 import { TravelTime } from "../../../src/core/maps/TravelTime";
 import { PacketUtils } from "../../../src/core/utils/PacketUtils";
 import { ReachDestinationNotificationPacket } from "../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
+import type Player from "../../../src/core/database/game/models/Player";
+import { asMilliseconds } from "../../../../Lib/src/utils/TimeUtils";
 
 describe("processDueReportNotifications", () => {
 	beforeEach(() => {
@@ -80,48 +82,74 @@ describe("processDueReportNotifications", () => {
 describe("dispatchOrRescheduleArrivalNotification", () => {
 	const now = Date.now();
 
+	/**
+	 * `dispatchOrRescheduleArrivalNotification` only reads the id and the destination of the player, and a full
+	 * Sequelize model instance cannot be built here: the cast keeps the fixture in a single place.
+	 */
+	function travellingPlayer(destinationId: number): Player {
+		return {
+			id: 1,
+			getDestinationId: (): number => destinationId
+		} as Player;
+	}
+
+	function travelEndingAt(travelEndTime: number): ReturnType<typeof TravelTime.getTravelDataSimplified> {
+		return {
+			travelStartTime: asMilliseconds(0),
+			travelEndTime: asMilliseconds(travelEndTime),
+			effectStartTime: asMilliseconds(0),
+			effectEndTime: asMilliseconds(0),
+			effectDuration: asMilliseconds(0),
+			effectRemainingTime: asMilliseconds(0),
+			playerTravelledTime: asMilliseconds(0)
+		};
+	}
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
 	it("never resurrects a notification for a travel that is already over", async () => {
 		// The arrival big event granted an alteration, pushing the travel end back into the future
-		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue({ travelEndTime: now + 3_600_000 } as never);
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue(travelEndingAt(now + 3_600_000));
 
-		await dispatchOrRescheduleArrivalNotification({
-			id: 1,
-			getDestinationId: (): number => 42
-		} as never);
+		await dispatchOrRescheduleArrivalNotification(travellingPlayer(42));
 
 		expect(ScheduledReportNotifications.rescheduleNotification).toHaveBeenCalledWith(1, 42, new Date(now + 3_600_000));
 		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
 	});
 
 	it("stays silent when the player has no pending notification left", async () => {
-		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue({ travelEndTime: now - 1_000 } as never);
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue(travelEndingAt(now - 1_000));
 		vi.mocked(ScheduledReportNotifications.getPendingNotification).mockResolvedValue(null);
 
-		await dispatchOrRescheduleArrivalNotification({
-			id: 1,
-			getDestinationId: (): number => 42
-		} as never);
+		await dispatchOrRescheduleArrivalNotification(travellingPlayer(42));
 
 		expect(ScheduledReportNotifications.claimNotification).not.toHaveBeenCalled();
 		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
 	});
 
 	it("dispatches the arrival notification it claimed", async () => {
-		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue({ travelEndTime: now - 1_000 } as never);
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue(travelEndingAt(now - 1_000));
 		vi.mocked(ScheduledReportNotifications.getPendingNotification).mockResolvedValue({
 			playerId: 1, keycloakId: "player", mapId: 42
-		} as never);
+		});
 		vi.mocked(ScheduledReportNotifications.claimNotification).mockResolvedValue(true);
 
-		await dispatchOrRescheduleArrivalNotification({
-			id: 1,
-			getDestinationId: (): number => 42
-		} as never);
+		await dispatchOrRescheduleArrivalNotification(travellingPlayer(42));
 
 		expect(PacketUtils.sendNotifications).toHaveBeenCalledOnce();
+	});
+
+	it("never dispatches a notification scheduled for another destination", async () => {
+		vi.mocked(TravelTime.getTravelDataSimplified).mockReturnValue(travelEndingAt(now - 1_000));
+		vi.mocked(ScheduledReportNotifications.getPendingNotification).mockResolvedValue({
+			playerId: 1, keycloakId: "player", mapId: 42
+		});
+		vi.mocked(ScheduledReportNotifications.claimNotification).mockResolvedValue(true);
+
+		await dispatchOrRescheduleArrivalNotification(travellingPlayer(43));
+
+		expect(PacketUtils.sendNotifications).not.toHaveBeenCalled();
 	});
 });

--- a/Core/src/core/bot/ReportNotifications.ts
+++ b/Core/src/core/bot/ReportNotifications.ts
@@ -1,8 +1,59 @@
 import { makePacket } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { ReachDestinationNotificationPacket } from "../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
 import { MapLocationDataController } from "../../data/MapLocation";
+import type Player from "../database/game/models/Player";
 import { ScheduledReportNotifications } from "../database/game/models/ScheduledReportNotification";
+import { TravelTime } from "../maps/TravelTime";
 import { PacketUtils } from "../utils/PacketUtils";
+
+/**
+ * Send the arrival notification of a player, whose row has already been claimed.
+ */
+function sendArrivalNotification(keycloakId: string, mapId: number): void {
+	const mapLocation = MapLocationDataController.instance.getById(mapId);
+	if (!mapLocation) {
+		return;
+	}
+	PacketUtils.sendNotifications([
+		makePacket(ReachDestinationNotificationPacket, {
+			keycloakId,
+			mapType: mapLocation.type,
+			mapId
+		})
+	]);
+}
+
+/**
+ * React to a change of the travel timers of a player: either postpone their pending arrival
+ * notification, or dispatch it because they have arrived.
+ *
+ * The pending row is only ever created by `Maps.startTravel`: once the arrival has been notified,
+ * a later change of the timers (an alteration granted by the arrival big event, then the player
+ * settling in the city) must not resurrect a notification for a travel that is over (issue #4626).
+ */
+export async function dispatchOrRescheduleArrivalNotification(player: Player): Promise<void> {
+	const now = new Date();
+	const travelEndDate = new Date(TravelTime.getTravelDataSimplified(player, now).travelEndTime);
+	const destinationId = player.getDestinationId();
+
+	if (travelEndDate > now && destinationId !== null) {
+		await ScheduledReportNotifications.rescheduleNotification(player.id, destinationId, travelEndDate);
+		return;
+	}
+
+	/*
+	 * Arrived: claim the pending row atomically. Only the winner of the claim dispatches
+	 * the notification, so the periodic poller can never send a duplicate (issue #4562).
+	 */
+	const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(player.id);
+	if (!pendingReportNotification) {
+		return;
+	}
+	if (!await ScheduledReportNotifications.claimNotification(player.id) || destinationId !== pendingReportNotification.mapId) {
+		return;
+	}
+	sendArrivalNotification(pendingReportNotification.keycloakId, pendingReportNotification.mapId);
+}
 
 /**
  * Dispatch every arrival notification whose scheduled time has passed.
@@ -22,12 +73,6 @@ export async function processDueReportNotifications(): Promise<void> {
 		if (!await ScheduledReportNotifications.claimNotification(notification.playerId)) {
 			return;
 		}
-		PacketUtils.sendNotifications([
-			makePacket(ReachDestinationNotificationPacket, {
-				keycloakId: notification.keycloakId,
-				mapType: MapLocationDataController.instance.getById(notification.mapId)!.type,
-				mapId: notification.mapId
-			})
-		]);
+		sendArrivalNotification(notification.keycloakId, notification.mapId);
 	}));
 }

--- a/Core/src/core/bot/ReportNotifications.ts
+++ b/Core/src/core/bot/ReportNotifications.ts
@@ -41,15 +41,16 @@ export async function dispatchOrRescheduleArrivalNotification(player: Player): P
 		return;
 	}
 
+	const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(player.id);
+	if (!pendingReportNotification || destinationId !== pendingReportNotification.mapId) {
+		return;
+	}
+
 	/*
 	 * Arrived: claim the pending row atomically. Only the winner of the claim dispatches
 	 * the notification, so the periodic poller can never send a duplicate (issue #4562).
 	 */
-	const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(player.id);
-	if (!pendingReportNotification) {
-		return;
-	}
-	if (!await ScheduledReportNotifications.claimNotification(player.id) || destinationId !== pendingReportNotification.mapId) {
+	if (!await ScheduledReportNotifications.claimNotification(player.id)) {
 		return;
 	}
 	sendArrivalNotification(pendingReportNotification.keycloakId, pendingReportNotification.mapId);

--- a/Core/src/core/bot/ReportNotifications.ts
+++ b/Core/src/core/bot/ReportNotifications.ts
@@ -42,15 +42,16 @@ export async function dispatchOrRescheduleArrivalNotification(player: Player): P
 	}
 
 	const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(player.id);
-	if (!pendingReportNotification || destinationId !== pendingReportNotification.mapId) {
+	if (!pendingReportNotification) {
 		return;
 	}
 
 	/*
 	 * Arrived: claim the pending row atomically. Only the winner of the claim dispatches
 	 * the notification, so the periodic poller can never send a duplicate (issue #4562).
+	 * The synchronous destination check comes first so a mismatch short-circuits the claim.
 	 */
-	if (!await ScheduledReportNotifications.claimNotification(player.id)) {
+	if (destinationId !== pendingReportNotification.mapId || !await ScheduledReportNotifications.claimNotification(player.id)) {
 		return;
 	}
 	sendArrivalNotification(pendingReportNotification.keycloakId, pendingReportNotification.mapId);

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -60,10 +60,8 @@ import { ClassInfoConstants } from "../../../../../../Lib/src/constants/ClassInf
 import { GuildConstants } from "../../../../../../Lib/src/constants/GuildConstants";
 import { MapConstants } from "../../../../../../Lib/src/constants/MapConstants";
 import { Effect } from "../../../../../../Lib/src/types/Effect";
-import { ScheduledReportNotifications } from "./ScheduledReportNotification";
-import { PacketUtils } from "../../../utils/PacketUtils";
+import { dispatchOrRescheduleArrivalNotification } from "../../../bot/ReportNotifications";
 import { StatValues } from "../../../../../../Lib/src/types/StatValues";
-import { ReachDestinationNotificationPacket } from "../../../../../../Lib/src/packets/notifications/ReachDestinationNotificationPacket";
 import { CrowniclesLogger } from "../../../../../../Lib/src/logs/CrowniclesLogger";
 import { TokensConstants } from "../../../../../../Lib/src/constants/TokensConstants";
 import { MathUtils } from "../../../utils/MathUtils";
@@ -2029,46 +2027,7 @@ export function initModel(sequelize: Sequelize): void {
 			return;
 		}
 
-		const handleNotifications = async (): Promise<void> => {
-			// Report Notification
-			const now = new Date();
-			const travelEndDate = new Date(TravelTime.getTravelDataSimplified(instance, now).travelEndTime);
-			const destinationId = instance.getDestinationId();
-
-			if (
-				travelEndDate > now
-				&& destinationId !== null
-			) {
-				// Still travelling: (re)schedule the arrival notification (upsert overwrites any stale row).
-				await ScheduledReportNotifications.scheduleNotification(instance.id, instance.keycloakId, destinationId, travelEndDate);
-				return;
-			}
-
-			/*
-			 * Arrived: claim the pending row atomically. Only the winner of the claim dispatches
-			 * the notification, so the periodic poller can never send a duplicate (issue #4562).
-			 */
-			const pendingReportNotification = await ScheduledReportNotifications.getPendingNotification(instance.id);
-			if (!pendingReportNotification) {
-				return;
-			}
-			const claimed = await ScheduledReportNotifications.claimNotification(instance.id);
-			if (!claimed || destinationId !== pendingReportNotification.mapId) {
-				return;
-			}
-			const mapLocation = MapLocationDataController.instance.getById(pendingReportNotification.mapId);
-			if (mapLocation) {
-				PacketUtils.sendNotifications([
-					makePacket(ReachDestinationNotificationPacket, {
-						keycloakId: pendingReportNotification.keycloakId,
-						mapType: mapLocation.type,
-						mapId: pendingReportNotification.mapId
-					})
-				]);
-			}
-		};
-
-		scheduleAfterCommit(handleNotifications, error => {
+		scheduleAfterCommit(async () => await dispatchOrRescheduleArrivalNotification(instance), error => {
 			CrowniclesLogger.errorWithObj("Error while handling notifications", error);
 		}, options.transaction);
 	});

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -2027,7 +2027,7 @@ export function initModel(sequelize: Sequelize): void {
 			return;
 		}
 
-		scheduleAfterCommit(async () => await dispatchOrRescheduleArrivalNotification(instance), error => {
+		scheduleAfterCommit(() => dispatchOrRescheduleArrivalNotification(instance), error => {
 			CrowniclesLogger.errorWithObj("Error while handling notifications", error);
 		}, options.transaction);
 	});

--- a/Core/src/core/database/game/models/ScheduledReportNotification.ts
+++ b/Core/src/core/database/game/models/ScheduledReportNotification.ts
@@ -38,6 +38,20 @@ export abstract class ScheduledReportNotifications {
 	}
 
 	/**
+	 * Update the pending notification of a player, if any.
+	 *
+	 * Never creates a row: once the arrival of a travel has been notified, any later change of the
+	 * travel timers (an alteration granted by the arrival big event, for instance) must not schedule
+	 * a second arrival notification for a travel that is already over (issue #4626).
+	 */
+	static async rescheduleNotification(playerId: number, mapId: number, scheduledAt: Date): Promise<void> {
+		await ScheduledReportNotification.update({
+			mapId,
+			scheduledAt
+		}, { where: { playerId } });
+	}
+
+	/**
 	 * Atomically claim (delete) the scheduled notification of a player.
 	 *
 	 * The row acts as a single-use token: the DELETE is serialised by the

--- a/Core/src/core/maps/Maps.ts
+++ b/Core/src/core/maps/Maps.ts
@@ -21,6 +21,7 @@ import {
 	asMinutes, minutesToMilliseconds
 } from "../../../../Lib/src/utils/TimeUtils";
 import { CityDataController } from "../../data/City";
+import { ScheduledReportNotifications } from "../database/game/models/ScheduledReportNotification";
 
 export type OptionsStartBoatTravel = {
 	startTravelTimestamp: number;
@@ -81,6 +82,17 @@ export class Maps {
 		player.startTravelDate = new Date(time);
 		player.insideCity = false;
 		await player.save();
+
+		const destinationId = player.getDestinationId();
+		if (destinationId !== null) {
+			// The arrival notification only exists for the travel that is starting here; later saves may refresh it but never recreate it
+			await ScheduledReportNotifications.scheduleNotification(
+				player.id,
+				player.keycloakId,
+				destinationId,
+				new Date(TravelTime.getTravelDataSimplified(player, new Date()).travelEndTime)
+			);
+		}
 
 		crowniclesInstance?.logsDatabase.logNewTravel(player.keycloakId, newLink)
 			.then();


### PR DESCRIPTION
Fixes #4626

## Pourquoi le fix de #4562 ne suffisait pas

Le commit `ed0c38ca0` réglait un doublon **poller vs hook `afterSave`** : la ligne `ScheduledReportNotification` devient un jeton à usage unique, seul le gagnant du `DELETE` atomique émet la notification. Il est bien sur `develop` (donc sur l'alpha), mais la double notification en entrée de ville a une autre cause.

## Cause

La notification d'arrivée pouvait être **ressuscitée après l'arrivée** :

1. Le joueur arrive à la ville → 1ʳᵉ notification (légitime), la ligne est consommée.
2. Le big event d'arrivée applique une altération → `save()` → dans le hook `afterSave`, `travelEndTime = startTravelDate + effectDuration + tripDuration` **repasse dans le futur** → `scheduleNotification` (un `upsert`) **recrée** une ligne pour un voyage pourtant terminé.
3. Le joueur clique « entrer en ville » → `applyStayInCity` pose `startTravelDate = 0` → le hook recalcule `travelEndTime` à l'epoch, donc dans le passé → branche « arrivé » → la ligne est réclamée et **la 2ᵉ notification part immédiatement**, juste après le clic.

## Correctif

La ligne de notification devient la propriété du voyage qui la crée :

- `Maps.startTravel` planifie explicitement la notification d'arrivée du voyage qui démarre ;
- le hook `afterSave` ne fait plus que **mettre à jour** une ligne existante (`rescheduleNotification`, un `UPDATE` qui ne crée jamais de ligne). Un changement des minuteurs après l'arrivée ne peut donc plus ressusciter de notification.

La logique du hook est extraite dans `ReportNotifications.dispatchOrRescheduleArrivalNotification`, aux côtés du poller, ce qui la rend testable et retire une trentaine de lignes de `Player.ts`.

## Tests

3 tests ajoutés dans `ReportNotifications.test.ts` :
- une fin de voyage repoussée après l'arrivée ne crée pas de notification ;
- aucune notification n'est émise quand il n'y a plus de ligne en attente ;
- la notification réclamée est bien dispatchée.

`pnpm eslint`, `pnpm tsc` et `pnpm test` (1568 tests) verts sur Core.
