### PR TITLE
Réserve le slot 3 du four aux recettes de matériaux

### DIFF
--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -186,6 +186,27 @@ describe("CookingSlotRotation", () => {
 			// Without the param, should still work (backward compatible)
 			expect(recipesWithout).toHaveLength(SLOT_CONFIGS.length);
 		});
+
+		it("should always fill the dedicated material slot with a material recipe, even with default recipes only", () => {
+			const materialSlotIndex = SLOT_CONFIGS.findIndex(
+				config => config.eligibleTypes.length === 1 && config.eligibleTypes[0] === RecipeType.MATERIAL_CRAFT
+			);
+			expect(materialSlotIndex).toBeGreaterThanOrEqual(0);
+
+			for (const daySeed of [1, 42, 100, 999, 12345, 50000]) {
+				for (let furnacePosition = 0; furnacePosition < 20; furnacePosition++) {
+					const recipes = getUniqueRecipesForSlots({
+						cookingSlots: SLOT_CONFIGS.length,
+						furnacePosition,
+						daySeed,
+						discoveredRecipeIds: [],
+						maxRecipeLevelWithoutPenalty: 2
+					});
+
+					expect(recipes[materialSlotIndex]?.recipeType).toBe(RecipeType.MATERIAL_CRAFT);
+				}
+			}
+		});
 	});
 
 	describe("isRecipeSecret", () => {

--- a/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
+++ b/Core/__tests__/core/cooking/CookingSlotRotation.test.ts
@@ -187,24 +187,24 @@ describe("CookingSlotRotation", () => {
 			expect(recipesWithout).toHaveLength(SLOT_CONFIGS.length);
 		});
 
-		it("should always fill the dedicated material slot with a material recipe, even with default recipes only", () => {
+		it.each([
+			1, 42, 100, 999, 12345, 50000
+		])("should always fill the dedicated material slot with a material recipe, even with default recipes only (day %i)", daySeed => {
 			const materialSlotIndex = SLOT_CONFIGS.findIndex(
 				config => config.eligibleTypes.length === 1 && config.eligibleTypes[0] === RecipeType.MATERIAL_CRAFT
 			);
 			expect(materialSlotIndex).toBeGreaterThanOrEqual(0);
 
-			for (const daySeed of [1, 42, 100, 999, 12345, 50000]) {
-				for (let furnacePosition = 0; furnacePosition < 20; furnacePosition++) {
-					const recipes = getUniqueRecipesForSlots({
-						cookingSlots: SLOT_CONFIGS.length,
-						furnacePosition,
-						daySeed,
-						discoveredRecipeIds: [],
-						maxRecipeLevelWithoutPenalty: 2
-					});
+			for (let furnacePosition = 0; furnacePosition < 20; furnacePosition++) {
+				const recipes = getUniqueRecipesForSlots({
+					cookingSlots: SLOT_CONFIGS.length,
+					furnacePosition,
+					daySeed,
+					discoveredRecipeIds: [],
+					maxRecipeLevelWithoutPenalty: 2
+				});
 
-					expect(recipes[materialSlotIndex]?.recipeType).toBe(RecipeType.MATERIAL_CRAFT);
-				}
+				expect(recipes[materialSlotIndex]?.recipeType, `furnace position ${furnacePosition}`).toBe(RecipeType.MATERIAL_CRAFT);
 			}
 		});
 	});

--- a/Lib/src/constants/CookingConstants.ts
+++ b/Lib/src/constants/CookingConstants.ts
@@ -308,6 +308,8 @@ const POTION_TYPES_ONLY = [
 	RecipeType.POTION_SPEED
 ] as const;
 
+const MATERIAL_TYPES_ONLY = [RecipeType.MATERIAL_CRAFT] as const;
+
 const ALL_TYPES_WITH_MATERIALS = [
 	...ALL_TYPES,
 	RecipeType.MATERIAL_CRAFT
@@ -329,7 +331,7 @@ export const SLOT_CONFIGS: readonly SlotConfig[] = [
 	{
 		minLevel: 1,
 		maxLevel: 8,
-		eligibleTypes: ALL_TYPES_WITH_MATERIALS,
+		eligibleTypes: MATERIAL_TYPES_ONLY,
 		potionsOnly: false
 	},
 	{


### PR DESCRIPTION
Closes #4655

## Changement

`SLOT_CONFIGS[2].eligibleTypes` passe de `ALL_TYPES_WITH_MATERIALS` à un nouveau `MATERIAL_TYPES_ONLY` : le **slot 3 du four devient dédié aux recettes de matériaux**, comme le slot 4 l'est déjà aux potions via `potionsOnly`.

Les matériaux restent aussi proposables sur le slot 5, qui garde tous les types.

## Pourquoi

Les recettes `MATERIAL_CRAFT` représentent 30 des 98 recettes du jeu (31 %) mais n'occupaient que **2 à 5 % des slots proposés**, noyées dans un cycle de 11 types sur les slots 3 et 5.

## Impact mesuré

Simulé avec l'[explorateur des slots de cuisine](https://crownicles.github.io/Tools/generators/cooking-slot-explorer.html) sur 60 jours × 20 positions de four :

| Profil | Matériaux | Potions | Nourriture | Slot 3 vide | Recettes distinctes |
|---|---|---|---|---|---|
| Débutant (cuisine 5, 3 slots) | 4,9 % → **33,3 %** | 95,1 % → 66,7 % | — | 0 % | 29 → 13 |
| Intermédiaire (cuisine 25, 4 slots) | 2,2 % → **25,0 %** | 70,7 % → 57,0 % | 27,1 % → 18,0 % | 0 % | 58 → 52 |
| Avancé (cuisine 60, 5 slots) | 3,6 % → **21,8 %** | 67,4 % → 56,5 % | 29,0 % → 21,8 % | 0 % | 81 → 81 |
| Endgame (cuisine 95, 5 slots) | 3,6 % → **21,8 %** | 67,4 % → 56,5 % | 29,0 % → 21,8 % | 0 % | 98 → 98 |

## Risques écartés

- **Slot 3 jamais vide** : le slot accepte les niveaux 1 à 8 et 6 recettes de matériaux sont connues par défaut (niveaux 3 à 5). Vérifié sur 6 seeds × 20 positions avec un joueur ne connaissant que les recettes par défaut.
- **Garantie « niveau joueur » intacte** : les recettes de matériaux commencent au niveau 3, au-dessus du `maxRecipeLevelWithoutPenalty` des premiers grades, donc le slot 3 n'est jamais consommé par la passe de garantie aux bas grades. Les tests existants sur `MIN_GUARANTEED_PLAYER_LEVEL_RECIPES` passent sans modification.
- **Pas de doublon entre slots** : les tests d'unicité existants passent.

## Point d'attention (hors scope)

Le profil débutant passe de 29 à 13 recettes distinctes vues. La cause n'est pas ce changement mais une interaction existante : au grade `kitchenHelper`, la garantie verrouille les slots 1 et 2 sur les recettes de niveau ≤ 2, dont un débutant ne connaît que 5. Le slot 3 était sa seule source de variété. Détaillé dans #4655 pour un traitement séparé.

## Tests

- Nouveau test : le slot dédié aux matériaux propose toujours une recette `MATERIAL_CRAFT`, même avec les seules recettes par défaut (6 seeds × 20 positions).
- `pnpm eslint` vert sur Core et Lib.
- `pnpm test` vert : Core 1566, Lib 580, Discord 261.
