### PR TITLE
feat(pet): add rare sea urchin companion

### DIFF
--- a/Core/__tests__/core/pets/SeaUrchinPet.test.ts
+++ b/Core/__tests__/core/pets/SeaUrchinPet.test.ts
@@ -1,0 +1,48 @@
+import {
+	readFileSync
+} from "node:fs";
+import { resolve } from "node:path";
+import {
+	describe, expect, it
+} from "vitest";
+import { PetConstants } from "../../../../Lib/src/constants/PetConstants";
+import { FightConstants } from "../../../../Lib/src/constants/FightConstants";
+import { ItemRarity } from "../../../../Lib/src/constants/ItemConstants";
+import { PET_EXPEDITION_PREFERENCES } from "../../../../Lib/src/constants/PetExpeditionPreferences";
+
+type PetData = {
+	rarity: ItemRarity;
+	diet: string;
+	force: number;
+	speed: number;
+	feedDelay: number;
+	tags: string[];
+};
+
+const seaUrchinData = JSON.parse(
+	readFileSync(resolve(__dirname, "../../../resources/pets/103.json"), "utf8")
+) as PetData;
+
+describe("sea urchin pet", () => {
+	it("is a rare, low-force aquatic pet with a speed bonus", () => {
+		expect(PetConstants.PETS.SEA_URCHIN).toBe(103);
+		expect(seaUrchinData).toMatchObject({
+			rarity: ItemRarity.RARE,
+			diet: PetConstants.RESTRICTIVES_DIETS.HERBIVOROUS,
+			force: 1,
+			speed: 6,
+			feedDelay: 4,
+			tags: [PetConstants.TAGS.AQUATIC]
+		});
+	});
+
+	it("retaliates with its spikes and prefers coastal expeditions", () => {
+		const behavior = PetConstants.PET_BEHAVIORS.find(entry => entry.petIds.includes(PetConstants.PETS.SEA_URCHIN));
+
+		expect(behavior?.behaviorId).toBe(FightConstants.FIGHT_ACTIONS.PET.REVENGE);
+		expect(PET_EXPEDITION_PREFERENCES[PetConstants.PETS.SEA_URCHIN]).toEqual({
+			liked: ["coast", "swamp"],
+			disliked: ["desert", "mountain"]
+		});
+	});
+});

--- a/Core/resources/pets/103.json
+++ b/Core/resources/pets/103.json
@@ -1,0 +1,8 @@
+{
+  "rarity": 4,
+  "diet": "herbivorous",
+  "force": 1,
+  "speed": 6,
+  "feedDelay": 4,
+  "tags": ["aquatic"]
+}

--- a/Lang/fr/models.json
+++ b/Lang/fr/models.json
@@ -1858,6 +1858,8 @@
     "101_female": "Vampire",
     "102_male": "Féetaud",
     "102_female": "Fée",
+    "103_male": "Oursin",
+    "103_female": "Oursin",
     "10_female": "Poule",
     "10_male": "Coq",
     "11_female": "Oiseau",

--- a/Lib/src/CrowniclesIcons.ts
+++ b/Lib/src/CrowniclesIcons.ts
@@ -1199,6 +1199,10 @@ export const CrowniclesIcons: {
 			emoteFemale: "🧚‍♀️",
 			emoteMale: "🧚"
 		},
+		103: {
+			emoteFemale: "✴️",
+			emoteMale: "✴️"
+		},
 		11: {
 			emoteFemale: "🐦",
 			emoteMale: "🐦"

--- a/Lib/src/constants/PetConstants.ts
+++ b/Lib/src/constants/PetConstants.ts
@@ -315,7 +315,8 @@ export abstract class PetConstants {
 		JACK_O_LANTERN: 99,
 		GHOST: 100,
 		VAMPIRE: 101,
-		FAIRY: 102
+		FAIRY: 102,
+		SEA_URCHIN: 103
 	};
 
 	static readonly PET_BEHAVIORS = [
@@ -493,7 +494,10 @@ export abstract class PetConstants {
 			behaviorId: FightConstants.FIGHT_ACTIONS.PET.MEDUSE_PARALYZE
 		},
 		{
-			petIds: [PetConstants.PETS.HEDGEHOG],
+			petIds: [
+				PetConstants.PETS.HEDGEHOG,
+				PetConstants.PETS.SEA_URCHIN
+			],
 			behaviorId: FightConstants.FIGHT_ACTIONS.PET.REVENGE
 		},
 		{

--- a/Lib/src/constants/PetExpeditionPreferences.ts
+++ b/Lib/src/constants/PetExpeditionPreferences.ts
@@ -209,6 +209,15 @@ export const PET_EXPEDITION_PREFERENCES: Record<number, PetExpeditionPreferenceC
 		disliked: ["desert"]
 	},
 
+	// Sea urchin - Coastal creature
+	103: {
+		liked: [
+			"coast",
+			"swamp"
+		],
+		disliked: ["desert", "mountain"]
+	},
+
 	// Rat - Ultimate survivor, thrives in ruins
 	93: {
 		liked: [


### PR DESCRIPTION
## Résumé

- ajoute l’oursin rare, aquatique, à faible force et bonus de vitesse
- centralise son icône et définit ses préférences d’expédition
- couvre les caractéristiques et le comportement de représailles

## Vérifications

- `pnpm eslintFix` / `pnpm eslint` / `pnpm tsc` / `pnpm test` dans `Core`
- `pnpm eslintFix` / `pnpm eslint` / `pnpm tsc` / `pnpm test` dans `Lib`

Fixes #4812