### PR TITLE
Prevent Discord Gateway session quota exhaustion

### DIFF
--- a/Discord/__tests__/utils/ShardSpawnRetryUtils.test.ts
+++ b/Discord/__tests__/utils/ShardSpawnRetryUtils.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from "vitest";
+import {getShardSpawnRetryDelay} from "../../src/utils/ShardSpawnRetryUtils";
+
+describe("getShardSpawnRetryDelay", () => {
+	it("waits for the Gateway session reset when the quota is exhausted", () => {
+		expect(getShardSpawnRetryDelay({
+			attempt: 1,
+			requiredSessions: 1,
+			sessionStartLimit: {
+				total: 1_000,
+				remaining: 0,
+				reset_after: 120_000,
+				max_concurrency: 1
+			},
+			jitterMs: 1_500
+		})).toBe(121_500);
+	});
+
+	it("uses exponential backoff while sessions remain available", () => {
+		expect(getShardSpawnRetryDelay({
+			attempt: 1,
+			requiredSessions: 1,
+			sessionStartLimit: {
+				total: 1_000,
+				remaining: 10,
+				reset_after: 120_000,
+				max_concurrency: 1
+			},
+			jitterMs: 0
+		})).toBe(5_000);
+		expect(getShardSpawnRetryDelay({
+			attempt: 3,
+			requiredSessions: 1,
+			sessionStartLimit: undefined,
+			jitterMs: 250
+		})).toBe(20_250);
+	});
+
+	it("caps exponential backoff", () => {
+		expect(getShardSpawnRetryDelay({
+			attempt: 20,
+			requiredSessions: 1,
+			sessionStartLimit: undefined,
+			jitterMs: 500
+		})).toBe(300_500);
+	});
+});

--- a/Discord/__tests__/utils/ShardSpawnSupervisor.test.ts
+++ b/Discord/__tests__/utils/ShardSpawnSupervisor.test.ts
@@ -1,0 +1,159 @@
+import {
+	afterEach, beforeEach, describe, expect, it, vi
+} from "vitest";
+
+const {
+	loggerError, loggerErrorWithObj, loggerWarn, restGet
+} = vi.hoisted(() => ({
+	loggerError: vi.fn(),
+	loggerErrorWithObj: vi.fn(),
+	loggerWarn: vi.fn(),
+	restGet: vi.fn()
+}));
+
+vi.mock("discord.js", () => ({
+	REST: class {
+		public setToken(): this {
+			return this;
+		}
+
+		public get(...args: unknown[]): Promise<unknown> {
+			return restGet(...args);
+		}
+	}
+}));
+
+vi.mock("../../../Lib/src/logs/CrowniclesLogger", () => ({
+	CrowniclesLogger: {
+		error: loggerError,
+		errorWithObj: loggerErrorWithObj,
+		warn: loggerWarn
+	}
+}));
+
+import type { Shard } from "discord.js";
+import { ShardSpawnSupervisor } from "../../src/utils/ShardSpawnSupervisor";
+
+interface FakeShardOptions {
+	process?: { pid: number } | null;
+	worker?: { threadId: number } | null;
+}
+
+function createShard({
+	process = null,
+	worker = null
+}: FakeShardOptions = {}): Shard {
+	return {
+		id: 0,
+		process,
+		worker,
+		kill: vi.fn(),
+		spawn: vi.fn(),
+		on: vi.fn().mockReturnThis()
+	} as unknown as Shard;
+}
+
+function getAvailableSessionLimit(): object {
+	return {
+		session_start_limit: {
+			total: 1_000,
+			remaining: 10,
+			reset_after: 120_000,
+			max_concurrency: 1
+		}
+	};
+}
+
+describe("ShardSpawnSupervisor", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		restGet.mockReset();
+		loggerError.mockReset();
+		loggerErrorWithObj.mockReset();
+		loggerWarn.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("does not try to kill an already dead shard", () => {
+		const shard = createShard();
+		const supervisor = new ShardSpawnSupervisor("token");
+
+		expect(supervisor.killIntentionally(shard)).toBe(true);
+		expect(shard.kill).not.toHaveBeenCalled();
+	});
+
+	it("cleans up a live shard without querying the Gateway", () => {
+		const shard = createShard({ process: { pid: 123 } });
+		const supervisor = new ShardSpawnSupervisor("token");
+
+		expect(supervisor.killIntentionally(shard)).toBe(true);
+		expect(shard.kill).toHaveBeenCalledOnce();
+		expect(restGet).not.toHaveBeenCalled();
+	});
+
+	it("retries a failed spawn after bounded backoff", async () => {
+		restGet.mockResolvedValue(getAvailableSessionLimit());
+		const shard = createShard();
+		shard.spawn = vi.fn().mockResolvedValue({});
+		const supervisor = new ShardSpawnSupervisor("token");
+
+		supervisor.handleSpawnFailure(shard);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(restGet).toHaveBeenCalledOnce();
+		expect(shard.spawn).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(shard.spawn).toHaveBeenCalledOnce();
+	});
+
+	it("waits for the Gateway reset before retrying an exhausted quota", async () => {
+		restGet.mockResolvedValue({
+			session_start_limit: {
+				total: 1_000,
+				remaining: 0,
+				reset_after: 60_000,
+				max_concurrency: 1
+			}
+		});
+		const shard = createShard();
+		shard.spawn = vi.fn().mockResolvedValue({});
+		const supervisor = new ShardSpawnSupervisor("token");
+
+		supervisor.handleSpawnFailure(shard);
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(59_999);
+		expect(shard.spawn).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(shard.spawn).toHaveBeenCalledOnce();
+	});
+
+	it("cancels a pending retry when a shard is replaced", async () => {
+		restGet.mockResolvedValue(getAvailableSessionLimit());
+		const shard = createShard();
+		shard.spawn = vi.fn().mockResolvedValue({});
+		const supervisor = new ShardSpawnSupervisor("token");
+
+		supervisor.handleSpawnFailure(shard);
+		await vi.advanceTimersByTimeAsync(0);
+		supervisor.cancelRetry(shard.id);
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		expect(shard.spawn).not.toHaveBeenCalled();
+	});
+
+	it("kills a still-running process after a spawn timeout", () => {
+		const shard = createShard({ process: { pid: 123 } });
+		const supervisor = new ShardSpawnSupervisor("token");
+
+		supervisor.handleSpawnFailure(shard);
+
+		expect(shard.kill).toHaveBeenCalledOnce();
+		expect(restGet).not.toHaveBeenCalled();
+	});
+});

