### PR TITLE
fix(player): persist selected class through health rescale

### DIFF
--- a/.github/instructions/review-checklist.instructions.md
+++ b/.github/instructions/review-checklist.instructions.md
@@ -15,6 +15,20 @@ Generic review procedure to catch common issues before submitting a PR. Based on
 
 ---
 
+## 0.5 Architecture & System Boundaries
+
+Apply this section when a change has a non-local blast radius: a shared abstraction or utility, persisted state or migration, cache, packet/API contract, authorization, asynchronous callback/job, transaction, or cross-module flow. Do not turn it into ceremony for a leaf UI/text-only change.
+
+- [ ] **Write a short architecture note before approving** — name the 1–3 invariants that must remain true, the canonical source of truth for each affected state, the components/boundaries crossed, and the observable test that proves it. Example: “a successful class choice is persisted before any health recalculation; the database and response expose the same class”.
+- [ ] **Trace the complete changed path, not only the diff** — follow input/event → orchestration → model/service → persistence/cache/external side effect → packet/job. At every `await`, callback, reload, retry, event publication, or transaction boundary, state which data may have changed and which object/store is authoritative afterwards.
+- [ ] **Search the reverse dependencies and parallel flows** — before changing shared behavior, inspect every caller, implementation, sibling feature, background job, and protocol consumer with `rg`. Check compatibility, duplicated business rules, and alternate paths that bypass the proposed invariant.
+- [ ] **Give each state transition one owner** — do not let a stale in-memory object, cache, database row, packet payload, or background job independently overwrite another source of truth. A refresh, merge, retry, invalidation, or synchronization must have an explicit ownership rule and preserve all fields it does not own.
+- [ ] **Review failure and time dimensions deliberately** — cover partial success, exceptions after a side effect, duplicate/retried delivery, cancellation, concurrent execution, and stale reads whenever the flow can encounter them. The required property is explicit: idempotence, compensation, serialization, or a user-visible recoverable failure.
+- [ ] **Ask for one adversarial counterexample from a fresh review context** — the reviewer must try to break an invariant through a different caller, an old persisted state, an interrupted/retried operation, or two executions in a different order. Do not accept “looks correct”; record why the counterexample cannot occur or add the regression test it exposes.
+- [ ] **Test the invariant at an observable boundary** — tests must assert persisted state, externally returned packets/API, or a conserved domain value after the full flow. A unit test of the new helper alone is insufficient for a cross-boundary change.
+
+---
+
 ## 1. Magic Strings & Constants
 
 - [ ] **No hardcoded strings** used as identifiers, action names, or error codes — use `as const` objects (e.g., `CHEST_ACTIONS.DEPOSIT`, `EQUIP_ERRORS.INVALID`)

--- a/Core/__tests__/core/database/models/PlayerHealthDeath.test.ts
+++ b/Core/__tests__/core/database/models/PlayerHealthDeath.test.ts
@@ -49,6 +49,7 @@ function countDeathPackets(response: CrowniclesPacket[]): number {
 
 describe("Player health and death", () => {
 	let applyEffectSpy: ReturnType<typeof vi.spyOn>;
+	let saveSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
 		setCrowniclesInstanceForTests({
@@ -60,7 +61,7 @@ describe("Player health and death", () => {
 		applyEffectSpy = vi.spyOn(TravelTime, "applyEffect")
 			.mockResolvedValue(undefined);
 		vi.spyOn(Player, "withLocked").mockImplementation((_id, body) => body(lockedPlayer));
-		vi.spyOn(Player.prototype, "save").mockImplementation(function(this: Player) {
+		saveSpy = vi.spyOn(Player.prototype, "save").mockImplementation(function(this: Player) {
 			return Promise.resolve(this);
 		});
 	});
@@ -243,6 +244,26 @@ describe("Player health and death", () => {
 
 			expect(player.getMaxCumulativeEnergy(noEnchantmentActiveObjects)).toBe(281);
 			expect(player.fightPointsLost).toBe(141);
+		});
+
+		it("does not restore the old class when health rescaling re-fetches the player", async () => {
+			const player = buildPlayer({
+				level: 9,
+				classId: 0,
+				health: 71
+			});
+			const reloadedPlayer = Object.assign(Object.create(Player.prototype) as Player, player);
+			lockedPlayer = reloadedPlayer;
+			saveSpy.mockImplementation(function(this: Player) {
+				// Simulate the database row seen by the nested `Player.withLocked` call.
+				reloadedPlayer.class = this.class;
+				return Promise.resolve(this);
+			});
+
+			await player.changeClass(8, noEnchantmentActiveObjects, []);
+
+			expect(player.class).toBe(8);
+			expect(player.getHealthValue()).toBe(19);
 		});
 	});
 });

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -1053,6 +1053,13 @@ export class Player extends Model {
 
 		this.class = newClassId;
 
+		/*
+		 * Persist the selected class before the health rescale. `addHealth` may re-fetch this player under the
+		 * current transaction; without this flush, that nested lock reads the former class and synchronizes it
+		 * back onto this instance, silently cancelling the class change (#4817).
+		 */
+		await this.save();
+
 		const targetHealth = Math.ceil(previousHealth / previousMaxHealth * this.getMaxHealth());
 		await this.addHealth({
 			amount: targetHealth - this.getHealth(),

--- a/Core/src/core/utils/withLockedPlayerAndMissions.ts
+++ b/Core/src/core/utils/withLockedPlayerAndMissions.ts
@@ -12,7 +12,7 @@ import { DailyMissions } from "../database/game/models/DailyMission";
  * / `setGloryPoints` / `addRage` / level-up): those all go through `MissionsController.update`,
  * which locks `player_missions_info` + `players`. Locking a player-only row first and then
  * letting the nested mission update acquire `player_missions_info` inverts the canonical lock
- * order (`players -> player_missions_info`) and can deadlock against a concurrent standalone
+ * order (`player_missions_info -> players`) and can deadlock against a concurrent standalone
  * mission update on the same player. Acquiring both rows up-front keeps the order canonical.
  * The daily mission is resolved before either row is locked because its rollover resets every
  * `player_missions_info` row. Running that reset under a per-player lock can deadlock with another


### PR DESCRIPTION
## Résumé

- persiste la classe sélectionnée avant le recalcul des PV
- évite qu’une relecture verrouillée interne réinjecte l’ancienne classe
- ajoute une régression qui reproduit le scénario observé depuis 6.0.3

## Vérifications

- `pnpm eslintFix`
- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` — 123 fichiers, 1 614 tests

Fixes #4817