### PR TITLE
fix(report): release destination lock on persistence failure

### DIFF
--- a/Core/__tests__/core/report/ChooseDestinationDecision.test.ts
+++ b/Core/__tests__/core/report/ChooseDestinationDecision.test.ts
@@ -1,15 +1,28 @@
 import {
 	describe, expect, it, vi
 } from "vitest";
+import { BlockingConstants } from "../../../../Lib/src/constants/BlockingConstants";
 import { Constants } from "../../../../Lib/src/constants/Constants";
 import type { Player } from "../../../src/core/database/game/models/Player";
+import { PlayerSmallEvents } from "../../../src/core/database/game/models/PlayerSmallEvent";
 import type { MapLink } from "../../../src/data/MapLink";
+import { BlockingUtils } from "../../../src/core/utils/BlockingUtils";
 
 // Mock Maps so we can control whether the player is on the PvE island
 const isOnPveIslandMock = vi.fn();
+const getNextPlayerAvailableMapsMock = vi.fn();
+const startTravelMock = vi.fn();
 vi.mock("../../../src/core/maps/Maps", () => ({
 	Maps: {
-		isOnPveIsland: (player: Player) => isOnPveIslandMock(player)
+		isOnPveIsland: (player: Player) => isOnPveIslandMock(player),
+		getNextPlayerAvailableMaps: (player: Player) => getNextPlayerAvailableMapsMock(player),
+		startTravel: (player: Player, mapLink: MapLink, time: number) => startTravelMock(player, mapLink, time)
+	}
+}));
+
+vi.mock("../../../src/core/maps/MapCache", () => ({
+	MapCache: {
+		allPveMapLinks: [12]
 	}
 }));
 
@@ -23,8 +36,58 @@ vi.mock("../../../src/data/City", () => ({
 	}
 }));
 
