### PR TITLE
fix(island): show guild points at maximum level

### DIFF
--- a/Core/__tests__/core/smallEvents/BonusGuildPVEIslandSmallEvent.test.ts
+++ b/Core/__tests__/core/smallEvents/BonusGuildPVEIslandSmallEvent.test.ts
@@ -6,6 +6,7 @@ import {
 	SmallEventBonusGuildPVEIslandPacket,
 	SmallEventBonusGuildPVEIslandResultType
 } from "../../../../Lib/src/packets/smallEvents/SmallEventBonusGuildPVEIslandPacket";
+import { Guild } from "../../../src/core/database/game/models/Guild";
 import { smallEventFuncs } from "../../../src/core/smallEvents/bonusGuildPVEIsland";
 import { Maps } from "../../../src/core/maps/Maps";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
@@ -52,6 +53,46 @@ describe("bonus guild PVE island small event", () => {
 		expect(response).toContainEqual(expect.objectContaining({
 			result: SmallEventBonusGuildPVEIslandResultType.LOSE,
 			emoteKey: SmallEventBonusGuildPVEIslandEmote.LOST_HEALTH
+		}));
+	});
+
+	it("awards guild points when the locked guild is already at max level", async () => {
+		const guild = {
+			isAtMaxLevel: vi.fn().mockReturnValue(true),
+			addExperience: vi.fn(),
+			addScore: vi.fn().mockResolvedValue(undefined),
+			save: vi.fn().mockResolvedValue(undefined)
+		};
+		vi.spyOn(Guild, "withLocked").mockImplementation(async (_guildId, callback) => await callback(guild as never));
+		vi.spyOn(Maps, "getGuildMembersOnPveIsland").mockResolvedValue([]);
+		vi.spyOn(SmallEventDataController.instance, "getById").mockReturnValue({
+			getProperties: () => ({
+				ranges: { expOrPointsGuild: { min: 25, max: 25 } },
+				events: [{
+					success: {
+						withGuild: "expOrPointsGuild",
+						solo: "experience"
+					}
+				}]
+			})
+		} as never);
+		vi.mocked(RandomUtils.randInt).mockReset();
+		vi.mocked(RandomUtils.randInt)
+			.mockReturnValueOnce(0)
+			.mockReturnValueOnce(0)
+			.mockReturnValueOnce(1)
+			.mockReturnValueOnce(25);
+		vi.spyOn(RandomUtils.crowniclesRandom, "bool").mockReturnValue(true);
+
+		const response: SmallEventBonusGuildPVEIslandPacket[] = [];
+		await smallEventFuncs.executeSmallEvent(response, player as never, {} as never, {} as never);
+
+		expect(Guild.withLocked).toHaveBeenCalledWith(player.guildId, expect.any(Function));
+		expect(guild.addExperience).not.toHaveBeenCalled();
+		expect(guild.addScore).toHaveBeenCalledWith(expect.objectContaining({ amount: 25 }));
+		expect(response).toContainEqual(expect.objectContaining({
+			isExperienceGain: false,
+			emoteKey: SmallEventBonusGuildPVEIslandEmote.GUILD_POINTS
 		}));
 	});
 });

--- a/Core/src/core/smallEvents/bonusGuildPVEIsland.ts
+++ b/Core/src/core/smallEvents/bonusGuildPVEIsland.ts
@@ -1,4 +1,4 @@
-/* @lockInherited — body runs under loadAndExecuteSmallEvents withLockedPlayerAndMissions callback. */
+/* @lockInherited — player write paths run under loadAndExecuteSmallEvents withLockedPlayerAndMissions; guild writes use Guild.withLocked. */
 import {
 	SmallEventDataController, SmallEventFuncs
 } from "../../data/SmallEvent";
@@ -16,7 +16,8 @@ import { Maps } from "../maps/Maps";
 import Player from "../database/game/models/Player";
 import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
 import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
-import { Guilds } from "../database/game/models/Guild";
+import { Guild } from "../database/game/models/Guild";
+import { LockedRowNotFoundError } from "../../../../Lib/src/locks/withLockedEntities";
 
 enum Outcome {
 	EXPERIENCE = "experience",
@@ -73,23 +74,33 @@ function getEmoteKey(rewardKind: Outcome, isExperienceGain: boolean): SmallEvent
 }
 
 async function manageGuildReward(response: CrowniclesPacket[], player: Player, result: RewardResult): Promise<void> {
-	const guild = await Guilds.getById(player.guildId);
-	if (!guild) {
+	if (!player.guildId) {
 		return;
 	}
-	if (guild.isAtMaxLevel()) {
-		result.isExperienceGain = false;
+
+	try {
+		await Guild.withLocked(player.guildId, async guild => {
+			if (guild.isAtMaxLevel()) {
+				result.isExperienceGain = false;
+			}
+			const params = {
+				amount: result.amount, response, reason: NumberChangeReason.SMALL_EVENT
+			};
+			if (result.isExperienceGain) {
+				await guild.addExperience(params);
+			}
+			else {
+				await guild.addScore(params);
+			}
+			await guild.save();
+		});
 	}
-	const params = {
-		amount: result.amount, response, reason: NumberChangeReason.SMALL_EVENT
-	};
-	if (result.isExperienceGain) {
-		await guild.addExperience(params);
+	catch (error) {
+		if (error instanceof LockedRowNotFoundError) {
+			return;
+		}
+		throw error;
 	}
-	else {
-		await guild.addScore(params);
-	}
-	await guild.save();
 }
 
 async function manageClassicReward(response: CrowniclesPacket[], player: Player, result: RewardResult, rewardKind: Outcome): Promise<void> {
@@ -143,7 +154,7 @@ async function applyPossibility(
 	}
 	return {
 		...result,
-		emoteKey: getEmoteKey(rewardKind, isExperienceGain)
+		emoteKey: getEmoteKey(rewardKind, result.isExperienceGain)
 	};
 }
 


### PR DESCRIPTION
## Résumé

- calcule la récompense de guilde à partir de son état verrouillé et actuel
- affiche des points de guilde quand la guilde est déjà au niveau maximum
- ajoute une régression couvrant ce scénario

## Vérifications

- `pnpm eslintFix && pnpm eslint` (Core)
- `pnpm test` (Core, 1 614 tests)
- `pnpm tsc` (Core)
- `pnpm test:integration` tenté ; MariaDB est indisponible dans cet environnement, les scénarios de concurrence ont été ignorés après timeout

Fixes #4819