### PR TITLE
fix(pet): weight food biome by travel progress

### DIFF
--- a/Core/__tests__/core/maps/TravelTime.test.ts
+++ b/Core/__tests__/core/maps/TravelTime.test.ts
@@ -4,6 +4,7 @@ import {MapLinkDataController} from '../../../src/data/MapLink';
 import {PVEConstants} from '../../../../Lib/src/constants/PVEConstants';
 import {Constants} from '../../../../Lib/src/constants/Constants';
 import {PlayerSmallEvents} from '../../../src/core/database/game/models/PlayerSmallEvent';
+import type Player from '../../../src/core/database/game/models/Player';
 import {RandomUtils} from '../../../../Lib/src/utils/RandomUtils';
 import {Maps} from '../../../src/core/maps/Maps';
 import {TravelTime} from '../../../src/core/maps/TravelTime';
@@ -62,6 +63,19 @@ describe('TravelTime', () => {
 		expect(data.effectEndTime).toBe(start + effectDurationMs);
 		expect(data.playerTravelledTime).toBe((date.valueOf() - start) - effectDurationMs);
 		expect(data.travelEndTime).toBe(start + effectDurationMs + 10 * 60_000);
+	});
+
+	it('calculates clamped travel progress', () => {
+		const player = {
+			startTravelDate: new Date(now),
+			effectEndDate: new Date(now),
+			effectDuration: 0,
+			mapLinkId: 5
+		} as Player;
+
+		expect(TravelTime.getTravelProgress(player, new Date(now - 60_000))).toBe(0);
+		expect(TravelTime.getTravelProgress(player, new Date(now + 5 * 60_000))).toBe(0.5);
+		expect(TravelTime.getTravelProgress(player, new Date(now + 15 * 60_000))).toBe(1);
 	});
 
 	it('gets travel data with small events', async () => {

--- a/Core/__tests__/core/smallEvents/PetFoodBiomeSelection.test.ts
+++ b/Core/__tests__/core/smallEvents/PetFoodBiomeSelection.test.ts
@@ -1,0 +1,63 @@
+import {
+	afterEach, beforeEach, describe, expect, it, vi
+} from "vitest";
+import { MapConstants } from "../../../../Lib/src/constants/MapConstants";
+import { MapLocationConstants } from "../../../../Lib/src/constants/MapLocationConstants";
+import { RandomUtils } from "../../../../Lib/src/utils/RandomUtils";
+import Player from "../../../src/core/database/game/models/Player";
+import { TravelTime } from "../../../src/core/maps/TravelTime";
+import { getFoodType } from "../../../src/core/smallEvents/petFood";
+import { MapLinkDataController } from "../../../src/data/MapLink";
+import { MapLocationDataController } from "../../../src/data/MapLocation";
+
+const player = { mapLinkId: 12 } as Player;
+const startMapId = MapConstants.LOCATIONS_IDS.ROAD_OF_WONDERS + 1;
+const endMapId = MapConstants.LOCATIONS_IDS.ROAD_OF_WONDERS + 2;
+
+describe("pet food biome selection", () => {
+	beforeEach(() => {
+		vi.spyOn(MapLinkDataController.instance, "getById").mockReturnValue({
+			id: player.mapLinkId,
+			startMap: startMapId,
+			endMap: endMapId
+		} as never);
+		vi.spyOn(MapLocationDataController.instance, "getById").mockImplementation(mapId => ({
+			id: mapId,
+			type: mapId === startMapId ? MapLocationConstants.TYPES.FOREST : MapLocationConstants.TYPES.RIVER
+		}) as never);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("uses the departure biome near the start of the journey", () => {
+		vi.spyOn(TravelTime, "getTravelProgress").mockReturnValue(0.2);
+		vi.spyOn(RandomUtils.crowniclesRandom, "realZeroToOneInclusive")
+			.mockReturnValueOnce(0.7)
+			.mockReturnValueOnce(0.5);
+
+		expect(getFoodType(player)).toBe("vegetarian");
+	});
+
+	it("uses the destination biome near the end of the journey", () => {
+		vi.spyOn(TravelTime, "getTravelProgress").mockReturnValue(0.8);
+		vi.spyOn(RandomUtils.crowniclesRandom, "realZeroToOneInclusive")
+			.mockReturnValueOnce(0.7)
+			.mockReturnValueOnce(0.5);
+
+		expect(getFoodType(player)).toBe("meat");
+	});
+
+	it("keeps the Route des Merveilles soup outcome", () => {
+		const random = vi.spyOn(RandomUtils.crowniclesRandom, "realZeroToOneInclusive");
+		vi.spyOn(MapLinkDataController.instance, "getById").mockReturnValue({
+			id: player.mapLinkId,
+			startMap: MapConstants.LOCATIONS_IDS.ROAD_OF_WONDERS,
+			endMap: endMapId
+		} as never);
+
+		expect(getFoodType(player)).toBe("soup");
+		expect(random).not.toHaveBeenCalled();
+	});
+});

--- a/Core/src/core/maps/TravelTime.ts
+++ b/Core/src/core/maps/TravelTime.ts
@@ -145,6 +145,19 @@ export abstract class TravelTime {
 	}
 
 	/**
+	 * Get how far a player has progressed through their current trip, clamped
+	 * between the departure (0) and the destination (1).
+	 */
+	static getTravelProgress(player: Player, date = new Date()): number {
+		const travelData = this.getTravelDataSimplified(player, date);
+		const tripDuration = travelData.travelEndTime - travelData.travelStartTime - travelData.effectDuration;
+		if (tripDuration <= 0) {
+			return 1;
+		}
+		return Math.min(1, Math.max(0, travelData.playerTravelledTime / tripDuration));
+	}
+
+	/**
 	 * Move travel-related timers by a duration expressed in milliseconds.
 	 *
 	 * @param player The player

--- a/Core/src/core/smallEvents/findMaterial.ts
+++ b/Core/src/core/smallEvents/findMaterial.ts
@@ -23,23 +23,11 @@ function getBiomeExpeditionType(mapType: string | undefined): ExpeditionLocation
 }
 
 /**
- * Compute the travel progress of the player (0 at the start of the trip, 1 once arrived).
- */
-function getTravelProgress(player: Player): number {
-	const travelData = TravelTime.getTravelDataSimplified(player, new Date());
-	const tripDuration = travelData.travelEndTime - travelData.travelStartTime - travelData.effectDuration;
-	if (tripDuration <= 0) {
-		return 1;
-	}
-	return Math.min(1, Math.max(0, travelData.playerTravelledTime / tripDuration));
-}
-
-/**
  * Pick the biome to loot from: it blends the origin and destination biomes, the destination being
  * more likely the further along the trip the player is.
  */
 function pickBiomeExpeditionType(player: Player): ExpeditionLocationType {
-	const progress = getTravelProgress(player);
+	const progress = TravelTime.getTravelProgress(player);
 	return RandomUtils.crowniclesRandom.realZeroToOneInclusive() < progress
 		? getBiomeExpeditionType(player.getDestination()?.type)
 		: getBiomeExpeditionType(player.getPreviousMap()?.type);

--- a/Core/src/core/smallEvents/petFood.ts
+++ b/Core/src/core/smallEvents/petFood.ts
@@ -101,11 +101,11 @@ function getProbabilities(type: string): { [key: string]: number } {
 }
 
 /**
- * Determine the type of food found based on the player's current map location
+ * Determine the type of food found from the origin or destination biome, weighted by travel progress.
  * @param player - The player finding the food
  * @returns The food type identifier
  */
-function getFoodType(player: Player): string {
+export function getFoodType(player: Player): string {
 	const mapLink = MapLinkDataController.instance.getById(player.mapLinkId)!;
 	const endMap = MapLocationDataController.instance.getById(mapLink.endMap)!;
 	const startMap = MapLocationDataController.instance.getById(mapLink.startMap)!;
@@ -114,7 +114,10 @@ function getFoodType(player: Player): string {
 		return SmallEventConstants.PET_FOOD.FOOD_TYPES.SOUP;
 	}
 
-	const probabilities = getProbabilities(endMap.type);
+	const selectedMap = RandomUtils.crowniclesRandom.realZeroToOneInclusive() < TravelTime.getTravelProgress(player)
+		? endMap
+		: startMap;
+	const probabilities = getProbabilities(selectedMap.type);
 	const rand = RandomUtils.crowniclesRandom.realZeroToOneInclusive();
 	let cumulativeProbability = 0;
 	for (const [foodType, probability] of Object.entries(probabilities)) {


### PR DESCRIPTION
## Résumé

- tire le biome de départ ou d’arrivée selon la progression réelle du trajet pour le mini-événement `petFood`
- préserve le bonus de soupe de la Route des Merveilles
- centralise le calcul de progression déjà utilisé par `findMaterial`

## Vérifications

- `pnpm eslintFix && pnpm eslint` (Core)
- `pnpm test` (Core, 1 617 tests)
- `pnpm tsc` (Core)

Fixes #4818