### PR TITLE
Fix campaign recipe unlock after chained missions

### DIFF
--- a/Core/__tests__/core/missions/CampaignCompletion.test.ts
+++ b/Core/__tests__/core/missions/CampaignCompletion.test.ts
@@ -113,13 +113,13 @@ describe("Campaign.completeCampaignMissions", () => {
 	 * Creates a mock PlayerMissionsInfo
 	 */
 	function createMockMissionInfo(overrides: Partial<{
-		campaignBlob: string;
+		campaignBlob: string | null;
 		campaignProgression: number;
 	}> = {}): PlayerMissionsInfo {
 		const info = Object.create(PlayerMissionsInfo.prototype);
 		Object.assign(info, {
 			playerId: 1,
-			campaignBlob: overrides.campaignBlob ?? "000", // 3 missions, none completed
+			campaignBlob: overrides.campaignBlob !== undefined ? overrides.campaignBlob : "000", // 3 missions, none completed
 			campaignProgression: overrides.campaignProgression ?? 1, // Currently on mission 1
 			save: vi.fn().mockResolvedValue(undefined)
 		});
@@ -231,6 +231,27 @@ describe("Campaign.completeCampaignMissions", () => {
 			expect(result).toHaveLength(1);
 			expect(missionInfo.campaignBlob).toBe("111");
 			expect(getMissionInfoSpy).not.toHaveBeenCalled();
+		});
+
+		it("should initialize a null campaign blob before marking a mission complete", async () => {
+			const campaign = createMockCampaignSlot({
+				missionId: "earnLifePoints",
+				numberDone: 100,
+				missionObjective: 100
+			});
+			const missionInfo = createMockMissionInfo({
+				campaignBlob: null,
+				campaignProgression: 1
+			});
+			vi.spyOn(MissionSlots, "getCampaignOfPlayer").mockResolvedValue(campaign);
+			vi.spyOn(MissionsController, "getMissionInterface").mockReturnValue({
+				initialNumberDone: vi.fn().mockResolvedValue(0)
+			} as never);
+
+			const result = await Campaign.updatePlayerCampaign(true, player, missionInfo);
+
+			expect(result).toHaveLength(1);
+			expect(missionInfo.campaignBlob).toBe(`1${"0".repeat(CAMPAIGN_MISSIONS.length - 1)}`);
 		});
 
 		it("should record completion and advance progression for a single completed mission", async () => {

--- a/Core/__tests__/core/missions/CampaignCompletion.test.ts
+++ b/Core/__tests__/core/missions/CampaignCompletion.test.ts
@@ -4,8 +4,8 @@ import {
 import { Campaign } from "../../../src/core/missions/Campaign";
 import { MissionsController } from "../../../src/core/missions/MissionsController";
 import Player from "../../../src/core/database/game/models/Player";
-import { MissionSlot } from "../../../src/core/database/game/models/MissionSlot";
-import { PlayerMissionsInfo } from "../../../src/core/database/game/models/PlayerMissionsInfo";
+import { MissionSlot, MissionSlots } from "../../../src/core/database/game/models/MissionSlot";
+import { PlayerMissionsInfo, PlayerMissionsInfos } from "../../../src/core/database/game/models/PlayerMissionsInfo";
 import { CampaignData, CampaignMission } from "../../../src/data/Campaign";
 
 // Mock crowniclesInstance (required by Campaign for logging)
@@ -212,6 +212,27 @@ describe("Campaign.completeCampaignMissions", () => {
 	});
 
 	describe("Normal completion: completedCampaign=true", () => {
+		it("should use the locked mission info passed by the mission controller", async () => {
+			const campaign = createMockCampaignSlot({
+				missionId: "findItem",
+				missionVariant: 1,
+				numberDone: 3,
+				missionObjective: 3
+			});
+			const missionInfo = createMockMissionInfo({
+				campaignBlob: "110",
+				campaignProgression: 3
+			});
+			vi.spyOn(MissionSlots, "getCampaignOfPlayer").mockResolvedValue(campaign);
+			const getMissionInfoSpy = vi.spyOn(PlayerMissionsInfos, "getOfPlayer");
+
+			const result = await Campaign.updatePlayerCampaign(true, player, missionInfo);
+
+			expect(result).toHaveLength(1);
+			expect(missionInfo.campaignBlob).toBe("111");
+			expect(getMissionInfoSpy).not.toHaveBeenCalled();
+		});
+
 		it("should record completion and advance progression for a single completed mission", async () => {
 			const campaign = createMockCampaignSlot({
 				missionId: "earnLifePoints",

--- a/Core/src/core/missions/Campaign.ts
+++ b/Core/src/core/missions/Campaign.ts
@@ -2,12 +2,13 @@
 import MissionSlot, { MissionSlots } from "../database/game/models/MissionSlot";
 import { MissionsController } from "./MissionsController";
 import Player from "../database/game/models/Player";
-import PlayerMissionsInfo, { PlayerMissionsInfos } from "../database/game/models/PlayerMissionsInfo";
+import PlayerMissionsInfo from "../database/game/models/PlayerMissionsInfo";
 import { crowniclesInstance } from "../../app";
 import { CampaignData } from "../../data/Campaign";
 import {
 	CompletedMission, MissionType
 } from "../../../../Lib/src/types/CompletedMission";
+import { Locked } from "../../../../Lib/src/locks/withLockedEntities";
 
 export class Campaign {
 	private static maxCampaignCache = -1;
@@ -38,7 +39,7 @@ export class Campaign {
 		return campaignBlob.indexOf("0");
 	}
 
-	public static async completeCampaignMissions(player: Player, missionInfo: PlayerMissionsInfo, completedCampaign: boolean, campaign: MissionSlot): Promise<CompletedMission[]> {
+	public static async completeCampaignMissions(player: Locked<Player>, missionInfo: Locked<PlayerMissionsInfo>, completedCampaign: boolean, campaign: MissionSlot): Promise<CompletedMission[]> {
 		if (!completedCampaign) {
 			return [];
 		}
@@ -78,14 +79,13 @@ export class Campaign {
 		return completedMissions;
 	}
 
-	public static async updatePlayerCampaign(completedCampaign: boolean, player: Player): Promise<CompletedMission[]> {
+	public static async updatePlayerCampaign(completedCampaign: boolean, player: Locked<Player>, missionInfo: Locked<PlayerMissionsInfo>): Promise<CompletedMission[]> {
 		if (!completedCampaign) {
 			return [];
 		}
 		const campaign = await MissionSlots.getCampaignOfPlayer(player.id);
-		const missionsInfo = await PlayerMissionsInfos.getOfPlayer(player.id);
-		if (Campaign.hasNextCampaign(missionsInfo.campaignBlob)) {
-			return this.completeCampaignMissions(player, missionsInfo, completedCampaign, campaign);
+		if (Campaign.hasNextCampaign(missionInfo.getCampaignBlob())) {
+			return this.completeCampaignMissions(player, missionInfo, completedCampaign, campaign);
 		}
 		return [];
 	}

--- a/Core/src/core/missions/Campaign.ts
+++ b/Core/src/core/missions/Campaign.ts
@@ -53,7 +53,8 @@ export class Campaign {
 				pointsToWin: 0, // Campaign doesn't give points
 				petRewardTypeId: currentCampaignData?.petRewardTypeId
 			});
-			missionInfo.campaignBlob = `${missionInfo.campaignBlob.slice(0, missionInfo.campaignProgression - 1)}1${missionInfo.campaignBlob.slice(missionInfo.campaignProgression)}`;
+			const campaignBlob = missionInfo.getCampaignBlob();
+			missionInfo.campaignBlob = `${campaignBlob.slice(0, missionInfo.campaignProgression - 1)}1${campaignBlob.slice(missionInfo.campaignProgression)}`;
 			missionInfo.campaignProgression = this.hasNextCampaign(missionInfo.campaignBlob) ? this.findNextCampaignIndex(missionInfo.campaignBlob) + 1 : 0;
 			crowniclesInstance.logsDatabase.logMissionCampaignProgress(player.keycloakId, missionInfo.campaignProgression)
 				.then();

--- a/Core/src/core/missions/MissionsController.ts
+++ b/Core/src/core/missions/MissionsController.ts
@@ -167,7 +167,7 @@ export abstract class MissionsController {
 		dailyMission: DailyMission
 	): Promise<Player> {
 		assertUnderLock("MissionsController.checkCompletedMissionsUnderLock");
-		const completedMissions = await MissionsController.completeAndUpdateMissionsUnderLock(player, missionSlots, specialMissionCompletion, dailyMission);
+		const completedMissions = await MissionsController.completeAndUpdateMissionsUnderLock(player, missionSlots, missionInfo, specialMissionCompletion, dailyMission);
 		if (completedMissions.length === 0) {
 			return player;
 		}
@@ -483,12 +483,13 @@ export abstract class MissionsController {
 	static async completeAndUpdateMissionsUnderLock(
 		player: Locked<Player>,
 		missionSlots: MissionSlot[],
+		missionInfo: Locked<PlayerMissionsInfo>,
 		specialMissionCompletion: SpecialMissionCompletion,
 		dailyMission: DailyMission
 	): Promise<CompletedMission[]> {
 		assertUnderLock("MissionsController.completeAndUpdateMissionsUnderLock");
 		const completedMissions: CompletedMission[] = [];
-		completedMissions.push(...await Campaign.updatePlayerCampaign(specialMissionCompletion.campaign, player));
+		completedMissions.push(...await Campaign.updatePlayerCampaign(specialMissionCompletion.campaign, player, missionInfo));
 		for (const mission of missionSlots.filter(mission => mission.isCompleted() && !mission.isCampaign())) {
 			completedMissions.push({
 				...mission.toJSON(),


### PR DESCRIPTION
Fixes #4793

## Summary

Fixes the missing cooking recipe notification when campaign missions are completed in a chain. The campaign completion flow now reuses the locked `PlayerMissionsInfo` instance instead of refetching a stale row, so the recipe milestone is evaluated against the updated campaign blob.

## Validation

- Added a regression test covering the locked mission info instance
- Core typecheck passes
- Core ESLint passes
- Core tests pass: 120 files, 1600 tests
- Recipe progression tests pass