--- a/Discord/src/index.ts
+++ b/Discord/src/index.ts
@@ -11,13 +11,14 @@ import { connect } from "mqtt";
 import { MqttConstants } from "../../Lib/src/constants/MqttConstants";
 import { MqttTopicUtils } from "../../Lib/src/utils/MqttTopicUtils";
 import { DiscordConstants } from "./DiscordConstants";
+import { ShardSpawnSupervisor } from "./utils/ShardSpawnSupervisor";
 
 const shardCount = "auto";
 
 // As shardingManager overrides old shards with the same IDs, we need to keep track of the spawned shards
 let spawnedShards: Shard[] = [];
 
-function startShardingManagerMqtt(config: CrowniclesConfig, shardingManager: ShardingManager): void {
+function startShardingManagerMqtt(config: CrowniclesConfig, shardingManager: ShardingManager, shardSpawnSupervisor: ShardSpawnSupervisor): void {
 	const mqttClient = connect(discordConfig.MQTT_HOST, {
 		connectTimeout: MqttConstants.CONNECTION_TIMEOUT
 	});
@@ -42,6 +43,7 @@ function startShardingManagerMqtt(config: CrowniclesConfig, shardingManager: Sha
 					const pid = shard.process!.pid;
 					CrowniclesLogger.info(`Killing shard ${shardId} with PID ${pid}...`);
 					try {
+						shardSpawnSupervisor.ignoreDeath(shard);
 						shard.kill();
 						CrowniclesLogger.info(`Shard ${shardId} with PID ${pid} killed`);
 					}
@@ -85,17 +87,22 @@ function main(): void {
 
 	const shardingManager = new ShardingManager("./dist/Discord/src/bot/CrowniclesShard.js", {
 		totalShards: shardCount,
+		respawn: false,
 
 		// Needed as in auto mode it has to make a request to know the needed number of shards
 		token: config.DISCORD_CLIENT_TOKEN
 	});
+	const shardSpawnSupervisor = new ShardSpawnSupervisor(config.DISCORD_CLIENT_TOKEN);
 
-	startShardingManagerMqtt(config, shardingManager);
+	startShardingManagerMqtt(config, shardingManager, shardSpawnSupervisor);
 
 	shardingManager.on("shardCreate", shard => {
+		shardSpawnSupervisor.watch(shard);
 		shard.on("ready", () => CrowniclesLogger.info("Shard connected to Discord's Gateway"));
 		shard.on("spawn", () => {
-			spawnedShards.push(shard);
+			if (!spawnedShards.includes(shard)) {
+				spawnedShards.push(shard);
+			}
 			CrowniclesLogger.info(`Shard ${shard.id} created`);
 			shard.send({
 				type: "shardId",
@@ -106,7 +113,6 @@ function main(): void {
 			})
 				.then();
 		});
-		shard.on("death", () => CrowniclesLogger.error(`Shard ${shard.id} exited`));
 		shard.on("disconnect", () => {
 			/*
 			 * Recreate the shard because it often creates duplications

--- a/Discord/src/index.ts
+++ b/Discord/src/index.ts
@@ -36,37 +36,44 @@ function startShardingManagerMqtt(config: CrowniclesConfig, shardingManager: Sha
 			const messageParts = messageString.split(":");
 			const shardId = parseInt(messageParts[1], 10);
 			CrowniclesLogger.info(`Shard ${shardId} is duplicated, killing all its instances`);
+			let canReplaceShards = true;
+			shardSpawnSupervisor.cancelRetry(shardId);
 
 			// Kill all shards with the same ID
-			spawnedShards.forEach(shard => {
-				if (shard.id === shardId) {
-					const pid = shard.process!.pid;
-					CrowniclesLogger.info(`Killing shard ${shardId} with PID ${pid}...`);
-					try {
-						shardSpawnSupervisor.ignoreDeath(shard);
-						shard.kill();
-						CrowniclesLogger.info(`Shard ${shardId} with PID ${pid} killed`);
-					}
-					catch (e) {
-						CrowniclesLogger.errorWithObj(`Error while killing shard ${shardId} with PID ${pid}. Kill the whole process to clean everything up.`, e);
-						process.exit(1);
-					}
+			spawnedShards.filter(shard => shard.id === shardId).forEach(shard => {
+				if (!shard.process && !shard.worker) {
+					return;
+				}
+
+				CrowniclesLogger.info(`Killing shard ${shardId}...`);
+				if (shardSpawnSupervisor.killIntentionally(shard)) {
+					CrowniclesLogger.info(`Shard ${shardId} killed`);
+				}
+				else {
+					canReplaceShards = false;
 				}
 			});
+			if (!canReplaceShards) {
+				CrowniclesLogger.error(`Unable to replace duplicated shard ${shardId}; keeping the current instances`);
+				return;
+			}
 
 			// Clean up spawned shards
 			spawnedShards = spawnedShards.filter(shard => shard.id !== shardId);
 
 			// Create a new shard with the same ID
 			CrowniclesLogger.info(`Creating a new shard ${shardId}...`);
+			let newShard: Shard | undefined;
 			try {
-				const newShard = shardingManager.createShard(shardId);
+				newShard = shardingManager.createShard(shardId);
 				await newShard.spawn();
 				CrowniclesLogger.info(`New shard ${shardId} created`);
 			}
 			catch (e) {
-				CrowniclesLogger.errorWithObj(`Error while creating shard ${shardId}. Kill the whole process to clean everything up.`, e);
-				process.exit(1);
+				CrowniclesLogger.errorWithObj(`Error while creating shard ${shardId}`, e);
+				if (newShard) {
+					shardSpawnSupervisor.handleSpawnFailure(newShard);
+				}
 			}
 		}
 	});
@@ -99,6 +106,9 @@ function main(): void {
 	shardingManager.on("shardCreate", shard => {
 		shardSpawnSupervisor.watch(shard);
 		shard.on("ready", () => CrowniclesLogger.info("Shard connected to Discord's Gateway"));
+		shard.on("death", () => {
+			spawnedShards = spawnedShards.filter(spawnedShard => spawnedShard !== shard);
+		});
 		shard.on("spawn", () => {
 			if (!spawnedShards.includes(shard)) {
 				spawnedShards.push(shard);

--- a/Discord/src/utils/ShardSpawnRetryUtils.ts
+++ b/Discord/src/utils/ShardSpawnRetryUtils.ts
@@ -1,0 +1,28 @@
+import type { APIGatewaySessionStartLimit } from "discord-api-types/v10";
+
+const SHARD_SPAWN_RETRY_INITIAL_DELAY_MS = 5_000;
+const SHARD_SPAWN_RETRY_MAX_DELAY_MS = 5 * 60 * 1_000;
+
+export interface ShardSpawnRetryOptions {
+	attempt: number;
+	requiredSessions: number;
+	sessionStartLimit?: APIGatewaySessionStartLimit;
+	jitterMs: number;
+}
+
+export function getShardSpawnRetryDelay({
+	attempt,
+	requiredSessions,
+	sessionStartLimit,
+	jitterMs
+}: ShardSpawnRetryOptions): number {
+	const safeAttempt = Math.max(1, Math.floor(attempt));
+	const safeJitterMs = Math.max(0, jitterMs);
+
+	if (sessionStartLimit && sessionStartLimit.remaining < requiredSessions) {
+		return Math.max(0, sessionStartLimit.reset_after) + safeJitterMs;
+	}
+
+	const exponentialDelay = SHARD_SPAWN_RETRY_INITIAL_DELAY_MS * 2 ** (safeAttempt - 1);
+	return Math.min(exponentialDelay, SHARD_SPAWN_RETRY_MAX_DELAY_MS) + safeJitterMs;
+}

--- a/Discord/src/utils/ShardSpawnSupervisor.ts
+++ b/Discord/src/utils/ShardSpawnSupervisor.ts
@@ -2,7 +2,7 @@ import {
 	type APIGatewaySessionStartLimit, RESTGetAPIGatewayBotResult, Routes
 } from "discord-api-types/v10";
 import {
-	REST, Shard
+	REST, type Shard
 } from "discord.js";
 import { CrowniclesLogger } from "../../../Lib/src/logs/CrowniclesLogger";
 import { getShardSpawnRetryDelay } from "./ShardSpawnRetryUtils";
@@ -46,9 +46,41 @@ export class ShardSpawnSupervisor {
 		});
 	}
 
-	public ignoreDeath(shard: Shard): void {
+	public killIntentionally(shard: Shard): boolean {
 		this.clearRetry(shard.id);
+		if (!shard.process && !shard.worker) {
+			return true;
+		}
+
 		this.ignoredDeaths.add(shard);
+		try {
+			shard.kill();
+			return true;
+		}
+		catch (error) {
+			this.ignoredDeaths.delete(shard);
+			CrowniclesLogger.errorWithObj(`Error while intentionally killing shard ${shard.id}`, error);
+			return false;
+		}
+	}
+
+	public cancelRetry(shardId: number): void {
+		this.clearRetry(shardId);
+	}
+
+	public handleSpawnFailure(shard: Shard): void {
+		if (shard.process || shard.worker) {
+			try {
+				shard.kill();
+			}
+			catch (error) {
+				CrowniclesLogger.errorWithObj(`Error while cleaning up failed shard ${shard.id}`, error);
+			}
+		}
+
+		if (!shard.process && !shard.worker) {
+			void this.scheduleRetry(shard);
+		}
 	}
 
 	private clearRetry(shardId: number): void {
@@ -86,12 +118,7 @@ export class ShardSpawnSupervisor {
 				this.retryTimers.delete(shard.id);
 				void shard.spawn().catch(error => {
 					CrowniclesLogger.errorWithObj(`Error while respawning shard ${shard.id}`, error);
-					if (shard.process || shard.worker) {
-						shard.kill();
-					}
-					else {
-						void this.scheduleRetry(shard);
-					}
+					this.handleSpawnFailure(shard);
 				});
 			}, retryPlan.delayMs);
 			this.retryTimers.set(shard.id, retryTimer);

--- a/Discord/src/utils/ShardSpawnSupervisor.ts
+++ b/Discord/src/utils/ShardSpawnSupervisor.ts
@@ -1,0 +1,137 @@
+import {
+	type APIGatewaySessionStartLimit, RESTGetAPIGatewayBotResult, Routes
+} from "discord-api-types/v10";
+import {
+	REST, Shard
+} from "discord.js";
+import { CrowniclesLogger } from "../../../Lib/src/logs/CrowniclesLogger";
+import { getShardSpawnRetryDelay } from "./ShardSpawnRetryUtils";
+
+const REQUIRED_SESSIONS_PER_SHARD = 1;
+const SHARD_RETRY_JITTER_MAX_MS = 5_000;
+
+type ShardRetryReason = "Gateway session-start quota exhausted" | "bounded startup backoff";
+
+interface ShardRetryPlan {
+	delayMs: number;
+	reason: ShardRetryReason;
+}
+
+type ShardRetryTimer = ReturnType<typeof setTimeout>;
+
+export class ShardSpawnSupervisor {
+	private readonly rest: REST;
+
+	private readonly retryAttempts = new Map<number, number>();
+
+	private readonly pendingRetries = new Set<number>();
+
+	private readonly retryTimers = new Map<number, ShardRetryTimer>();
+
+	private readonly ignoredDeaths = new Set<Shard>();
+
+	public constructor(discordClientToken: string) {
+		this.rest = new REST({ version: "10" }).setToken(discordClientToken);
+	}
+
+	public watch(shard: Shard): void {
+		shard.on("ready", () => this.clearRetry(shard.id));
+		shard.on("death", () => {
+			if (this.ignoredDeaths.delete(shard)) {
+				return;
+			}
+
+			CrowniclesLogger.error(`Shard ${shard.id} exited`);
+			void this.scheduleRetry(shard);
+		});
+	}
+
+	public ignoreDeath(shard: Shard): void {
+		this.clearRetry(shard.id);
+		this.ignoredDeaths.add(shard);
+	}
+
+	private clearRetry(shardId: number): void {
+		const retryTimer = this.retryTimers.get(shardId);
+		if (retryTimer) {
+			clearTimeout(retryTimer);
+			this.retryTimers.delete(shardId);
+		}
+
+		this.pendingRetries.delete(shardId);
+		this.retryAttempts.delete(shardId);
+	}
+
+	private async scheduleRetry(shard: Shard): Promise<void> {
+		if (this.pendingRetries.has(shard.id) || this.retryTimers.has(shard.id)) {
+			return;
+		}
+
+		const attempt = (this.retryAttempts.get(shard.id) ?? 0) + 1;
+		this.retryAttempts.set(shard.id, attempt);
+		this.pendingRetries.add(shard.id);
+
+		try {
+			const retryPlan = await this.getRetryPlan(attempt);
+			if (this.retryAttempts.get(shard.id) !== attempt) {
+				this.pendingRetries.delete(shard.id);
+				return;
+			}
+
+			this.pendingRetries.delete(shard.id);
+			const retryAt = new Date(Date.now() + retryPlan.delayMs).toISOString();
+			CrowniclesLogger.warn(`Shard ${shard.id} retry scheduled at ${retryAt} (${retryPlan.reason}, attempt ${attempt})`);
+
+			const retryTimer = setTimeout(() => {
+				this.retryTimers.delete(shard.id);
+				void shard.spawn().catch(error => {
+					CrowniclesLogger.errorWithObj(`Error while respawning shard ${shard.id}`, error);
+					if (shard.process || shard.worker) {
+						shard.kill();
+					}
+					else {
+						void this.scheduleRetry(shard);
+					}
+				});
+			}, retryPlan.delayMs);
+			this.retryTimers.set(shard.id, retryTimer);
+		}
+		catch (error) {
+			this.pendingRetries.delete(shard.id);
+			CrowniclesLogger.errorWithObj(`Error while scheduling shard ${shard.id} retry`, error);
+		}
+	}
+
+	private async getRetryPlan(attempt: number): Promise<ShardRetryPlan> {
+		const sessionStartLimit = await this.getSessionStartLimit();
+		const quotaExhausted = sessionStartLimit !== undefined
+			&& sessionStartLimit.remaining < REQUIRED_SESSIONS_PER_SHARD;
+
+		return {
+			delayMs: getShardSpawnRetryDelay({
+				attempt,
+				requiredSessions: REQUIRED_SESSIONS_PER_SHARD,
+				sessionStartLimit,
+				jitterMs: this.getRetryJitterMs()
+			}),
+			reason: quotaExhausted
+				? "Gateway session-start quota exhausted"
+				: "bounded startup backoff"
+		};
+	}
+
+	private async getSessionStartLimit(): Promise<APIGatewaySessionStartLimit | undefined> {
+		try {
+			const gatewayInfo = await this.rest.get(Routes.gatewayBot()) as RESTGetAPIGatewayBotResult;
+			return gatewayInfo.session_start_limit;
+		}
+		catch (error) {
+			CrowniclesLogger.errorWithObj("Unable to fetch Discord Gateway session limit", error);
+			return undefined;
+		}
+	}
+
+	private getRetryJitterMs(): number {
+		return Math.floor(Math.random() * (SHARD_RETRY_JITTER_MAX_MS + 1));
+	}
+}


### PR DESCRIPTION
## Summary

- disable discord.js automatic shard respawning after a child process exits
- supervise failed shard startups with bounded exponential backoff
- query Discords Gateway session-start limit and wait for `reset_after` when the quota is exhausted
- preserve normal Gateway reconnects and ignore intentional shard kills used for duplicate cleanup
- avoid tracking the same shard object more than once
- add focused tests for quota-aware retry delays

Fixes #4805

## Validation

- `pnpm eslint` passed
- `pnpm test` passed: 26 test files, 268 tests
- `pnpm exec vitest run __tests__/utils/ShardSpawnRetryUtils.test.ts` passed
- `pnpm tsc --noEmit` reaches only the pre-existing `TS2589` error in `Discord/src/translations/i18n.ts:107`