### PR TITLE
fix(expedition): preserve awarded token rewards (#4836)

### DIFF
--- a/Core/__tests__/core/expeditions/ExpeditionRewardApplicator.test.ts
+++ b/Core/__tests__/core/expeditions/ExpeditionRewardApplicator.test.ts
@@ -3,11 +3,13 @@ import {
 } from "vitest";
 import { PacketContext } from "../../../../Lib/src/packets/CrowniclesPacket";
 import { MaterialRarity } from "../../../../Lib/src/types/MaterialRarity";
+import { NumberChangeReason } from "../../../../Lib/src/constants/LogsConstants";
 import { applyExpeditionRewards } from "../../../src/core/expeditions/ExpeditionRewardApplicator";
 import Player from "../../../src/core/database/game/models/Player";
 import {
 	applyMaterialLoot, updateCollectMaterialsMission
 } from "../../../src/core/utils/MaterialLootUtils";
+import { MissionsController } from "../../../src/core/missions/MissionsController";
 
 vi.mock("../../../src/core/utils/ItemUtils", () => ({
 	getItemByIdAndCategory: vi.fn(() => undefined),
@@ -17,6 +19,12 @@ vi.mock("../../../src/core/utils/ItemUtils", () => ({
 vi.mock("../../../src/core/utils/MaterialLootUtils", () => ({
 	applyMaterialLoot: vi.fn(),
 	updateCollectMaterialsMission: vi.fn()
+}));
+
+vi.mock("../../../src/core/missions/MissionsController", () => ({
+	MissionsController: {
+		update: vi.fn()
+	}
 }));
 
 describe("ExpeditionRewardApplicator", () => {
@@ -43,5 +51,36 @@ describe("ExpeditionRewardApplicator", () => {
 
 		expect(applyMaterialLoot).toHaveBeenCalledWith(player.id, materialLoot);
 		expect(updateCollectMaterialsMission).toHaveBeenCalledWith(player, response, materialLoot);
+	});
+
+	it("keeps the actual token reward in the response when it crosses the cap", async () => {
+		const response = [];
+		const player = {
+			id: 42,
+			tokens: 20,
+			addTokensAndGetActualGain: vi.fn().mockResolvedValue(3)
+		} as unknown as Player;
+		const rewards = {
+			money: 0,
+			experience: 0,
+			points: 0,
+			tokens: 3,
+			itemId: 0,
+			itemCategory: 0
+		};
+
+		await applyExpeditionRewards(rewards, player, response, {} as PacketContext);
+
+		expect(player.addTokensAndGetActualGain).toHaveBeenCalledWith({
+			amount: 3,
+			response,
+			reason: NumberChangeReason.EXPEDITION
+		});
+		expect(rewards.tokens).toBe(3);
+		expect(MissionsController.update).toHaveBeenCalledWith(player, response, {
+			missionId: "earnTokensInOneExpedition",
+			count: 3,
+			set: true
+		});
 	});
 });

--- a/Core/src/core/database/game/models/Player.ts
+++ b/Core/src/core/database/game/models/Player.ts
@@ -430,23 +430,40 @@ export class Player extends Model {
 	}
 
 	/**
+	 * Add tokens to the player and return the actual gain applied.
+	 *
+	 * The returned value must be used when the value shown to the player depends
+	 * on the capped token mutation. It is calculated on the locked instance,
+	 * rather than from this caller's synchronized Sequelize instance.
+	 * This is only valid for positive amounts.
+	 * @param parameters
+	 */
+	public async addTokensAndGetActualGain(parameters: EditValueParameters): Promise<number> {
+		if (parameters.amount <= 0) {
+			throw new Error("addTokensAndGetActualGain requires a positive amount");
+		}
+		const gainedTokens = await this.earnTokens(parameters);
+		if (gainedTokens === 0) {
+			return 0;
+		}
+		await crowniclesInstance?.logsDatabase.logTokensChange(this.keycloakId, this.tokens, parameters.reason);
+		return gainedTokens;
+	}
+
+	/**
 	 * Add or remove tokens to the player
 	 * @param parameters
 	 */
 	public async addTokens(parameters: EditValueParameters): Promise<Player> {
 		if (parameters.amount > 0) {
-			const gainedTokens = await this.earnTokens(parameters);
-			if (gainedTokens === 0) {
-				return this;
-			}
+			await this.addTokensAndGetActualGain(parameters);
 		}
 		else {
 			await this.mutateLocked(locked => {
 				locked.tokens = computeNewTokens(locked.tokens, parameters.amount, parameters.reason);
 			});
+			await crowniclesInstance?.logsDatabase.logTokensChange(this.keycloakId, this.tokens, parameters.reason);
 		}
-		await crowniclesInstance?.logsDatabase.logTokensChange(this.keycloakId, this.tokens, parameters.reason);
-
 		return this;
 	}
 

--- a/Core/src/core/expeditions/ExpeditionRewardApplicator.ts
+++ b/Core/src/core/expeditions/ExpeditionRewardApplicator.ts
@@ -54,11 +54,9 @@ async function applyTokensReward(player: Player, response: CrowniclesPacket[], a
 	if (amount <= 0) {
 		return 0;
 	}
-	const previousTokens = player.tokens;
-	await player.addTokens({
+	const actualChange = await player.addTokensAndGetActualGain({
 		amount, response, reason: NumberChangeReason.EXPEDITION
 	});
-	const actualChange = player.tokens - previousTokens;
 
 	if (actualChange > 0) {
 		// Track mission for earning tokens in a single expedition (set: true replaces progression instead of incrementing)


### PR DESCRIPTION
## Résumé
- conserve le gain de jetons effectivement appliqué par la mutation verrouillée dans la réponse d'expédition ;
- ajoute une régression couvrant le franchissement du plafond et la mise à jour de mission associée.

## Validation
- ESLint, TypeScript et suites complètes Core, Lib et Discord.

Fixes #4836