### PR TITLE
fix(fight): restore glory icon in confirmation (#4831)

### DIFF
--- a/Discord/__tests__/commands/player/FightCommand.test.ts
+++ b/Discord/__tests__/commands/player/FightCommand.test.ts
@@ -6,9 +6,10 @@ vi.mock("../../../src/bot/CrowniclesShard", () => ({
 
 import { buildFightConfirmationDescription } from "../../../src/commands/player/FightCommand";
 import { ReactionCollectorFightData } from "../../../../Lib/src/packets/interaction/ReactionCollectorFight";
+import { CrowniclesIcons } from "../../../../Lib/src/CrowniclesIcons";
 
 describe("buildFightConfirmationDescription", () => {
-	it("keeps glory numeric in the confirmation message", () => {
+	it("renders the glory icon and its numeric value in the confirmation message", () => {
 		const data = {
 			playerStats: {
 				classId: 21,
@@ -24,6 +25,7 @@ describe("buildFightConfirmationDescription", () => {
 		const description = buildFightConfirmationDescription("fr", "Jack", data, "common");
 
 		expect(description).not.toContain("NaN");
+		expect(description).toContain(CrowniclesIcons.unitValues.glory);
 		expect(description).toMatch(/1\D869/);
 	});
 });

--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -2348,7 +2348,7 @@
   "fight": {
     "title": "{{pseudo}}, vous êtes sur le point de démarrer un combat",
     "canceledTitle": "{{pseudo}}, vous avez annulé la recherche",
-    "confirmDesc": "{emote:fightCommand.crossedSwords} | **{{pseudo}}**{{confirmSubText}}\n\n{emote:fightCommand.crossedSwords} | **Combattant : {{pseudo}}** | {{glory, number}} | {{className}} {{pet}}\n\n{{stats}}",
+    "confirmDesc": "{emote:fightCommand.crossedSwords} | **{{pseudo}}**{{confirmSubText}}\n\n{emote:fightCommand.crossedSwords} | **Combattant : {{pseudo}}** | {emote:unitValues.glory} {{glory, number}} | {{className}} {{pet}}\n\n{{stats}}",
     "pet": "| {{petInfo}}",
     "petOnExpedition": "| ~~{{petInfo}}~~",
     "confirmSubTexts": {


### PR DESCRIPTION
Fixes #4831.

## Cause
The 6.0.3.a fight hardening switched the confirmation interpolation from a pre-rendered glory display to the raw numeric value to avoid `NaN`. The confirmation translation did not render the glory emote itself, so the number remained without its icon.

## Change
- Restore the glory emote in the French source translation while keeping the raw numeric interpolation.
- Extend the fight confirmation regression test to assert both the icon and the formatted numeric value.

## Verification
- `pnpm eslint`
- `pnpm tsc`
- `pnpm test` (Discord: 269 tests)