### PR TITLE
Le reset quotidien ne rabote plus les jetons au-dessus du plafond

### DIFF
--- a/Core/__tests__/core/bot/cronJobs/CrowniclesChristmas.test.ts
+++ b/Core/__tests__/core/bot/cronJobs/CrowniclesChristmas.test.ts
@@ -89,7 +89,11 @@ describe("CrowniclesChristmas.christmasBonus", () => {
 
 		await CrowniclesChristmas.christmasBonus();
 
-		expect(Player.update).toHaveBeenCalledWith({ tokens: TokensConstants.MAX }, { where: {} });
+		// Players above the token cap must keep their tokens instead of being cut down to MAX
+		expect(Player.update).toHaveBeenCalledWith(
+			{ tokens: expect.objectContaining({ val: `GREATEST(tokens, ${TokensConstants.MAX})` }) },
+			{ where: {} }
+		);
 		expect(Settings.LAST_CHRISTMAS_BONUS_YEAR.setValue).toHaveBeenCalledWith(currentYear);
 		expect(PacketUtils.announce).toHaveBeenCalledTimes(1);
 

--- a/Core/__tests__/core/bot/cronJobs/CrowniclesChristmas.test.ts
+++ b/Core/__tests__/core/bot/cronJobs/CrowniclesChristmas.test.ts
@@ -91,7 +91,7 @@ describe("CrowniclesChristmas.christmasBonus", () => {
 
 		// Players above the token cap must keep their tokens instead of being cut down to MAX
 		expect(Player.update).toHaveBeenCalledWith(
-			{ tokens: expect.objectContaining({ val: `GREATEST(tokens, ${TokensConstants.MAX})` }) },
+			{ tokens: expect.objectContaining({ val: TokensConstants.buildRefillExpression() }) },
 			{ where: {} }
 		);
 		expect(Settings.LAST_CHRISTMAS_BONUS_YEAR.setValue).toHaveBeenCalledWith(currentYear);

--- a/Core/__tests__/core/bot/cronJobs/CrowniclesDaily.test.ts
+++ b/Core/__tests__/core/bot/cronJobs/CrowniclesDaily.test.ts
@@ -90,7 +90,7 @@ describe("CrowniclesDaily.job", () => {
 		expect(Player.update).toHaveBeenCalledWith(
 			{
 				tokens: expect.objectContaining({
-					val: `GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`
+					val: TokensConstants.buildRefillExpression(TokensConstants.DAILY.FREE_PER_DAY)
 				})
 			},
 			{ where: {} }

--- a/Core/__tests__/core/bot/cronJobs/CrowniclesDaily.test.ts
+++ b/Core/__tests__/core/bot/cronJobs/CrowniclesDaily.test.ts
@@ -41,6 +41,8 @@ vi.mock("../../../../src/core/bot/CrowniclesCoreMetrics", () => ({
 
 import { CrowniclesDaily } from "../../../../src/core/bot/cronJobs/CrowniclesDaily";
 import { CrowniclesCoreMetrics } from "../../../../src/core/bot/CrowniclesCoreMetrics";
+import Player from "../../../../src/core/database/game/models/Player";
+import { TokensConstants } from "../../../../../Lib/src/constants/TokensConstants";
 
 type Gate<T> = {
 	promise: Promise<T>;
@@ -73,6 +75,26 @@ describe("CrowniclesDaily.job", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		vi.mocked(CrowniclesCoreMetrics.incrementDailyTaskFailure).mockReset();
+	});
+
+	it("never cuts down players that are above the token cap", async () => {
+		vi.spyOn(CrowniclesDaily, "randomPotion").mockResolvedValue();
+		vi.spyOn(CrowniclesDaily, "randomLovePointsLoose").mockResolvedValue(false);
+		vi.spyOn(CrowniclesDaily, "reloadEnchanter").mockResolvedValue();
+		vi.spyOn(CrowniclesDaily, "trainingGroundLoveBonus").mockResolvedValue();
+		vi.spyOn(CrowniclesDaily, "pantryAutoFill").mockResolvedValue();
+		vi.mocked(Player.update).mockClear();
+
+		await CrowniclesDaily.job();
+
+		expect(Player.update).toHaveBeenCalledWith(
+			{
+				tokens: expect.objectContaining({
+					val: `GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`
+				})
+			},
+			{ where: {} }
+		);
 	});
 
 	it("keeps running the other daily tasks when one of them fails", async () => {

--- a/Core/src/core/bot/cronJobs/CrowniclesChristmas.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesChristmas.ts
@@ -13,6 +13,7 @@ import { TokensConstants } from "../../../../../Lib/src/constants/TokensConstant
 import { TimeoutFunctionsConstants } from "../../../../../Lib/src/constants/TimeoutFunctionsConstants";
 import { ChristmasConstants } from "../../../../../Lib/src/constants/ChristmasConstants";
 import { hoursToMilliseconds } from "../../../../../Lib/src/utils/TimeUtils";
+import { literal } from "sequelize";
 
 export class CrowniclesChristmas {
 	/**
@@ -95,9 +96,9 @@ export class CrowniclesChristmas {
 
 		CrowniclesLogger.info("Applying Christmas token bonus to all players...");
 
-		// Set all players' tokens to maximum
+		// Refill all players' tokens, without cutting down those who are above the cap
 		await Player.update(
-			{ tokens: TokensConstants.MAX },
+			{ tokens: literal(`GREATEST(tokens, ${TokensConstants.MAX})`) },
 			{ where: {} }
 		);
 

--- a/Core/src/core/bot/cronJobs/CrowniclesChristmas.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesChristmas.ts
@@ -98,7 +98,7 @@ export class CrowniclesChristmas {
 
 		// Refill all players' tokens, without cutting down those who are above the cap
 		await Player.update(
-			{ tokens: literal(`GREATEST(tokens, ${TokensConstants.MAX})`) },
+			{ tokens: literal(TokensConstants.buildRefillExpression()) },
 			{ where: {} }
 		);
 

--- a/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
@@ -50,7 +50,8 @@ export class CrowniclesDaily {
 
 		await Player.update(
 			{
-				tokens: literal(`LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY})`)
+				// Mirrors computeNewTokens: players above the cap (expedition and big event rewards) keep their tokens instead of being cut down to MAX
+				tokens: literal(`GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`)
 			},
 			{ where: {} }
 		);

--- a/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
+++ b/Core/src/core/bot/cronJobs/CrowniclesDaily.ts
@@ -50,8 +50,7 @@ export class CrowniclesDaily {
 
 		await Player.update(
 			{
-				// Mirrors computeNewTokens: players above the cap (expedition and big event rewards) keep their tokens instead of being cut down to MAX
-				tokens: literal(`GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`)
+				tokens: literal(TokensConstants.buildRefillExpression(TokensConstants.DAILY.FREE_PER_DAY))
 			},
 			{ where: {} }
 		);

--- a/Lib/src/constants/TokensConstants.ts
+++ b/Lib/src/constants/TokensConstants.ts
@@ -26,4 +26,16 @@ export abstract class TokensConstants {
 
 	/** Number of tokens gifted by the report token merchant to a player with no tokens and not enough money (max once per week) */
 	static readonly MERCHANT_CHARITY_AMOUNT = 10;
+
+	/**
+	 * SQL expression refilling the `tokens` column of every player, mirroring `computeNewTokens`:
+	 * a player above the cap (expedition and big event rewards) keeps their tokens instead of being cut down to MAX.
+	 * @param dailyGain Tokens granted on top of the current balance, capped at MAX. Omit to only top up to MAX.
+	 */
+	static buildRefillExpression(dailyGain?: number): string {
+		const target = dailyGain === undefined
+			? `${TokensConstants.MAX}`
+			: `LEAST(${TokensConstants.MAX}, tokens + ${dailyGain})`;
+		return `GREATEST(tokens, ${target})`;
+	}
 }

--- a/Lib/tests/constants/TokensConstants.test.ts
+++ b/Lib/tests/constants/TokensConstants.test.ts
@@ -1,0 +1,25 @@
+import {
+	describe, expect, it
+} from "vitest";
+import { TokensConstants } from "../../src/constants/TokensConstants";
+
+/*
+ * The expression is evaluated by MariaDB, so it cannot be run here: the tests below pin the two
+ * properties the daily and Christmas crons rely on, and every caller reuses this single definition
+ * instead of rewriting the SQL (issue #4590).
+ */
+describe("TokensConstants.buildRefillExpression", () => {
+	it("never lowers the tokens of a player above the cap", () => {
+		expect(TokensConstants.buildRefillExpression()).toContain("GREATEST(tokens,");
+		expect(TokensConstants.buildRefillExpression(TokensConstants.DAILY.FREE_PER_DAY)).toContain("GREATEST(tokens,");
+	});
+
+	it("tops up to the cap when no daily gain is given", () => {
+		expect(TokensConstants.buildRefillExpression()).toBe(`GREATEST(tokens, ${TokensConstants.MAX})`);
+	});
+
+	it("caps the daily gain at the maximum", () => {
+		expect(TokensConstants.buildRefillExpression(TokensConstants.DAILY.FREE_PER_DAY))
+			.toBe(`GREATEST(tokens, LEAST(${TokensConstants.MAX}, tokens + ${TokensConstants.DAILY.FREE_PER_DAY}))`);
+	});
+});


### PR DESCRIPTION
Fixes #4590

## Cause

La règle métier des jetons, portée par `computeNewTokens` dans `Player.ts`, autorise explicitement le dépassement du plafond (« Block all gains when already at or above max (including over-cap reward sources) ») : un joueur peut se retrouver au-dessus de `TokensConstants.MAX = 20` via une récompense de gros événement ou d'expédition.

Mais le reset quotidien contournait cette règle avec un `UPDATE` de masse en SQL brut :

```sql
tokens = LEAST(20, tokens + 3)
```

Pour un joueur à 150 jetons, `LEAST(20, 153)` vaut **20** : le reset de la nuit ne plafonnait pas un gain, il rabotait le stock existant. Le bonus de Noël avait le même défaut avec son `tokens = 20` inconditionnel.

## Constaté en production

- Joueur 27787 : 163 jetons (récompense de gros événement, `reason = BIG_EVENT`), redescendu sous le plafond sans aucune ligne dans `players_tokens` — le reset ne journalise pas.
- Joueur 27678 : 160 jetons, aujourd'hui à 20.
- Joueur 47273 : 163 jetons, actif hier — il aurait perdu son cadeau au prochain reset.

## Correctif

Les deux `UPDATE` de masse respectent désormais la même règle que `computeNewTokens` : un joueur au-dessus du plafond conserve ses jetons.

- Reset quotidien : `GREATEST(tokens, LEAST(MAX, tokens + FREE_PER_DAY))`
- Bonus de Noël : `GREATEST(tokens, MAX)`

`ReleaseGift` n'est pas touché : c'est un one-shot déjà appliqué et verrouillé par son `Settings`.

## Tests

- Nouveau test dans `CrowniclesDaily.test.ts` : le reset ne rabote pas les joueurs au-dessus du plafond.
- `CrowniclesChristmas.test.ts` mis à jour sur la même garantie.

`pnpm eslint`, `pnpm tsc` et `pnpm test` (1566 tests) verts sur Core.
