### PR TITLE
Date de rotation exacte et formulations neutres pour La Bourse

### DIFF
--- a/Core/__tests__/core/utils/StockExchangeShopItems.test.ts
+++ b/Core/__tests__/core/utils/StockExchangeShopItems.test.ts
@@ -9,9 +9,13 @@ vi.mock("../../../src/core/database/game/models/PlayerBadges", () => ({
 	}
 }));
 
-import { getMarketAnalysisShopItem } from "../../../src/core/utils/StockExchangeShopItems";
+import {
+	FORECAST_OFFSETS, getMarketAnalysisShopItem
+} from "../../../src/core/utils/StockExchangeShopItems";
 import { CommandMissionShopMarketAnalysis } from "../../../../Lib/src/packets/commands/CommandMissionShopPacket";
-import { CrowniclesPacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+import {
+	CrowniclesPacket, PacketContext
+} from "../../../../Lib/src/packets/CrowniclesPacket";
 
 /**
  * Number of days between a date and the next monday, when the herbalist renews its selection.
@@ -20,16 +24,27 @@ function daysUntilNextMonday(date: Date): number {
 	return (8 - date.getDay()) % 7 || 7;
 }
 
+const emptyContext: PacketContext = {
+	keycloakId: "player",
+	frontEndOrigin: "test",
+	frontEndSubOrigin: "test"
+};
+
 function buildAnalysis(): CommandMissionShopMarketAnalysis {
 	const response: CrowniclesPacket[] = [];
 	getMarketAnalysisShopItem()
-		.buyCallback(response, 1, {} as never);
+		.buyCallback(response, 1, emptyContext, 1);
 	return response[0] as CommandMissionShopMarketAnalysis;
 }
 
 describe("market analysis rotation horizon", () => {
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	// The rotation search scans up to the last offset and resolves its horizon with the first one reaching that day
+	it("keeps the forecast offsets sorted ascending", () => {
+		expect([...FORECAST_OFFSETS].sort((a, b) => a - b)).toEqual([...FORECAST_OFFSETS]);
 	});
 
 	it("announces the exact day of the rotation instead of the forecast horizon", () => {

--- a/Core/__tests__/core/utils/StockExchangeShopItems.test.ts
+++ b/Core/__tests__/core/utils/StockExchangeShopItems.test.ts
@@ -1,0 +1,55 @@
+import {
+	afterEach, describe, expect, it, vi
+} from "vitest";
+
+vi.mock("../../../src/core/database/game/models/PlayerBadges", () => ({
+	PlayerBadgesManager: {
+		hasBadge: vi.fn(),
+		addBadge: vi.fn()
+	}
+}));
+
+import { getMarketAnalysisShopItem } from "../../../src/core/utils/StockExchangeShopItems";
+import { CommandMissionShopMarketAnalysis } from "../../../../Lib/src/packets/commands/CommandMissionShopPacket";
+import { CrowniclesPacket } from "../../../../Lib/src/packets/CrowniclesPacket";
+
+/**
+ * Number of days between a date and the next monday, when the herbalist renews its selection.
+ */
+function daysUntilNextMonday(date: Date): number {
+	return (8 - date.getDay()) % 7 || 7;
+}
+
+function buildAnalysis(): CommandMissionShopMarketAnalysis {
+	const response: CrowniclesPacket[] = [];
+	getMarketAnalysisShopItem()
+		.buyCallback(response, 1, {} as never);
+	return response[0] as CommandMissionShopMarketAnalysis;
+}
+
+describe("market analysis rotation horizon", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("announces the exact day of the rotation instead of the forecast horizon", () => {
+		vi.useFakeTimers();
+		let checkedDays = 0;
+
+		// Any day of the week: the rotation, when detected, always lands on the next monday
+		for (let dayOffset = 0; dayOffset < 7; dayOffset++) {
+			vi.setSystemTime(new Date(2026, 7, 10 + dayOffset, 12));
+			const now = new Date();
+			const rotation = buildAnalysis().plantRotation;
+			if (!rotation) {
+				continue;
+			}
+
+			expect(rotation.daysUntilRotation).toBe(daysUntilNextMonday(now));
+			expect(rotation.newPlantIds.length).toBeGreaterThan(0);
+			checkedDays++;
+		}
+
+		expect(checkedDays).toBeGreaterThan(0);
+	});
+});

--- a/Core/src/core/utils/StockExchangeShopItems.ts
+++ b/Core/src/core/utils/StockExchangeShopItems.ts
@@ -50,9 +50,10 @@ const TREND_THRESHOLDS = {
 };
 
 /**
- * Day offsets for market analysis forecasts
+ * Day offsets for market analysis forecasts. Sorted ascending: the rotation search relies on the last
+ * one being the furthest away, and resolves its horizon with the first offset reaching the rotation day.
  */
