### PR TITLE
fix(cooking): reject stale recipe slot actions (#4830)

### DIFF
--- a/Core/__tests__/core/report/ReportCookingCraftSnapshot.test.ts
+++ b/Core/__tests__/core/report/ReportCookingCraftSnapshot.test.ts
@@ -1,0 +1,92 @@
+import {
+	afterEach, beforeEach, describe, expect, it, vi
+} from "vitest";
+import { handleCookingCraft } from "../../../src/core/report/ReportCookingService";
+import {
+	CommandReportCookingCraftReq, CookingCraftErrors, CookingSlotData
+} from "../../../../Lib/src/packets/commands/CommandReportPacket";
+import type { PacketContext } from "../../../../Lib/src/packets/CrowniclesPacket";
+import {
+	CookingOutputType, RecipeType
+} from "../../../../Lib/src/constants/CookingConstants";
+import {
+	CookingRecipeData, CookingRecipeDataController
+} from "../../../src/data/CookingRecipeData";
+import { CookingService } from "../../../src/core/cooking/CookingService";
+import {
+	Player, Players
+} from "../../../src/core/database/game/models/Player";
+import {
+	Home, Homes
+} from "../../../src/core/database/game/models/Home";
+
+const player = {
+	id: 42,
+	keycloakId: "cooking-player",
+	cookingLevel: 0,
+	guildId: null,
+	pinnedCookingRecipeId: null
+} as Player;
+
+const home = {
+	id: 24,
+	getLevel: () => ({
+		features: { cookingSlots: 4 }
+	})
+} as Home;
+
+const currentRecipeId = "potion_health_1";
+const displayedRecipeId = "material_iron_1";
+
+const currentSlot: CookingSlotData = {
+	slotIndex: 3,
+	recipe: {
+		id: currentRecipeId,
+		level: 1,
+		isSecret: false,
+		outputDescription: "",
+		outputType: CookingOutputType.POTION,
+		recipeType: RecipeType.POTION_HEALTH,
+		ingredients: { plants: [], materials: [] },
+		canCraft: true
+	}
+};
+
+const currentRecipe = {
+	id: currentRecipeId,
+	outputType: CookingOutputType.POTION
+} as CookingRecipeData;
+
+describe("handleCookingCraft snapshot guard", () => {
+	beforeEach(() => {
+		vi.spyOn(Players, "getByKeycloakId").mockResolvedValue(player);
+		vi.spyOn(Homes, "getOfPlayer").mockResolvedValue(home);
+		vi.spyOn(CookingService, "getSlotRecipes").mockResolvedValue([currentSlot]);
+		vi.spyOn(CookingRecipeDataController.instance, "getById").mockReturnValue(currentRecipe);
+		vi.spyOn(CookingService, "executeCraft").mockResolvedValue({} as never);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not craft a recipe that replaced the one shown in the clicked slot", async () => {
+		const packet = new CommandReportCookingCraftReq();
+		packet.slotIndex = currentSlot.slotIndex;
+		packet.recipeId = displayedRecipeId;
+
+		const response = await handleCookingCraft(player.keycloakId, packet, {} as PacketContext);
+
+		expect(CookingService.executeCraft).not.toHaveBeenCalled();
+		expect(response).toHaveLength(1);
+		expect(response[0]).toMatchObject({
+			success: false,
+			error: CookingCraftErrors.CRAFT_UNAVAILABLE,
+			recipeId: currentRecipeId,
+			menu: {
+				currentSlots: [currentSlot],
+				isIgnited: true
+			}
+		});
+	});
+});

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -63,6 +63,7 @@ import { PlayerCookingRecipe } from "../database/game/models/PlayerCookingRecipe
 import { crowniclesInstance } from "../../app";
 import { MissionsController } from "../missions/MissionsController";
 import type { CookingUseLogParams } from "../database/logs/LogsCityLogger";
+import type { CookingRecipeId } from "../../../../Lib/src/types/CookingRecipe";
 
 interface PlayerAndHome {
 	player: Player;
@@ -719,7 +720,7 @@ function validateCraftRequest(
 	slot: CookingSlotData | undefined,
 	recipe: CookingRecipeData | undefined,
 	guild: Guild | null,
-	requestedRecipeId: string
+	requestedRecipeId: CookingRecipeId
 ): CookingCraftError | null {
 	if (!slot?.recipe || !recipe) {
 		return CookingCraftErrors.CRAFT_UNAVAILABLE;

--- a/Core/src/core/report/ReportCookingService.ts
+++ b/Core/src/core/report/ReportCookingService.ts
@@ -718,9 +718,18 @@ function getCraftErrorInfo(
 function validateCraftRequest(
 	slot: CookingSlotData | undefined,
 	recipe: CookingRecipeData | undefined,
-	guild: Guild | null
+	guild: Guild | null,
+	requestedRecipeId: string
 ): CookingCraftError | null {
 	if (!slot?.recipe || !recipe) {
+		return CookingCraftErrors.CRAFT_UNAVAILABLE;
+	}
+
+	/*
+	 * The displayed menu is a snapshot. Never craft whatever currently happens
+	 * to occupy a slot when the snapshot used for the click is stale.
+	 */
+	if (slot.recipe.id !== requestedRecipeId) {
 		return CookingCraftErrors.CRAFT_UNAVAILABLE;
 	}
 	if (recipe.outputType === CookingOutputType.PET_FOOD && !guild) {
@@ -923,7 +932,12 @@ export async function handleCookingCraft(
 		return [];
 	}
 
-	const validationError = validateCraftRequest(craftContext.slot, craftContext.recipe, craftContext.guild);
+	const validationError = validateCraftRequest(
+		craftContext.slot,
+		craftContext.recipe,
+		craftContext.guild,
+		packet.recipeId
+	);
 	if (validationError) {
 		return [await buildBlockedCookingCraftPacket(craftContext, validationError)];
 	}

--- a/Discord/__tests__/home/CookingFeatureHandler.test.ts
+++ b/Discord/__tests__/home/CookingFeatureHandler.test.ts
@@ -366,7 +366,7 @@ describe("CookingFeatureHandler", () => {
 			const ctx = createHandlerContext({
 				homeData: createCookingHomeData(2)
 			});
-			const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
+			const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0:test_recipe`;
 			const interaction = createMockComponentInteraction(craftValue);
 			const nestedMenus = createMockNestedMenus();
 
@@ -392,7 +392,7 @@ describe("CookingFeatureHandler", () => {
 			const ctx = createHandlerContext({
 				homeData: createCookingHomeData(2)
 			});
-			const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}notanumber`;
+			const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}notanumber:test_recipe`;
 			const interaction = createMockComponentInteraction(craftValue);
 			const nestedMenus = createMockNestedMenus();
 
@@ -638,7 +638,7 @@ describe("CookingFeatureHandler", () => {
 				const ctx = createHandlerContext({
 					homeData: createCookingHomeData(2)
 				});
-				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}1`;
+				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}1:test_recipe`;
 				const interaction = createMockComponentInteraction(craftValue);
 				const nestedMenus = createMockNestedMenus();
 				nestedMenus.message = {
@@ -652,9 +652,10 @@ describe("CookingFeatureHandler", () => {
 
 				const sendMock = DiscordMQTT.asyncPacketSender.sendPacketAndHandleResponse as ReturnType<typeof vi.fn>;
 				expect(sendMock).toHaveBeenCalled();
-				// Verify the packet has slotIndex = 1
+				// The request remains bound to the recipe rendered in the button.
 				const packetArg = sendMock.mock.calls[0][1];
 				expect(packetArg).toHaveProperty("slotIndex", 1);
+				expect(packetArg).toHaveProperty("recipeId", "test_recipe");
 			});
 
 			it("should handle craft success response", async () => {
@@ -662,7 +663,7 @@ describe("CookingFeatureHandler", () => {
 					homeData: createCookingHomeData(2),
 					packet: createMockPacket([{ type: ReactionCollectorHomeMenuReaction.name }]) as HomeFeatureHandlerContext["packet"]
 				});
-				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
+				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0:test_recipe`;
 				const interaction = createMockComponentInteraction(craftValue);
 				const nestedMenus = createMockNestedMenus();
 				nestedMenus.message = {
@@ -701,7 +702,7 @@ describe("CookingFeatureHandler", () => {
 					homeData: createCookingHomeData(2),
 					packet: createMockPacket([{ type: ReactionCollectorHomeMenuReaction.name }]) as HomeFeatureHandlerContext["packet"]
 				});
-				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
+				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0:test_recipe`;
 				const interaction = createMockComponentInteraction(craftValue);
 				const nestedMenus = createMockNestedMenus();
 				nestedMenus.message = {
@@ -734,7 +735,7 @@ describe("CookingFeatureHandler", () => {
 					homeData: createCookingHomeData(2),
 					packet: createMockPacket([{ type: ReactionCollectorHomeMenuReaction.name }]) as HomeFeatureHandlerContext["packet"]
 				});
-				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
+				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0:test_recipe`;
 				const interaction = createMockComponentInteraction(craftValue);
 				const nestedMenus = createMockNestedMenus();
 				nestedMenus.message = {
@@ -769,7 +770,7 @@ describe("CookingFeatureHandler", () => {
 					homeData: createCookingHomeData(2),
 					packet: createMockPacket([{ type: ReactionCollectorHomeMenuReaction.name }]) as HomeFeatureHandlerContext["packet"]
 				});
-				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
+				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0:test_recipe`;
 				const interaction = createMockComponentInteraction(craftValue);
 				const nestedMenus = createMockNestedMenus();
 				nestedMenus.message = {
@@ -807,7 +808,7 @@ describe("CookingFeatureHandler", () => {
 					homeData: createCookingHomeData(2),
 					packet: createMockPacket([{ type: ReactionCollectorHomeMenuReaction.name }]) as HomeFeatureHandlerContext["packet"]
 				});
-				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
+				const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0:test_recipe`;
 				const nestedMenus = createMockNestedMenus();
 				nestedMenus.message = {
 					reply: vi.fn().mockResolvedValue(undefined)

--- a/Discord/__tests__/home/CookingFeatureHandler.test.ts
+++ b/Discord/__tests__/home/CookingFeatureHandler.test.ts
@@ -99,6 +99,7 @@ import {
 	CommandReportCookingWoodConfirmReq,
 	CommandReportCookingReviveRes,
 	CommandReportCookingCraftRes,
+	CommandReportCookingMenuReq,
 	CommandReportCookingMenuRes
 } from "../../../Lib/src/packets/commands/CommandReportPacket";
 import { CookingCraftErrors, CookingSlotData } from "../../../Lib/src/types/CookingTypes";
@@ -388,19 +389,19 @@ describe("CookingFeatureHandler", () => {
 			expect(result).toBe(false);
 		});
 
-		it("should ignore craft selection with invalid slot index", async () => {
+		it("should refresh the menu for a legacy craft button without a recipe ID", async () => {
 			const ctx = createHandlerContext({
 				homeData: createCookingHomeData(2)
 			});
-			const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}notanumber:test_recipe`;
+			const craftValue = `${HomeMenuIds.COOKING_CRAFT_PREFIX}0`;
 			const interaction = createMockComponentInteraction(craftValue);
 			const nestedMenus = createMockNestedMenus();
 
 			const result = await handler.handleSubMenuSelection(ctx, craftValue, interaction as any, nestedMenus as any);
 
 			expect(result).toBe(true);
-			// No MQTT call since slot index is NaN
-			expect(DiscordMQTT.asyncPacketSender.sendPacketAndHandleResponse).not.toHaveBeenCalled();
+			const sendMock = DiscordMQTT.asyncPacketSender.sendPacketAndHandleResponse as ReturnType<typeof vi.fn>;
+			expect(sendMock.mock.calls[0][1]).toBeInstanceOf(CommandReportCookingMenuReq);
 		});
 	});
 
@@ -913,6 +914,36 @@ describe("CookingFeatureHandler", () => {
 			// Now check state via getMenuOption
 			const option = handler.getMenuOption(ctx);
 			expect(option!.description).toContain('"level":20');
+		});
+
+		it("should bind each rendered craft button to its recipe ID", async () => {
+			const ctx = createHandlerContext({
+				homeData: createCookingHomeData(2)
+			});
+			const nestedMenus = createMockNestedMenus();
+
+			await handler.handleSubMenuSelection(
+				ctx,
+				HomeMenuIds.COOKING_IGNITE,
+				createMockComponentInteraction(HomeMenuIds.COOKING_IGNITE) as any,
+				nestedMenus as any
+			);
+			await simulateMqttResponse(CommandReportCookingIgniteRes.name, {
+				menu: {
+					cookingLevel: 5,
+					cookingGrade: "apprentice",
+					currentSlots: [createSlotWithRecipe({
+						slotIndex: 0,
+						recipeId: "testRecipe"
+					})],
+					isIgnited: true
+				},
+				woodConsumed: true,
+				woodMaterialId: 1
+			} as CommandReportCookingIgniteRes);
+
+			const menuOptions = (nestedMenus.registerMenu as ReturnType<typeof vi.fn>).mock.calls[0][1];
+			expect(JSON.stringify(menuOptions.containers)).toContain(`${HomeMenuIds.COOKING_CRAFT_PREFIX}0:testRecipe`);
 		});
 	});
 });

--- a/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
@@ -71,6 +71,11 @@ interface CookingSessionState {
 	pinnedRecipe?: PinnedRecipeInfo;
 }
 
+interface CookingCraftSelection {
+	slotIndex: number;
+	recipeId: string;
+}
+
 export class CookingFeatureHandler implements HomeFeatureHandler {
 	public readonly featureId = HomeMenuIds.FEATURE_COOKING;
 
@@ -244,12 +249,34 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 		if (this.getState(ctx).craftPending) {
 			return true;
 		}
-		const slotIndex = parseInt(selectedValue.replace(HomeMenuIds.COOKING_CRAFT_PREFIX, ""), 10);
-		if (isNaN(slotIndex)) {
+		const craftSelection = this.parseCraftSelection(selectedValue);
+		if (!craftSelection) {
 			return true;
 		}
-		await this.sendCraftAction(ctx, slotIndex, nestedMenus);
+		await this.sendCraftAction(ctx, craftSelection, nestedMenus);
 		return true;
+	}
+
+	/**
+	 * Decode the immutable recipe identity embedded in a craft button. The
+	 * recipe ID is part of the button payload rather than the cosmetic cache so
+	 * a delayed Discord interaction remains bound to what the player saw.
+	 */
+	private parseCraftSelection(selectedValue: string): CookingCraftSelection | null {
+		const payload = selectedValue.slice(HomeMenuIds.COOKING_CRAFT_PREFIX.length);
+		const separatorIndex = payload.indexOf(":");
+		if (separatorIndex <= 0 || separatorIndex !== payload.lastIndexOf(":")) {
+			return null;
+		}
+		const slotIndex = Number(payload.slice(0, separatorIndex));
+		const recipeId = payload.slice(separatorIndex + 1);
+		if (!Number.isInteger(slotIndex) || slotIndex < 0 || !recipeId) {
+			return null;
+		}
+		return {
+			slotIndex,
+			recipeId
+		};
 	}
 
 	/**
@@ -650,11 +677,19 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 		const stationEmoji = CrowniclesIcons.cookingStations[slot.slotIndex] ?? CrowniclesIcons.city.homeUpgrades.cooking;
 		const craftLabel = i18n.t(`commands:report.city.homes.cooking.craftButton.${slot.slotIndex}`, { lng: ctx.lng });
 		return new ButtonBuilder()
-			.setCustomId(buildCustomId(HomeMenuIds.COOKING_CRAFT_PREFIX, slot.slotIndex))
+			.setCustomId(this.buildCraftCustomId(slot.slotIndex, recipe.id))
 			.setLabel(craftLabel)
 			.setEmoji(parseEmoji(stationEmoji)!)
 			.setStyle(recipe.canCraft && !allDisabled ? ButtonStyle.Primary : ButtonStyle.Secondary)
 			.setDisabled(!recipe.canCraft || allDisabled);
+	}
+
+	/**
+	 * Keep the slot and recipe in one custom-ID part: recipe identifiers contain
+	 * underscores, which are reserved by buildCustomId for multi-part payloads.
+	 */
+	private buildCraftCustomId(slotIndex: number, recipeId: string): string {
+		return buildCustomId(HomeMenuIds.COOKING_CRAFT_PREFIX, `${slotIndex}:${recipeId}`);
 	}
 
 	/**
@@ -883,7 +918,7 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 	 */
 	private async sendCraftAction(
 		ctx: HomeFeatureHandlerContext,
-		slotIndex: number,
+		craftSelection: CookingCraftSelection,
 		nestedMenus: CrowniclesNestedMenus
 	): Promise<void> {
 		const state = this.getState(ctx);
@@ -891,7 +926,7 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 		try {
 			await DiscordMQTT.asyncPacketSender.sendPacketAndHandleResponse(
 				ctx.context,
-				makePacket(CommandReportCookingCraftReq, { slotIndex }),
+				makePacket(CommandReportCookingCraftReq, craftSelection),
 				async (_responseContext, packetName, responsePacket) => {
 					if (packetName !== CommandReportCookingCraftRes.name) {
 						return;

--- a/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
+++ b/Discord/src/commands/player/report/home/features/CookingFeatureHandler.ts
@@ -48,6 +48,7 @@ import { DiscordCollectorUtils } from "../../../../../utils/DiscordCollectorUtil
 import { buildCustomId } from "../../../../../utils/CustomIdUtils";
 import { buildRecipeDiscoveryMessage } from "../../../../../utils/CookingDisplayUtils";
 import { ReactionCollectorRefuseReaction } from "../../../../../../../Lib/src/packets/interaction/ReactionCollectorPacket";
+import type { CookingRecipeId } from "../../../../../../../Lib/src/types/CookingRecipe";
 
 /**
  * Cosmetic cache of the last menu state known to the client.
@@ -73,7 +74,7 @@ interface CookingSessionState {
 
 interface CookingCraftSelection {
 	slotIndex: number;
-	recipeId: string;
+	recipeId: CookingRecipeId;
 }
 
 export class CookingFeatureHandler implements HomeFeatureHandler {
@@ -251,6 +252,11 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 		}
 		const craftSelection = this.parseCraftSelection(selectedValue);
 		if (!craftSelection) {
+			/*
+			 * Buttons rendered before the recipe ID was added use the legacy
+			 * slot-only format. Refresh instead of crafting from a stale snapshot.
+			 */
+			await this.fetchAndShowCookingMenu(ctx, nestedMenus);
 			return true;
 		}
 		await this.sendCraftAction(ctx, craftSelection, nestedMenus);
@@ -264,18 +270,13 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 	 */
 	private parseCraftSelection(selectedValue: string): CookingCraftSelection | null {
 		const payload = selectedValue.slice(HomeMenuIds.COOKING_CRAFT_PREFIX.length);
-		const separatorIndex = payload.indexOf(":");
-		if (separatorIndex <= 0 || separatorIndex !== payload.lastIndexOf(":")) {
-			return null;
-		}
-		const slotIndex = Number(payload.slice(0, separatorIndex));
-		const recipeId = payload.slice(separatorIndex + 1);
-		if (!Number.isInteger(slotIndex) || slotIndex < 0 || !recipeId) {
+		const selection = (/^(\d+):([^:]+)$/).exec(payload);
+		if (!selection) {
 			return null;
 		}
 		return {
-			slotIndex,
-			recipeId
+			slotIndex: Number(selection[1]),
+			recipeId: selection[2]
 		};
 	}
 
@@ -685,10 +686,10 @@ export class CookingFeatureHandler implements HomeFeatureHandler {
 	}
 
 	/**
-	 * Keep the slot and recipe in one custom-ID part: recipe identifiers contain
-	 * underscores, which are reserved by buildCustomId for multi-part payloads.
+	 * Keep the slot and recipe in one custom-ID part because buildCustomId uses
+	 * underscores to separate multiple parts.
 	 */
-	private buildCraftCustomId(slotIndex: number, recipeId: string): string {
+	private buildCraftCustomId(slotIndex: number, recipeId: CookingRecipeId): string {
 		return buildCustomId(HomeMenuIds.COOKING_CRAFT_PREFIX, `${slotIndex}:${recipeId}`);
 	}
 

--- a/Lib/src/packets/commands/CommandReportPacket.ts
+++ b/Lib/src/packets/commands/CommandReportPacket.ts
@@ -21,6 +21,7 @@ import { ApartmentLocationRef } from "../../types/ApartmentLocation";
 import {
 	FinalPveBossId, PveBossLeaderboardEntry, PveBossPersonalRecord
 } from "../../types/PveBossRecord";
+import type { CookingRecipeId } from "../../types/CookingRecipe";
 export {
 	CookingSlotData, CookingCraftErrors, CookingCraftError, PinnedRecipeInfo, RecipeIngredients, CookingMenuSnapshot
 } from "../../types/CookingTypes";
@@ -677,7 +678,7 @@ export class CommandReportCookingCraftReq extends CrowniclesPacket {
 	 * Recipe shown in the menu snapshot that produced this request. Core uses
 	 * it as an optimistic-concurrency guard before consuming ingredients.
 	 */
-	recipeId!: string;
+	recipeId!: CookingRecipeId;
 }
 
 export interface CraftPetFoodResult {

--- a/Lib/src/packets/commands/CommandReportPacket.ts
+++ b/Lib/src/packets/commands/CommandReportPacket.ts
@@ -672,6 +672,12 @@ export class CommandReportCookingReviveRes extends CrowniclesPacket {
 @sendablePacket(PacketDirection.FRONT_TO_BACK)
 export class CommandReportCookingCraftReq extends CrowniclesPacket {
 	slotIndex!: number;
+
+	/**
+	 * Recipe shown in the menu snapshot that produced this request. Core uses
+	 * it as an optimistic-concurrency guard before consuming ingredients.
+	 */
+	recipeId!: string;
 }
 
 export interface CraftPetFoodResult {

--- a/Lib/src/types/CookingRecipe.ts
+++ b/Lib/src/types/CookingRecipe.ts
@@ -7,6 +7,9 @@ import {
 } from "../constants/CookingConstants";
 import { PetFood } from "./PetFood";
 
+/** Identifier of a cooking recipe stored in the recipe data set. */
+export type CookingRecipeId = string;
+
 export interface CookingRecipeMaterial {
 	materialId: number;
 	quantity: number;
@@ -24,7 +27,7 @@ export interface PetFoodRecipe {
 }
 
 export interface CookingRecipe {
-	id: string;
+	id: CookingRecipeId;
 	level: number;
 	recipeType: RecipeType;
 	plants: CookingRecipePlant[];

--- a/Lib/src/types/CookingTypes.ts
+++ b/Lib/src/types/CookingTypes.ts
@@ -4,6 +4,7 @@ import {
 } from "../constants/CookingConstants";
 import { PetFood } from "./PetFood";
 import { MaterialQuantity } from "./MaterialQuantity";
+import type { CookingRecipeId } from "./CookingRecipe";
 
 export interface PlantQuantity {
 	plantId: PlantId;
@@ -26,7 +27,7 @@ export interface RecipeIngredients {
 export interface CookingSlotData {
 	slotIndex: number;
 	recipe: {
-		id: string;
+		id: CookingRecipeId;
 		level: number;
 		isSecret: boolean;
 		outputDescription: string;
@@ -53,13 +54,13 @@ export type CookingCraftError = typeof CookingCraftErrors[keyof typeof CookingCr
  * Minimal recipe info needed to render a recipe as "{icon} Name (level)".
  */
 export interface RecipeDisplayInfo {
-	recipeId: string;
+	recipeId: CookingRecipeId;
 	level: number;
 	recipeType: RecipeType;
 }
 
 export interface PinnedRecipeInfo {
-	recipeId: string;
+	recipeId: CookingRecipeId;
 	level: number;
 	recipeType: RecipeType;
 	outputType: CookingOutputTypeValue;


### PR DESCRIPTION
Fixes #4830.

## Invariant
A craft action can only execute the recipe displayed in the clicked cooking slot.

## Change
- Include the displayed recipe ID in the Discord button and craft packet.
- Recompute the authoritative slots in Core and reject a stale recipe/slot pairing before executeCraft can consume ingredients.
- Return the existing refreshed-menu error response when the displayed recipe no longer matches the slot.

## Tests
- Core regression: a stale slot request never reaches executeCraft and returns the current snapshot.
- Discord packet flow: the recipe identity sent with the slot is asserted.
- pnpm eslint, pnpm tsc and pnpm test pass in Lib, Core and Discord.