### PR TITLE
Fix duplicate extension in Discord command imports

### DIFF
--- a/Discord/__tests__/utils/CommandDiscoveryUtils.test.ts
+++ b/Discord/__tests__/utils/CommandDiscoveryUtils.test.ts
@@ -1,7 +1,9 @@
 import {
 	describe, expect, it
 } from "vitest";
-import { isCommandModuleFile } from "../../src/commands/CommandDiscoveryUtils";
+import {
+	getCommandModuleImportPath, isCommandModuleFile
+} from "../../src/commands/CommandDiscoveryUtils";
 
 describe("isCommandModuleFile", () => {
 	it("accepts compiled command modules", () => {
@@ -14,5 +16,10 @@ describe("isCommandModuleFile", () => {
 
 	it("rejects source maps", () => {
 		expect(isCommandModuleFile("MissionShopCommand.js.map")).toBe(false);
+	});
+
+	it("uses the compiled command filename without adding another extension", () => {
+		expect(getCommandModuleImportPath("admin", "DeleteCodeCommand.js"))
+			.toBe("./admin/DeleteCodeCommand.js");
 	});
 });

--- a/Discord/src/commands/CommandDiscoveryUtils.ts
+++ b/Discord/src/commands/CommandDiscoveryUtils.ts
@@ -1,3 +1,7 @@
 export function isCommandModuleFile(fileName: string): boolean {
 	return fileName.endsWith("Command.js");
 }
+
+export function getCommandModuleImportPath(category: string, commandFile: string): string {
+	return `./${category}/${commandFile}`;
+}

--- a/Discord/src/commands/CommandsManager.ts
+++ b/Discord/src/commands/CommandsManager.ts
@@ -59,7 +59,9 @@ import {
 	setPendingDeletion,
 	verifyDeletionCode
 } from "../utils/AccountDeletionUtils";
-import { isCommandModuleFile } from "./CommandDiscoveryUtils";
+import {
+	getCommandModuleImportPath, isCommandModuleFile
+} from "./CommandDiscoveryUtils";
 import {
 	CHANNEL_PERMISSION_ERRORS, getThreadSendAccessError
 } from "./ChannelPermissionUtils";
@@ -335,7 +337,7 @@ export class CommandsManager {
 			commandsFiles = commandsFiles.filter(command => !command.startsWith("Test"));
 		}
 		for (const commandFile of commandsFiles) {
-			const commandInfo = (await import(`./${category}/${commandFile}.js`)).commandInfo as ICommand;
+			const commandInfo = (await import(getCommandModuleImportPath(category, commandFile))).commandInfo as ICommand;
 			if (!commandInfo?.slashCommandBuilder) {
 				CrowniclesLogger.error(`Command dist/Discord/src/commands/${category}/${commandFile} is not a slash command`);
 				continue;


### PR DESCRIPTION
## Summary

- stop appending `.js` to command filenames already returned by `readdirSync`
- centralize the compiled command import path construction
- add a regression test for `DeleteCodeCommand.js`

This fixes the `DeleteCodeCommand.js.js` startup failure introduced by the Crowdin-related change in #4799 and relates to #4805.

## Validation

- `pnpm eslint` passed
- `pnpm test` passed: 25 test files, 266 tests
- `pnpm tsc --noEmit` passed
- `pnpm start` launched successfully from the worktree
- `GET http://127.0.0.1:10124/health` returned `healthy` with `mqtt: true`