+const getMapLinkByLocationsMock = vi.fn();
+vi.mock("../../../src/data/MapLink", () => ({
+	MapLinkDataController: {
+		instance: {
+			getLinkByLocations: (startMap: number, endMap: number) => getMapLinkByLocationsMock(startMap, endMap)
+		}
+	}
+}));
+
+const getMapLocationByIdMock = vi.fn();
+vi.mock("../../../src/data/MapLocation", () => ({
+	MapLocationDataController: {
+		instance: {
+			getById: (mapId: number) => getMapLocationByIdMock(mapId)
+		}
+	}
+}));
+
+vi.mock("../../../src/core/database/game/models/PlayerSmallEvent", () => ({
+	PlayerSmallEvents: {
+		removeSmallEventsOfPlayer: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/core/utils/BlockingUtils", () => ({
+	BlockingUtils: {
+		blockPlayerUntil: vi.fn(),
+		unblockPlayer: vi.fn()
+	}
+}));
+
+let capturedEndCallback: ((collector: { getFirstReaction: () => unknown }, response: unknown[]) => Promise<void>) | undefined;
+vi.mock("../../../src/core/utils/ReactionsCollector", () => ({
+	ReactionCollectorInstance: class {
+		constructor(_collector: unknown, _context: unknown, _options: unknown, endCallback: typeof capturedEndCallback) {
+			capturedEndCallback = endCallback;
+		}
+
+		block(): this {
+			return this;
+		}
+
+		build(): this {
+			return this;
+		}
+	}
+}));
+
 // Import after mocks so the module under test picks up the mocked deps
-const { canStayInCity, canAutoChooseDestination, mustForceStayInCity } = await import("../../../src/core/report/ReportDestinationService");
+const {
+	canStayInCity, canAutoChooseDestination, chooseDestination, mustForceStayInCity
+} = await import("../../../src/core/report/ReportDestinationService");
 
 const LAST_MAP_LINK = Constants.BEGINNING.LAST_MAP_LINK;
 
@@ -114,5 +177,49 @@ describe("canAutoChooseDestination", () => {
 	it("does not auto-choose with several destinations and no forced link", () => {
 		isOnPveIslandMock.mockReturnValue(false);
 		expect(canAutoChooseDestination(makePlayer(10, 6), null, [1, 2], false)).toBe(false);
+	});
+});
+
+describe("chooseDestination collector", () => {
+	it("releases the destination lock when travel persistence fails", async () => {
+		capturedEndCallback = undefined;
+		vi.clearAllMocks();
+		isOnPveIslandMock.mockReturnValue(true);
+		getNextPlayerAvailableMapsMock.mockReturnValue([2, 3]);
+		getMapLinkByLocationsMock.mockReturnValue({
+			id: 12, endMap: 2, tripDuration: 10
+		});
+		getMapLocationByIdMock.mockReturnValue({ type: "cavern" });
+		vi.mocked(PlayerSmallEvents.removeSmallEventsOfPlayer).mockResolvedValue(undefined);
+		startTravelMock.mockRejectedValue(new Error("Database connection timed out"));
+
+		const player = {
+			id: 1,
+			keycloakId: "destination-player",
+			mapLinkId: 1,
+			getDestinationId: (): number => 1,
+			getPreviousMapId: (): number => 0,
+			effectRemainingTime: (): number => 0
+		} as Player;
+
+		await chooseDestination({} as never, player, null, [], { allowStayInCity: false });
+
+		if (!capturedEndCallback) {
+			throw new Error("Expected destination collector callback to be set");
+		}
+
+		await expect(capturedEndCallback({
+			getFirstReaction: () => ({
+				reaction: {
+					type: "chooseDestination",
+					data: { mapId: 2 }
+				}
+			})
+		}, [])).rejects.toThrow("Database connection timed out");
+
+		expect(BlockingUtils.unblockPlayer).toHaveBeenCalledWith(
+			player.keycloakId,
+			BlockingConstants.REASONS.CHOOSE_DESTINATION
+		);
 	});
 });

--- a/Core/__tests__/core/report/ChooseDestinationDecision.test.ts
+++ b/Core/__tests__/core/report/ChooseDestinationDecision.test.ts
@@ -4,7 +4,6 @@ import {
 import { BlockingConstants } from "../../../../Lib/src/constants/BlockingConstants";
 import { Constants } from "../../../../Lib/src/constants/Constants";
 import type { Player } from "../../../src/core/database/game/models/Player";
-import { PlayerSmallEvents } from "../../../src/core/database/game/models/PlayerSmallEvent";
 import type { MapLink } from "../../../src/data/MapLink";
 import { BlockingUtils } from "../../../src/core/utils/BlockingUtils";
 
@@ -233,6 +232,56 @@ describe("chooseDestination collector", () => {
 		);
 	});
 
+	it("does not retry travel persistence when a query may have been sent", async () => {
+		capturedEndCallback = undefined;
+		vi.clearAllMocks();
+		isOnPveIslandMock.mockReturnValue(true);
+		getNextPlayerAvailableMapsMock.mockReturnValue([2, 3]);
+		getMapLinkByLocationsMock.mockReturnValue({
+			id: 12, endMap: 2, tripDuration: 10
+		});
+		getMapLocationByIdMock.mockReturnValue({ type: "cavern" });
+
+		const ambiguousConnectionTimeout = Object.assign(new Error("Connection timeout after a query was sent"), {
+			name: "SequelizeConnectionError",
+			parent: {
+				code: "ER_CONNECTION_TIMEOUT",
+				sql: "UPDATE players SET mapLinkId = ?"
+			}
+		});
+		startTravelMock.mockRejectedValue(ambiguousConnectionTimeout);
+
+		const player = {
+			id: 1,
+			keycloakId: "destination-player",
+			mapLinkId: 1,
+			getDestinationId: (): number => 1,
+			getPreviousMapId: (): number => 0,
+			effectRemainingTime: (): number => 0
+		} as Player;
+
+		await chooseDestination({} as never, player, null, [], { allowStayInCity: false });
+
+		if (!capturedEndCallback) {
+			throw new Error("Expected destination collector callback to be set");
+		}
+
+		await expect(capturedEndCallback({
+			getFirstReaction: () => ({
+				reaction: {
+					type: "chooseDestination",
+					data: { mapId: 2 }
+				}
+			})
+		}, [])).rejects.toBe(ambiguousConnectionTimeout);
+
+		expect(startTravelMock).toHaveBeenCalledTimes(1);
+		expect(BlockingUtils.unblockPlayer).toHaveBeenCalledWith(
+			player.keycloakId,
+			BlockingConstants.REASONS.CHOOSE_DESTINATION
+		);
+	});
+
 	it("releases the destination lock when travel persistence fails", async () => {
 		capturedEndCallback = undefined;
 		vi.clearAllMocks();
@@ -242,7 +291,6 @@ describe("chooseDestination collector", () => {
 			id: 12, endMap: 2, tripDuration: 10
 		});
 		getMapLocationByIdMock.mockReturnValue({ type: "cavern" });
-		vi.mocked(PlayerSmallEvents.removeSmallEventsOfPlayer).mockResolvedValue(undefined);
 		startTravelMock.mockRejectedValue(new Error("Database connection timed out"));
 
 		const player = {

--- a/Core/__tests__/core/report/ChooseDestinationDecision.test.ts
+++ b/Core/__tests__/core/report/ChooseDestinationDecision.test.ts
@@ -181,6 +181,58 @@ describe("canAutoChooseDestination", () => {
 });
 
 describe("chooseDestination collector", () => {
+	it("retries travel persistence after a connection setup timeout", async () => {
+		capturedEndCallback = undefined;
+		vi.clearAllMocks();
+		isOnPveIslandMock.mockReturnValue(true);
+		getNextPlayerAvailableMapsMock.mockReturnValue([2, 3]);
+		getMapLinkByLocationsMock.mockReturnValue({
+			id: 12, endMap: 2, tripDuration: 10
+		});
+		getMapLocationByIdMock.mockReturnValue({ type: "cavern" });
+
+		const connectionTimeout = Object.assign(new Error("Connection timeout: failed to create socket"), {
+			name: "SequelizeConnectionError",
+			parent: {
+				code: "ER_CONNECTION_TIMEOUT",
+				sql: null
+			}
+		});
+		startTravelMock
+			.mockRejectedValueOnce(connectionTimeout)
+			.mockResolvedValueOnce(undefined);
+
+		const player = {
+			id: 1,
+			keycloakId: "destination-player",
+			mapLinkId: 1,
+			getDestinationId: (): number => 1,
+			getPreviousMapId: (): number => 0,
+			effectRemainingTime: (): number => 0
+		} as Player;
+
+		await chooseDestination({} as never, player, null, [], { allowStayInCity: false });
+
+		if (!capturedEndCallback) {
+			throw new Error("Expected destination collector callback to be set");
+		}
+
+		await expect(capturedEndCallback({
+			getFirstReaction: () => ({
+				reaction: {
+					type: "chooseDestination",
+					data: { mapId: 2 }
+				}
+			})
+		}, [])).resolves.toBeUndefined();
+
+		expect(startTravelMock).toHaveBeenCalledTimes(2);
+		expect(BlockingUtils.unblockPlayer).toHaveBeenCalledWith(
+			player.keycloakId,
+			BlockingConstants.REASONS.CHOOSE_DESTINATION
+		);
+	});
+
 	it("releases the destination lock when travel persistence fails", async () => {
 		capturedEndCallback = undefined;
 		vi.clearAllMocks();

--- a/Core/src/core/report/ReportDestinationService.ts
+++ b/Core/src/core/report/ReportDestinationService.ts
@@ -37,6 +37,50 @@ type ChosenDestination = {
 	isGoingBack?: boolean;
 };
 
+const DESTINATION_TRAVEL_RETRY_DELAY_MS = 250;
+
+type MariaDbConnectionSetupError = {
+	code?: unknown;
+	sql?: unknown;
+};
+
+type SequelizeConnectionSetupError = Error & {
+	parent?: MariaDbConnectionSetupError;
+	original?: MariaDbConnectionSetupError;
+};
+
+/**
+ * `ER_CONNECTION_TIMEOUT` happens while the driver is establishing a socket,
+ * before an SQL statement is sent. Retrying this specific error is therefore
+ * safe; broader connection failures may have an ambiguous write outcome.
+ */
+function isRetryableConnectionSetupTimeout(error: unknown): boolean {
+	if (!(error instanceof Error) || error.name !== "SequelizeConnectionError") {
+		return false;
+	}
+
+	const sequelizeError = error as SequelizeConnectionSetupError;
+	const driverErrors = [sequelizeError.parent, sequelizeError.original];
+	return driverErrors.some(driverError => driverError?.code === "ER_CONNECTION_TIMEOUT" && driverError.sql === null);
+}
+
+async function startDestinationTravel(player: Player, newLink: MapLink, time: number): Promise<void> {
+	try {
+		await Maps.startTravel(player, newLink, time);
+	}
+	catch (error) {
+		if (!isRetryableConnectionSetupTimeout(error)) {
+			throw error;
+		}
+
+		if (CrowniclesLogger.isInitialized()) {
+			CrowniclesLogger.warn(`chooseDestination: retrying travel persistence after a transient database connection timeout for player ${player.id}`);
+		}
+		await new Promise(resolve => setTimeout(resolve, DESTINATION_TRAVEL_RETRY_DELAY_MS));
+		await Maps.startTravel(player, newLink, time);
+	}
+}
+
 /**
  * Add the appropriate destination response packet (city or regular) to the response
  */
@@ -73,7 +117,7 @@ async function automaticChooseDestination(forcedLink: MapLink | null, player: Pl
 	// Read before starting the travel: `startTravel` makes the current destination become the previous map.
 	const isGoingBack = newLink.endMap === player.getPreviousMapId();
 
-	await Maps.startTravel(player, newLink, Date.now());
+	await startDestinationTravel(player, newLink, Date.now());
 	addDestinationResToResponse(response, {
 		mapLink: newLink,
 		mapTypeId: endMap.type,
@@ -154,7 +198,7 @@ function sendDestinationCollector(
 				return;
 			}
 
-			await Maps.startTravel(player, newLink, Date.now());
+			await startDestinationTravel(player, newLink, Date.now());
 
 			addDestinationResToResponse(response, {
 				mapLink: newLink,

--- a/Core/src/core/report/ReportDestinationService.ts
+++ b/Core/src/core/report/ReportDestinationService.ts
@@ -133,36 +133,38 @@ function sendDestinationCollector(
 	const collector = new ReactionCollectorChooseDestination(mapReactions, stayInCityAllowed);
 
 	const endCallback: EndCallback = async (collector, response) => {
-		const firstReaction = collector.getFirstReaction();
+		try {
+			const firstReaction = collector.getFirstReaction();
 
-		// Doing nothing (timeout) or explicitly choosing it defaults to staying in the city when that option is offered.
-		const staysInCity = stayInCityAllowed
-			&& (!firstReaction || firstReaction.reaction.type === ReactionCollectorStayInCityReaction.name);
-		if (staysInCity) {
-			await applyStayInCity(player, response);
+			// Doing nothing (timeout) or explicitly choosing it defaults to staying in the city when that option is offered.
+			const staysInCity = stayInCityAllowed
+				&& (!firstReaction || firstReaction.reaction.type === ReactionCollectorStayInCityReaction.name);
+			if (staysInCity) {
+				await applyStayInCity(player, response);
+				return;
+			}
+
+			const mapId = firstReaction
+				? (firstReaction.reaction.data as ReactionCollectorChooseDestinationReaction).mapId
+				: RandomUtils.crowniclesRandom.pick(mapReactions).mapId;
+			const newLink = MapLinkDataController.instance.getLinkByLocations(player.getDestinationId()!, mapId);
+			const endMap = MapLocationDataController.instance.getById(mapId);
+			if (!newLink || !endMap) {
+				CrowniclesLogger.error(`No map link or location found for chosen destination ${player.getDestinationId()} -> ${mapId}`);
+				return;
+			}
+
+			await Maps.startTravel(player, newLink, Date.now());
+
+			addDestinationResToResponse(response, {
+				mapLink: newLink,
+				mapTypeId: endMap.type,
+				tripDuration: newLink.tripDuration ?? 0
+			});
+		}
+		finally {
 			BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.CHOOSE_DESTINATION);
-			return;
 		}
-
-		const mapId = firstReaction
-			? (firstReaction.reaction.data as ReactionCollectorChooseDestinationReaction).mapId
-			: RandomUtils.crowniclesRandom.pick(mapReactions).mapId;
-		const newLink = MapLinkDataController.instance.getLinkByLocations(player.getDestinationId()!, mapId);
-		const endMap = MapLocationDataController.instance.getById(mapId);
-		if (!newLink || !endMap) {
-			CrowniclesLogger.error(`No map link or location found for chosen destination ${player.getDestinationId()} -> ${mapId}`);
-			return;
-		}
-
-		await Maps.startTravel(player, newLink, Date.now());
-
-		addDestinationResToResponse(response, {
-			mapLink: newLink,
-			mapTypeId: endMap.type,
-			tripDuration: newLink.tripDuration ?? 0
-		});
-
-		BlockingUtils.unblockPlayer(player.keycloakId, BlockingConstants.REASONS.CHOOSE_DESTINATION);
 	};
 
 	const packet = new ReactionCollectorInstance(

--- a/Lib/src/database/Database.ts
+++ b/Lib/src/database/Database.ts
@@ -14,6 +14,7 @@ import TYPES = Transaction.TYPES;
 const DB_RETRY_MAX_ATTEMPTS = 10;
 const DB_RETRY_BASE_DELAY_MS = 1000;
 const DB_RETRY_MAX_DELAY_MS = 30000;
+const DB_CONNECT_TIMEOUT_MS = 5000;
 
 export abstract class Database {
 	/**
@@ -111,6 +112,10 @@ export abstract class Database {
 					host: this.databaseConfiguration.host,
 					port: this.databaseConfiguration.port,
 					logging: false,
+					dialectOptions: {
+						// mariadb defaults to one second, which is too short for transient production network stalls.
+						connectTimeout: DB_CONNECT_TIMEOUT_MS
+					},
 					transactionType: TYPES.IMMEDIATE
 				});
 				await sequelize.authenticate();


### PR DESCRIPTION
## Résumé

- libère systématiquement le blocage de choix de destination, y compris après une erreur de persistance
- ajoute des régressions couvrant un timeout de base de données pendant le départ, y compris l’absence de relance lorsqu’une requête SQL a pu être envoyée
- fixe explicitement le délai de connexion MariaDB à 5 s au lieu du défaut de 1 s
- réessaie une seule fois le départ après `ER_CONNECTION_TIMEOUT`, uniquement lorsque le pilote confirme qu’aucune requête SQL n’a été envoyée

## Vérifications

- `pnpm eslintFix && pnpm eslint` (Core)
- `pnpm test` (Core, 1 616 tests)
- `pnpm tsc` (Core)

Fixes #4820
Related #4823