### PR TITLE
fix 6.0.3.a fight and weekly top regressions

### DIFF
--- a/Core/package.json
+++ b/Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_core",
-  "version": "6.0.3",
+  "version": "6.0.3.a",
   "description": "Core package of Crownicles which manages the game mechanics",
   "main": "src/main.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Discord/__tests__/commands/player/FightCommand.test.ts
+++ b/Discord/__tests__/commands/player/FightCommand.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/bot/CrowniclesShard", () => ({
+	keycloakConfig: {}
+}));
+
+import { buildFightConfirmationDescription } from "../../../src/commands/player/FightCommand";
+import { ReactionCollectorFightData } from "../../../../Lib/src/packets/interaction/ReactionCollectorFight";
+
+describe("buildFightConfirmationDescription", () => {
+	it("keeps glory numeric in the confirmation message", () => {
+		const data = {
+			playerStats: {
+				classId: 21,
+				fightRanking: { glory: 1869 },
+				energy: { value: 1869, max: 1869 },
+				attack: 549,
+				defense: 641,
+				speed: 512,
+				breath: { base: 17, max: 17, regen: 3 }
+			}
+		} satisfies ReactionCollectorFightData;
+
+		const description = buildFightConfirmationDescription("fr", "Jack", data, "common");
+
+		expect(description).not.toContain("NaN");
+		expect(description).toMatch(/1\D869/);
+	});
+});

--- a/Discord/__tests__/commands/player/TopCommand.test.ts
+++ b/Discord/__tests__/commands/player/TopCommand.test.ts
@@ -30,4 +30,19 @@ describe("top command packet", () => {
 		expect(getString).toHaveBeenCalledWith("duration");
 		expect(deferReply).toHaveBeenCalledOnce();
 	});
+
+	it("serializes the duration option with its localized name", () => {
+		const command = commandInfo.slashCommandBuilder.toJSON();
+		const scoreSubcommand = command.options?.find(option => option.name === "score");
+		if (!scoreSubcommand || !("options" in scoreSubcommand)) {
+			throw new Error("The score subcommand has no options");
+		}
+
+		const durationOption = scoreSubcommand.options?.find(option => option.name === "duration");
+
+		expect(durationOption).toMatchObject({
+			name: "duration",
+			name_localizations: { fr: "duree" }
+		});
+	});
 });

--- a/Discord/__tests__/commands/player/TopCommand.test.ts
+++ b/Discord/__tests__/commands/player/TopCommand.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/bot/CrowniclesShard", () => ({
+	keycloakConfig: {}
+}));
+
+import { commandInfo } from "../../../src/commands/player/TopCommand";
+import { CommandTopPacketReq } from "../../../../Lib/src/packets/commands/CommandTopPacket";
+import { TopDataType } from "../../../../Lib/src/types/TopDataType";
+import { TopTiming } from "../../../../Lib/src/types/TopTimings";
+
+describe("top command packet", () => {
+	it("reads the duration option for weekly score rankings", async () => {
+		const deferReply = vi.fn().mockResolvedValue(undefined);
+		const getString = vi.fn().mockReturnValue(TopTiming.WEEK);
+		const interaction = {
+			deferReply,
+			options: {
+				getSubcommand: vi.fn().mockReturnValue("score"),
+				getString,
+				getInteger: vi.fn().mockReturnValue(null)
+			}
+		};
+
+		const packet = await commandInfo.getPacket(interaction as never, {} as never);
+
+		expect(packet).toBeInstanceOf(CommandTopPacketReq);
+		expect(packet.dataType).toBe(TopDataType.SCORE);
+		expect(packet.timing).toBe(TopTiming.WEEK);
+		expect(getString).toHaveBeenCalledWith("duration");
+		expect(deferReply).toHaveBeenCalledOnce();
+	});
+});

--- a/Discord/package.json
+++ b/Discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_discord_middleware",
-  "version": "6.0.3",
+  "version": "6.0.3.a",
   "description": "Discord middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",

--- a/Discord/src/commands/player/FightCommand.ts
+++ b/Discord/src/commands/player/FightCommand.ts
@@ -11,7 +11,9 @@ import { DiscordCollectorUtils } from "../../utils/DiscordCollectorUtils";
 import { CrowniclesIcons } from "../../../../Lib/src/CrowniclesIcons";
 import { PacketUtils } from "../../utils/PacketUtils";
 import { CommandFightPacketReq } from "../../../../Lib/src/packets/commands/CommandFightPacket";
-import { ReactionCollectorFightPacket } from "../../../../Lib/src/packets/interaction/ReactionCollectorFight";
+import {
+	ReactionCollectorFightData, ReactionCollectorFightPacket
+} from "../../../../Lib/src/packets/interaction/ReactionCollectorFight";
 import { KeycloakUser } from "../../../../Lib/src/keycloak/KeycloakUser";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { FightConstants } from "../../../../Lib/src/constants/FightConstants";
@@ -49,6 +51,43 @@ import { deferFightInteraction } from "./FightInteractionUtils";
 
 const buggedFights = new Set<string>();
 