-const FORECAST_OFFSETS: [number, number, number] = [
+export const FORECAST_OFFSETS: [number, number, number] = [
 	1,
 	3,
 	7

--- a/Core/src/core/utils/StockExchangeShopItems.ts
+++ b/Core/src/core/utils/StockExchangeShopItems.ts
@@ -108,6 +108,7 @@ type PlantTrendData = {
 
 type PlantRotationData = {
 	horizonIndex: number;
+	daysUntilRotation: number;
 	newPlantIds: PlantId[];
 	newPlantForecasts: {
 		plantId: PlantId;
@@ -129,15 +130,26 @@ function computeKingsMoneyTrends(): [MarketTrend, MarketTrend, MarketTrend] {
 	}) as [MarketTrend, MarketTrend, MarketTrend];
 }
 
-function findRotationHorizon(weeklyPlants: PlantType[], now: Date): {
-	index: number; newPlantIds: PlantId[];
-} | null {
-	for (let i = 0; i < FORECAST_OFFSETS.length; i++) {
-		const futureDate = new Date(now.getTime() + FORECAST_OFFSETS[i] * TimeConstants.MS_TIME.DAY);
+type RotationHorizon = {
+	index: number;
+	daysUntilRotation: number;
+	newPlantIds: PlantId[];
+};
+
+/**
+ * Find when the herbalist renews its selection within the forecast period.
+ * The search is day by day so the exact date is known, while `index` still points at the first
+ * forecast horizon that falls after the rotation.
+ */
+function findRotationHorizon(weeklyPlants: PlantType[], now: Date): RotationHorizon | null {
+	const lastForecastDay = FORECAST_OFFSETS[FORECAST_OFFSETS.length - 1];
+	for (let day = 1; day <= lastForecastDay; day++) {
+		const futureDate = new Date(now.getTime() + day * TimeConstants.MS_TIME.DAY);
 		const futurePlants = PlantConstants.getWeeklyHerbalistPlants(futureDate);
 		if (!samePlants(weeklyPlants, futurePlants)) {
 			return {
-				index: i,
+				index: FORECAST_OFFSETS.findIndex(offset => offset >= day),
+				daysUntilRotation: day,
 				newPlantIds: futurePlants.map(p => p.id)
 			};
 		}
@@ -194,6 +206,7 @@ function buildMarketAnalysisPacket(): MarketAnalysisData {
 	if (rotation) {
 		result.plantRotation = {
 			horizonIndex: rotation.index,
+			daysUntilRotation: rotation.daysUntilRotation,
 			newPlantIds: rotation.newPlantIds,
 			newPlantForecasts: computeNewPlantForecasts(rotation.index, now)
 		};

--- a/Discord/src/commands/mission/MissionShop.ts
+++ b/Discord/src/commands/mission/MissionShop.ts
@@ -282,7 +282,9 @@ function buildRotationSection(packet: CommandMissionShopMarketAnalysis, lng: Lan
 		return "";
 	}
 
-	const horizonLabel = i18n.t(`commands:shop.shopItems.marketAnalysis.horizonLabels.${TIME_HORIZONS[packet.plantRotation.horizonIndex]}`, { lng });
+	const horizonLabel = i18n.t("commands:shop.shopItems.marketAnalysis.rotationHorizon", {
+		lng, count: packet.plantRotation.daysUntilRotation
+	});
 	const newPlantsList = packet.plantRotation.newPlantIds.map(plantId =>
 		i18n.t("commands:shop.shopItems.marketAnalysis.plantHeader", {
 			lng, plantId

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -1746,55 +1746,52 @@
         "plantHeader_bold": "{emote:plants.{{plantId}}} **$t(models:plants.{{plantId}})** :",
         "plants": {
           "tomorrow": {
-            "bigDrop": "• **Demain** : Des stocks massifs de $t(models:plants.{{plantId}}) arriveront sur les étals, les prix vont s'effondrer.",
-            "drop": "• **Demain** : L'offre de $t(models:plants.{{plantId}}) sera un peu supérieure à la demande, les prix devraient baisser.",
+            "bigDrop": "• **Demain** : Des stocks massifs arriveront sur les étals, les prix vont s'effondrer.",
+            "drop": "• **Demain** : L'offre sera un peu supérieure à la demande, les prix devraient baisser.",
             "stable": "• **Demain** : Rien de particulier à signaler pour cette plante, les cours resteront stables.",
-            "rise": "• **Demain** : Les réserves de $t(models:plants.{{plantId}}) s'amenuisent chez les herboristes, les prix vont monter.",
-            "bigRise": "• **Demain** : Une pénurie de $t(models:plants.{{plantId}}) se profile, les prix vont flamber !"
+            "rise": "• **Demain** : Les réserves s'amenuisent chez les herboristes, les prix vont monter.",
+            "bigRise": "• **Demain** : Une pénurie se profile, les prix vont flamber !"
           },
           "threeDays": {
-            "bigDrop": "• **Dans 3 jours** : Le marché sera inondé de $t(models:plants.{{plantId}}), les prix chuteront fortement.",
-            "drop": "• **Dans 3 jours** : Une légère surproduction de $t(models:plants.{{plantId}}) fera baisser les prix.",
+            "bigDrop": "• **Dans 3 jours** : Le marché sera inondé de cette plante, les prix chuteront fortement.",
+            "drop": "• **Dans 3 jours** : Une légère surproduction fera baisser les prix.",
             "stable": "• **Dans 3 jours** : Le marché de cette plante restera équilibré.",
-            "rise": "• **Dans 3 jours** : La demande de $t(models:plants.{{plantId}}) augmentera sensiblement, les prix grimperont.",
-            "bigRise": "• **Dans 3 jours** : Les herboristes peineront à trouver de la $t(models:plants.{{plantId}}), les prix exploseront !"
+            "rise": "• **Dans 3 jours** : La demande augmentera sensiblement, les prix grimperont.",
+            "bigRise": "• **Dans 3 jours** : Les herboristes peineront à s'approvisionner, les prix exploseront !"
           },
           "oneWeek": {
-            "bigDrop": "• **Dans une semaine** : Une surproduction massive fera chuter les prix de la $t(models:plants.{{plantId}}).",
-            "drop": "• **Dans une semaine** : Le marché de la $t(models:plants.{{plantId}}) sera légèrement en surplus.",
+            "bigDrop": "• **Dans une semaine** : Une surproduction massive fera chuter les prix.",
+            "drop": "• **Dans une semaine** : Le marché sera légèrement en surplus.",
             "stable": "• **Dans une semaine** : Le marché de cette plante devrait maintenir son équilibre actuel.",
-            "rise": "• **Dans une semaine** : Les réserves de $t(models:plants.{{plantId}}) s'épuiseront, les prix augmenteront.",
-            "bigRise": "• **Dans une semaine** : Une sécheresse frappera les cultures de $t(models:plants.{{plantId}}), les prix seront au plus haut !"
+            "rise": "• **Dans une semaine** : Les réserves s'épuiseront, les prix augmenteront.",
+            "bigRise": "• **Dans une semaine** : Une sécheresse frappera les cultures, les prix seront au plus haut !"
           }
         },
         "outro": "*Le conseiller roule le parchemin et vous le tend avec un sourire entendu.*",
-        "horizonLabels": {
-          "tomorrow": "demain",
-          "threeDays": "dans 3 jours",
-          "oneWeek": "dans une semaine"
-        },
+        "rotationHorizon_one": "demain",
+        "rotationHorizon_other": "dans {{count}} jours",
         "rotation": "{emote:inventory.stock} **Changement de stock** : L'herboriste renouvellera sa sélection **{{horizon}}**. Les nouvelles plantes disponibles seront : {{newPlants}}.",
         "newPlants": {
           "tomorrow": {
-            "bigDrop": "• **Demain** : Le prix de la $t(models:plants.{{plantId}}) sera très en dessous de sa valeur habituelle, une excellente affaire !",
-            "drop": "• **Demain** : Le prix de la $t(models:plants.{{plantId}}) sera légèrement en dessous du prix courant.",
-            "stable": "• **Demain** : Le prix de la $t(models:plants.{{plantId}}) sera conforme à sa valeur habituelle.",
-            "rise": "• **Demain** : Le prix de la $t(models:plants.{{plantId}}) sera un peu élevé par rapport à la normale.",
-            "bigRise": "• **Demain** : Le prix de la $t(models:plants.{{plantId}}) sera bien au-dessus de sa valeur habituelle, mieux vaut attendre."
+            "bigDrop": "• **Demain** : Le prix sera très en dessous de sa valeur habituelle, une excellente affaire !",
+            "drop": "• **Demain** : Le prix sera légèrement en dessous du prix courant.",
+            "stable": "• **Demain** : Le prix sera conforme à sa valeur habituelle.",
+            "rise": "• **Demain** : Le prix sera un peu élevé par rapport à la normale.",
+            "bigRise": "• **Demain** : Le prix sera bien au-dessus de sa valeur habituelle, mieux vaut attendre."
           },
           "threeDays": {
-            "bigDrop": "• **Dans 3 jours** : La $t(models:plants.{{plantId}}) sera proposée à un prix très avantageux.",
-            "drop": "• **Dans 3 jours** : Le prix de la $t(models:plants.{{plantId}}) sera un peu en dessous de la moyenne.",
-            "stable": "• **Dans 3 jours** : Le prix de la $t(models:plants.{{plantId}}) n'aura rien de surprenant.",
-            "rise": "• **Dans 3 jours** : La $t(models:plants.{{plantId}}) sera un peu plus chère que d'ordinaire.",
-            "bigRise": "• **Dans 3 jours** : La $t(models:plants.{{plantId}}) coûtera bien plus cher que d'habitude."
+            "bigDrop": "• **Dans 3 jours** : Le prix sera très avantageux.",
+            "drop": "• **Dans 3 jours** : Le prix sera un peu en dessous de la moyenne.",
+            "stable": "• **Dans 3 jours** : Le prix n'aura rien de surprenant.",
+            "rise": "• **Dans 3 jours** : Le prix sera un peu plus élevé que d'ordinaire.",
+            "bigRise": "• **Dans 3 jours** : Le prix sera bien plus élevé que d'habitude."
           },
           "oneWeek": {
-            "bigDrop": "• **Dans une semaine** : Le prix de la $t(models:plants.{{plantId}}) sera exceptionnellement bas.",
-            "drop": "• **Dans une semaine** : La $t(models:plants.{{plantId}}) sera proposée à un prix légèrement réduit.",
-            "stable": "• **Dans une semaine** : Le prix de la $t(models:plants.{{plantId}}) sera dans la moyenne.",
-            "rise": "• **Dans une semaine** : Le prix de la $t(models:plants.{{plantId}}) sera un peu au-dessus de la normale.",
-            "bigRise": "• **Dans une semaine** : La $t(models:plants.{{plantId}}) sera vendue à un prix exorbitant !"
+            "bigDrop": "• **Dans une semaine** : Le prix sera exceptionnellement bas.",
+            "drop": "• **Dans une semaine** : Le prix sera légèrement réduit.",
+            "stable": "• **Dans une semaine** : Le prix sera dans la moyenne.",
+            "rise": "• **Dans une semaine** : Le prix sera un peu au-dessus de la normale.",
+            "bigRise": "• **Dans une semaine** : Le prix sera exorbitant !"
           }
         }
       },

--- a/Lib/src/packets/commands/CommandMissionShopPacket.ts
+++ b/Lib/src/packets/commands/CommandMissionShopPacket.ts
@@ -126,6 +126,10 @@ export class CommandMissionShopMarketAnalysis extends CrowniclesPacket {
 	 */
 	plantRotation?: {
 		horizonIndex: number;
+
+		/** Exact number of days before the rotation, so the report does not round it up to the next forecast horizon */
+		daysUntilRotation: number;
+
 		newPlantIds: PlantId[];
 
 		/**


### PR DESCRIPTION
Fixes #4620

## 1. « Dans une semaine » au milieu de la semaine

`findRotationHorizon` ne testait que les trois horizons de prévision (1, 3 et 7 jours) et rapportait celui où le stock avait changé. Une rotation à 5 jours n'était donc détectée qu'à l'horizon 7 jours et annoncée « dans une semaine ».

La recherche se fait désormais jour par jour, ce qui donne la date exacte de la rotation. Le packet transporte `daysUntilRotation` à côté de `horizonIndex` — ce dernier reste nécessaire pour savoir à partir de quel horizon les prévisions basculent sur les nouvelles plantes.

Côté affichage, la clé `rotationHorizon` est pluralisée : « demain » pour 1 jour, « dans {{count}} jours » sinon. Les libellés figés `horizonLabels`, devenus inutilisés, sont supprimés.

## 2. Déterminants figés sur le nom des plantes

Les lignes de tendance interpolaient le nom de la plante avec des déterminants au féminin en dur (« le prix **de la** $t(plants.X) », « une pénurie **de** … », « la X sera proposé**e** »). Faux pour « Trèfle doré », « Champignon nocturne », « Bulbe de feu » ou « Arbre ancestral », et impossible à corriger proprement par un déterminant unique — il faudrait aussi accorder les participes.

Le nom de la plante figure déjà en en-tête gras juste au-dessus (`plantHeader_bold`), et la variante `stable` fonctionnait déjà sans le répéter. Les lignes de tendance sont donc reformulées sans le nom : plus de problème de genre, et moins de redondance à l'écran.

Seules les traductions françaises sont touchées ; les autres langues suivront via Crowdin.

## Tests

Nouveau test `StockExchangeShopItems.test.ts` : quel que soit le jour de la semaine, la rotation annoncée tombe bien sur le lundi suivant.

`pnpm eslint` + `pnpm tsc` + `pnpm test` verts sur Core (1566), Discord (261) et Lib (580).