+type FightConfirmationSubTextKey = "common" | "rare";
+
+export function buildFightConfirmationDescription(
+	lng: Language,
+	pseudo: string,
+	data: ReactionCollectorFightData,
+	subTextKey: FightConfirmationSubTextKey
+): string {
+	return i18n.t("commands:fight.confirmDesc", {
+		lng,
+		pseudo,
+		confirmSubText: i18n.t(`commands:fight.confirmSubTexts.${subTextKey}`, { lng }),
+		glory: data.playerStats.fightRanking.glory,
+		className: i18n.t("commands:fight:information.class", {
+			lng,
+			id: data.playerStats.classId
+		}),
+		pet: data.playerStats.pet?.petTypeId
+			? i18n.t(data.playerStats.pet.isOnExpedition ? "commands:fight.petOnExpedition" : "commands:fight.pet", {
+				lng,
+				petInfo: PetUtils.petToShortString(lng, data.playerStats.pet.petNickname, data.playerStats.pet.petTypeId, data.playerStats.pet.petSex)
+			})
+			: "",
+		stats: i18n.t("commands:fight:information.stats", {
+			lng,
+			baseBreath: data.playerStats.breath.base,
+			breathRegen: data.playerStats.breath.regen,
+			cumulativeAttack: data.playerStats.attack,
+			cumulativeDefense: data.playerStats.defense,
+			cumulativeHealth: data.playerStats.energy.value,
+			cumulativeSpeed: data.playerStats.speed,
+			cumulativeMaxHealth: data.playerStats.energy.max,
+			maxBreath: data.playerStats.breath.max
+		})
+	});
+}
+
 /**
  * Mark a fight as bugged and request cancellation from the backend
  * @param context - Packet context
@@ -78,38 +117,12 @@ export async function createFightCollector(context: PacketContext, packet: React
 		lng,
 		pseudo: escapeUsername(interaction.user.displayName)
 	}), interaction.user)
-		.setDescription(
-			i18n.t("commands:fight.confirmDesc", {
-				lng,
-				pseudo: escapeUsername(interaction.user.displayName),
-				confirmSubText: i18n.t(`commands:fight.confirmSubTexts.${subTextKey}`, { lng }),
-				glory: i18n.t("commands:fight:information.glory", {
-					lng,
-					gloryPoints: data.playerStats.fightRanking.glory
-				}),
-				className: i18n.t("commands:fight:information.class", {
-					lng,
-					id: data.playerStats.classId
-				}),
-				pet: data.playerStats.pet?.petTypeId
-					? i18n.t(data.playerStats.pet.isOnExpedition ? "commands:fight.petOnExpedition" : "commands:fight.pet", {
-						lng,
-						petInfo: PetUtils.petToShortString(lng, data.playerStats.pet.petNickname, data.playerStats.pet.petTypeId, data.playerStats.pet.petSex)
-					})
-					: "",
-				stats: i18n.t("commands:fight:information.stats", {
-					lng,
-					baseBreath: data.playerStats.breath.base,
-					breathRegen: data.playerStats.breath.regen,
-					cumulativeAttack: data.playerStats.attack,
-					cumulativeDefense: data.playerStats.defense,
-					cumulativeHealth: data.playerStats.energy.value,
-					cumulativeSpeed: data.playerStats.speed,
-					cumulativeMaxHealth: data.playerStats.energy.max,
-					maxBreath: data.playerStats.breath.max
-				})
-			})
-		);
+		.setDescription(buildFightConfirmationDescription(
+			lng,
+			escapeUsername(interaction.user.displayName),
+			data,
+			subTextKey
+		));
 
 	return await DiscordCollectorUtils.createAcceptRefuseCollector(interaction, embed, packet, context, {
 		emojis: {

--- a/Discord/src/commands/player/TopCommand.ts
+++ b/Discord/src/commands/player/TopCommand.ts
@@ -39,7 +39,7 @@ async function getPacket(interaction: CrowniclesInteraction): Promise<CommandTop
 	await interaction.deferReply();
 
 	const subCommand = interaction.options.getSubcommand();
-	const timing = interaction.options.getString("timing") as TopTiming ?? TopTiming.ALL_TIME;
+	const timing = interaction.options.getString("duration") as TopTiming ?? TopTiming.ALL_TIME;
 	const page = interaction.options.getInteger("page") ?? undefined;
 
 	return makePacket(CommandTopPacketReq, {

--- a/Lib/package.json
+++ b/Lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_lib",
-  "version": "6.0.3",
+  "version": "6.0.3.a",
   "description": "Lib package of DaftBot, used my multiple module",
   "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402",
   "engines": {

--- a/RestWs/package.json
+++ b/RestWs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crownicles_rest_ws_middleware",
-  "version": "6.0.3",
+  "version": "6.0.3.a",
   "description": "Rest API middleware package of Crownicles",
   "main": "src/index.js",
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",


### PR DESCRIPTION
## Summary

Fix the two regressions planned for 6.0.3.a:

- Pass the raw numeric glory value to the fight confirmation translation so it no longer renders `NaN` after the i18next upgrade.
- Read the canonical `duration` option for `/top score`, so the weekly ranking uses `weeklyScore` instead of falling back to the all-time score.
- Bump Core, Discord, Lib and RestWs to `6.0.3.a`.
- Add focused regression tests for both behaviors.

Fixes #4808
Fixes #4810

## Validation

- Discord: 27 test suites, 268 tests passed.
- Focused Fight and Top regression tests passed.
- Discord and Core ESLint passed.
- Core and Lib typechecks passed.
- Full Discord typecheck remains blocked by the pre-existing `TS2589` error in `Discord/src/translations/i18n.ts` on `origin/develop`.